### PR TITLE
Fixed 404 links in Readme Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The official documentation is hosted at https://microsoft.github.io/MixedReality
 - The [User Manual](https://microsoft.github.io/MixedReality-WebRTC/manual/introduction) contains a general overview and some tutorials.
   - The [Hello, Unity world!](https://microsoft.github.io/MixedReality-WebRTC/manual/helloworld-unity) tutorial introduces the Unity integration by building a simple chat client.
   - The Hello, C# world! tutorial (under construction) introduces the C# API.
-- An [API reference](https://microsoft.github.io/MixedReality-WebRTC/#api-documentation) is also available for the C# library and the Unity integration.
+- An [API reference](https://microsoft.github.io/MixedReality-WebRTC/api/Microsoft.MixedReality.WebRTC.html) is also available for the C# library and the Unity integration.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The current up-to-date branch with latest developments is the `master` branch. I
 
 The official documentation is hosted at https://microsoft.github.io/MixedReality-WebRTC/.
 
-- The [User Manual](https://microsoft.github.io/MixedReality-WebRTC/manual/) contains a general overview and some tutorials.
-  - The [Hello, Unity world!](https://microsoft.github.io/MixedReality-WebRTC/manual/helloworld-unity.md) tutorial introduces the Unity integration by building a simple chat client.
+- The [User Manual](https://microsoft.github.io/MixedReality-WebRTC/manual/introduction) contains a general overview and some tutorials.
+  - The [Hello, Unity world!](https://microsoft.github.io/MixedReality-WebRTC/manual/helloworld-unity) tutorial introduces the Unity integration by building a simple chat client.
   - The Hello, C# world! tutorial (under construction) introduces the C# API.
-- An [API reference](https://microsoft.github.io/MixedReality-WebRTC/api/) is also available for the C# library and the Unity integration.
+- An [API reference](https://microsoft.github.io/MixedReality-WebRTC/#api-documentation) is also available for the C# library and the Unity integration.
 
 ## Getting Started
 


### PR DESCRIPTION
The links to the Manual, Unity Tutorial, and API reference returned 404 pages so I updated them. 