### PR TITLE
Added the exclusion of WSAPlayer platform on Win32 plugin docs

### DIFF
--- a/docs/manual/helloworld-unity-importwebrtc.md
+++ b/docs/manual/helloworld-unity-importwebrtc.md
@@ -43,8 +43,8 @@ For **Windows Desktop**, the C++ library variants are:
 
 | Path | Any Platform | Exclude Platforms | CPU | OS | Example use |
 |---|---|---|---|---|---|
-| `Assets/Plugins/Win32/x86` | yes | - | x86 | Windows | 32-bit Windows Desktop application |
-| `Assets/Plugins/Win32/x86_64` | yes | - | x86_64 | Windows | 64-bit Windows Desktop application, including the Unity Editor on Windows |
+| `Assets/Plugins/Win32/x86` | yes | -WSAPlayer | x86 | Windows | 32-bit Windows Desktop application |
+| `Assets/Plugins/Win32/x86_64` | yes | -WSAPlayer | x86_64 | Windows | 64-bit Windows Desktop application, including the Unity Editor on Windows |
 
 For **Windows UWP**, the C++ library variants are:
 


### PR DESCRIPTION
I think there is an inconsistency on the documentation regarding the configuration of the Microsoft.MixedReality.WebRTC.Native.dll on the Unity inspector:

On Getting started->Unity tutorial->Importing MixedReality->WebRTC->Configuring the import settings the first picture shows on "Exclude Platforms" the WSAPlayer **checked ** for Win32/x86_64 library but later on the following table there is nothing written on "Exclude Platforms" for the same library:
![Wrong_Doc](https://user-images.githubusercontent.com/10771957/63946895-396e6a80-ca76-11e9-9d18-ee7c20c73f96.png)
