### PR TITLE
Remove extra Chromium header failing ARM build

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "base/memory/ref_counted.h"
-
 #include "audio_frame_observer.h"
 #include "callback.h"
 #include "data_channel_observer.h"


### PR DESCRIPTION
Stop including ref_counted.h from the Chromium base library, which
includes some headers making the ARM build fail, and is not necessary in
the first place.

Note that the rtc::RefCounted type is from the RTC base, not the
Chromium base.