### PR TITLE
Initialize MF sources from actual frame format

### DIFF
--- a/examples/TestAppUwp/Video/VideoBridge.cs
+++ b/examples/TestAppUwp/Video/VideoBridge.cs
@@ -131,8 +131,7 @@ namespace TestAppUwp.Video
         /// <param name="args">The Media Foundation sample request to attempt to serve</param>
         public void TryServeVideoFrame(MediaStreamSourceSampleRequestedEventArgs args)
         {
-            // Check if the local video stream is enabled
-            if (_frameQueue == null) //< TODO - not the correct check (though also useful)
+            if (_frameQueue == null)
             {
                 // End of stream
                 args.Request.Sample = null;
@@ -152,9 +151,13 @@ namespace TestAppUwp.Video
                         // Already a frame pending, and now another one.
                         // The earlier one will be skipped (we don't keep track of it for simplicity).
                         //_frameQueue.FrameSkip.Track();
+
+                        _request = null;
+                        _deferral.Complete();
+                        _deferral = null;
                     }
-                    args.Request.ReportSampleProgress(0);
                     _request = args.Request;
+                    _request.ReportSampleProgress(0);
                     _deferral = _request.GetDeferral();
                     return;
                 }


### PR DESCRIPTION
In TestAppUWP, ensure that the Media Foundation stream sources are
initialized, both for the local and the remote video, based on the
actual format of the video stream and not from a hard-coded resolution.
This prevent visual artifacts when resolution mismatches.

Bug: #36