### PR TITLE
Build TestAppUWP during C# CI

### DIFF
--- a/examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
+++ b/examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
@@ -17,6 +17,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
+    <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>

--- a/examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
+++ b/examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
@@ -17,7 +17,6 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
-    <PackageCertificateKeyFile>TestAppUwp_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>

--- a/examples/TestAppUwp/Package.appxmanifest
+++ b/examples/TestAppUwp/Package.appxmanifest
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4" IgnorableNamespaces="uap mp uap3 desktop4">
-  <Identity Name="TestAppUwp" Publisher="CN=jehumb" Version="1.0.0.0" />
+  <Identity Name="TestAppUwp" Publisher="CN=dummy" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="feabc679-bf6c-4bb5-9958-cdf82e23e993" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>TestAppUwp</DisplayName>
-    <PublisherDisplayName>jehumb</PublisherDisplayName>
+    <PublisherDisplayName>dummy</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>

--- a/tools/ci/ci-cs.yaml
+++ b/tools/ci/ci-cs.yaml
@@ -15,6 +15,7 @@ trigger:
   paths:
     include:
     - libs/Microsoft.MixedReality.WebRTC/*
+    - examples/TestAppUwp/*
 
 # Do not trigger CI on PRs
 pr: none

--- a/tools/ci/templates/jobs-cs.yaml
+++ b/tools/ci/templates/jobs-cs.yaml
@@ -33,12 +33,24 @@ jobs:
 
   # Build Microsoft.MixedReality.WebRTC (Release, full build)
   - task: DotNetCoreCLI@2
-    condition: succeededOrFailed() # Build even if Debug failed
+    condition: succeededOrFailed() # Build even previous task failed
     displayName: 'Build C# WebRTC lib (AnyCPU-Release) [full build]'
     inputs:
       projects: libs/Microsoft.MixedReality.WebRTC/Microsoft.MixedReality.WebRTC.csproj
       arguments: '-f netstandard2.0 --no-incremental -c Release'
       workingDirectory: libs/Microsoft.MixedReality.WebRTC/
+
+  # Build TestAppUWP (Release)
+  - task: MSBuild@1
+    condition: succeededOrFailed() # Build even previous task failed
+    displayName: 'Build C# sample TestAppUWP (AnyCPU-Release)'
+    inputs:
+      msbuildVersion: 16.0
+      msbuildArchitecture: x64
+      solution: examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
+      platform: x64
+      configuration: Release
+      restoreNugetPackages: true
 
   # Build C# tests
   - task: DotNetCoreCLI@2

--- a/tools/ci/templates/jobs-cs.yaml
+++ b/tools/ci/templates/jobs-cs.yaml
@@ -23,6 +23,20 @@ jobs:
   steps:
   - checkout: self
 
+  # Use NuGet 5.2.0
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet 5.2.0'
+    inputs:
+      versionSpec: 5.2.0
+
+  # Restore NuGet packages for TestAppUWP
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand@2
+    displayName: 'Restore NuGet packages for TestAppUWP'
+    inputs:
+      command: restore
+      restoreSolution: examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
+    timeoutInMinutes: 10
+
   # Build Microsoft.MixedReality.WebRTC (Debug, incremental build)
   - task: DotNetCoreCLI@2
     displayName: 'Build C# WebRTC lib (AnyCPU-Debug) [incremental]'
@@ -45,12 +59,11 @@ jobs:
     condition: succeededOrFailed() # Build even previous task failed
     displayName: 'Build C# sample TestAppUWP (AnyCPU-Release)'
     inputs:
-      msbuildVersion: 16.0
+      msbuildVersion: latest
       msbuildArchitecture: x64
       solution: examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
       platform: x64
       configuration: Release
-      restoreNugetPackages: true
 
   # Build C# tests
   - task: DotNetCoreCLI@2

--- a/tools/ci/templates/jobs-cs.yaml
+++ b/tools/ci/templates/jobs-cs.yaml
@@ -62,7 +62,7 @@ jobs:
       solution: examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
       platform: x64
       configuration: Release
-      msbuildArguments: -restore
+      msbuildArguments: -restore -p:AppxPackageSigningEnabled=false
 
   # Build C# tests
   - task: DotNetCoreCLI@2

--- a/tools/ci/templates/jobs-cs.yaml
+++ b/tools/ci/templates/jobs-cs.yaml
@@ -23,11 +23,17 @@ jobs:
   steps:
   - checkout: self
 
-  # Create fake native lib for TestAppUWP dependency
-  - powershell: |
-      New-Item -Path bin\UWP\x64\Release\ -Name Microsoft.MixedReality.WebRTC.Native.dll -ItemType File
-      New-Item -Path bin\UWP\x64\Release\ -Name Microsoft.MixedReality.WebRTC.Native.pdb -ItemType File
-    displayName: Create fake native DLL and PDB
+  # Download the native libraries for testing
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download native library (UWP-x64-Release)'
+    inputs:
+      source: specific
+      project: '5610c425-4799-474c-b133-d95d78fb63b1' # MixedReality-WebRTC-CI
+      pipeline: 24 # mr-webrtc-cpp-ci
+      runVersion: 'latest'
+      artifact: 'Microsoft.MixedReality.WebRTC.Native_UWP-x64-Release'
+      patterns: '**/*.@(pdb|dll)'
+      path: 'bin/UWP/x64/Release'
 
   # Build Microsoft.MixedReality.WebRTC (Debug, incremental build)
   - task: DotNetCoreCLI@2

--- a/tools/ci/templates/jobs-cs.yaml
+++ b/tools/ci/templates/jobs-cs.yaml
@@ -23,20 +23,6 @@ jobs:
   steps:
   - checkout: self
 
-  # Use NuGet 5.2.0
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet 5.2.0'
-    inputs:
-      versionSpec: 5.2.0
-
-  # Restore NuGet packages for TestAppUWP
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand@2
-    displayName: 'Restore NuGet packages for TestAppUWP'
-    inputs:
-      command: restore
-      restoreSolution: examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
-    timeoutInMinutes: 10
-
   # Build Microsoft.MixedReality.WebRTC (Debug, incremental build)
   - task: DotNetCoreCLI@2
     displayName: 'Build C# WebRTC lib (AnyCPU-Debug) [incremental]'
@@ -64,6 +50,7 @@ jobs:
       solution: examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
       platform: x64
       configuration: Release
+      msbuildArguments: -restore
 
   # Build C# tests
   - task: DotNetCoreCLI@2

--- a/tools/ci/templates/jobs-cs.yaml
+++ b/tools/ci/templates/jobs-cs.yaml
@@ -23,13 +23,25 @@ jobs:
   steps:
   - checkout: self
 
-  # Download the native libraries for testing
+  # Download Microsoft.MixedReality.WebRTC.Native.dll (UWP-x64-Debug)
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download native library (UWP-x64-Debug)'
+    inputs:
+      source: specific
+      project: $(ArtifactConfig.Project)
+      definition: $(ArtifactConfig.CppDefinitionId)
+      runVersion: 'latest'
+      artifact: 'Microsoft.MixedReality.WebRTC.Native_UWP-x64-Debug'
+      patterns: '**/*.@(pdb|dll)'
+      path: 'bin/UWP/x64/Debug'
+
+  # Download Microsoft.MixedReality.WebRTC.Native.dll (UWP-x64-Release)
   - task: DownloadPipelineArtifact@2
     displayName: 'Download native library (UWP-x64-Release)'
     inputs:
       source: specific
-      project: '5610c425-4799-474c-b133-d95d78fb63b1' # MixedReality-WebRTC-CI
-      pipeline: 24 # mr-webrtc-cpp-ci
+      project: $(ArtifactConfig.Project)
+      definition: $(ArtifactConfig.CppDefinitionId)
       runVersion: 'latest'
       artifact: 'Microsoft.MixedReality.WebRTC.Native_UWP-x64-Release'
       patterns: '**/*.@(pdb|dll)'
@@ -52,10 +64,22 @@ jobs:
       arguments: '-f netstandard2.0 --no-incremental -c Release'
       workingDirectory: libs/Microsoft.MixedReality.WebRTC/
 
+  # Build TestAppUWP (Debug)
+  - task: MSBuild@1
+    condition: succeededOrFailed() # Build even previous task failed
+    displayName: 'Build C# sample TestAppUWP (AnyCPU-Debug)'
+    inputs:
+      msbuildVersion: latest
+      msbuildArchitecture: x64
+      solution: examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
+      platform: x64
+      configuration: Debug
+      msbuildArguments: -restore -p:AppxPackageSigningEnabled=false
+
   # Build TestAppUWP (Release)
   - task: MSBuild@1
     condition: succeededOrFailed() # Build even previous task failed
-    displayName: 'Build C# sample TestAppUWP (AnyCPU-Release)'
+    displayName: 'Build C# sample TestAppUWP (AnyCPU-Release) [.NET Native]'
     inputs:
       msbuildVersion: latest
       msbuildArchitecture: x64
@@ -71,17 +95,6 @@ jobs:
       projects: tests/Microsoft.MixedReality.WebRTC.Tests/Microsoft.MixedReality.WebRTC.Tests.csproj
       arguments: '-c ${{parameters.testConfig}}'
       workingDirectory: tests/Microsoft.MixedReality.WebRTC.Tests/
-
-  # Download Microsoft.MixedReality.WebRTC.Native.dll (Win32-x64-Release)
-  - task: DownloadPipelineArtifact@1
-    displayName: 'Download C++ WebRTC lib (Win32-x64-Release)'
-    inputs:
-      buildType: specific
-      project: $(ArtifactConfig.Project)
-      definition: $(ArtifactConfig.CppDefinitionId)
-      artifactName: 'Microsoft.MixedReality.WebRTC.Native_Win32-x64-Release'
-      targetPath: '$(Build.SourcesDirectory)/bin/Win32/x64/Release'
-    enabled: false
 
   # Run tests (Win32-x64-Release)
   - task: VSTest@2

--- a/tools/ci/templates/jobs-cs.yaml
+++ b/tools/ci/templates/jobs-cs.yaml
@@ -23,6 +23,12 @@ jobs:
   steps:
   - checkout: self
 
+  # Create fake native lib for TestAppUWP dependency
+  - powershell: |
+      New-Item -Path bin\UWP\x64\Release\ -Name Microsoft.MixedReality.WebRTC.Native.dll -ItemType File
+      New-Item -Path bin\UWP\x64\Release\ -Name Microsoft.MixedReality.WebRTC.Native.pdb -ItemType File
+    displayName: Create fake native DLL and PDB
+
   # Build Microsoft.MixedReality.WebRTC (Debug, incremental build)
   - task: DotNetCoreCLI@2
     displayName: 'Build C# WebRTC lib (AnyCPU-Debug) [incremental]'


### PR DESCRIPTION
Avoid build breaks in TestAppUWP by compiling it during the CI builds of the C# library.

Build both the Debug and Release configs, the former using the managed .NET Standard 2.0 framework while the later uses the .NET Native toolchain.

Disable signing the resulting AppX, as this is just a sample app and no signing key is committed to the repository for security reasons by policy.