### PR TITLE
Add codec parameter override to SDP filtering

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/api.h
@@ -348,6 +348,19 @@ mrsPeerConnectionClose(PeerConnectionHandle* peerHandle) noexcept;
 // SDP utilities
 //
 
+/// Codec arguments for SDP filtering, to allow selecting a preferred codec and
+/// overriding some of its parameters.
+struct SdpFilter {
+  /// SDP name of a preferred codec, which is to be retained alone if present in
+  /// the SDP offer message, discarding all others.
+  const char* codec_name = nullptr;
+
+  /// Semicolon-separated list of "key=value" pairs of codec parameters to pass
+  /// to the codec. Arguments are passed as is without validation of their name
+  /// nor value.
+  const char* params = nullptr;
+};
+
 /// Force audio and video codecs when advertizing capabilities in an SDP offer.#
 ///
 /// This is a workaround for the lack of access to codec selection. Instead of
@@ -379,8 +392,8 @@ mrsPeerConnectionClose(PeerConnectionHandle* peerHandle) noexcept;
 /// Returns true on success or false if the buffer is not large enough to
 /// contain the new SDP message.
 MRS_API bool MRS_CALL mrsSdpForceCodecs(const char* message,
-                                        const char* audio_codec_name,
-                                        const char* video_codec_name,
+                                        SdpFilter audio_filter,
+                                        SdpFilter video_filter,
                                         char* buffer,
                                         size_t* buffer_size);
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/sdp_utils.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/sdp_utils.cpp
@@ -10,11 +10,65 @@
 #include "pc/sessiondescription.h"
 #include "pc/webrtcsdp.h"
 
+namespace {
+
+/// Assign a preferred audio or video codec to the media content description,
+/// and optionally add some extra codec parameters on top of the default one,
+/// overwritting any previous value.
+template <typename C>
+bool SetPreferredCodec(
+    const std ::string& codec_name,
+    cricket::MediaContentDescriptionImpl<C>* desc,
+    const std::map<std::string, std::string>& extra_codec_params) {
+  // Find the preferred codec, if available
+  const std::vector<C>& codecs = desc->codecs();
+  auto it = std::find_if(
+      codecs.begin(), codecs.end(),
+      [&codec_name](const C& codec) { return (codec.name == codec_name); });
+  if (it == codecs.end()) {
+    return false;
+  }
+
+  // Assign the codec to the media content description
+  std::vector<C> new_codecs;
+  new_codecs.reserve(1);
+  if (extra_codec_params.empty()) {
+    // Add preferred codec with default parameters
+    new_codecs.push_back(*it);
+  } else {
+    // Make a copy to modify the parameters
+    C preferred_codec = *it;
+    for (auto&& param : extra_codec_params) {
+      preferred_codec.SetParam(param.first, param.second);
+    }
+    new_codecs.push_back(preferred_codec);
+  }
+  desc->set_codecs(new_codecs);
+  return true;
+}
+
+}  // namespace
+
 namespace Microsoft::MixedReality::WebRTC {
 
-std::string SdpForceCodecs(const std::string& message,
-                           const std::string& audio_codec_name,
-                           const std::string& video_codec_name) {
+void SdpParseCodecParameters(const std::string& param_string,
+                             std::map<std::string, std::string>& params) {
+  std::vector<std::string> key_values;
+  rtc::split(param_string, ';', &key_values);
+  for (auto&& kv : key_values) {
+    std::vector<std::string> param(2);
+    if (rtc::split(kv, '=', &param) == 2) {
+      params[std::move(param[0])] = std::move(param[1]);
+    }
+  }
+}
+
+std::string SdpForceCodecs(
+    const std::string& message,
+    const std::string& audio_codec_name,
+    const std::map<std::string, std::string>& extra_audio_codec_params,
+    const std::string& video_codec_name,
+    const std::map<std::string, std::string>& extra_video_codec_params) {
   // Deserialize the SDP message
   webrtc::JsepSessionDescription jdesc(webrtc::SdpType::kOffer);
   webrtc::SdpParseError error;
@@ -24,8 +78,12 @@ std::string SdpForceCodecs(const std::string& message,
         << error.line << ": " << error.description;
     return message;
   }
+  if (jdesc.GetType() != webrtc::SdpType::kOffer) {
+    RTC_LOG(LS_WARNING) << "Cannot force codecs on non-offer SDP message.";
+    return message;
+  }
 
-  // Remove codecs not wanted
+  // Remove codecs not wanted, add extra parameters if needed
   {
     // Loop over the session contents to find the audio and video ones
     const cricket::SessionDescription* const desc = jdesc.description();
@@ -38,19 +96,8 @@ std::string SdpForceCodecs(const std::string& message,
           if (!audio_codec_name.empty()) {
             cricket::AudioContentDescription* const audio_desc =
                 media_desc->as_audio();
-            const std::vector<cricket::AudioCodec>& codecs =
-                audio_desc->codecs();
-            auto it = std::find_if(
-                codecs.begin(), codecs.end(),
-                [&audio_codec_name](const cricket::AudioCodec& codec) {
-                  return (codec.name == audio_codec_name);
-                });
-            if (it == codecs.end()) {
-              break;
-            }
-            std::vector<cricket::AudioCodec> new_codecs;
-            new_codecs.push_back(*it);
-            audio_desc->set_codecs(new_codecs);
+            SetPreferredCodec<cricket::AudioCodec>(audio_codec_name, audio_desc,
+                                                   extra_audio_codec_params);
           }
           break;
         case cricket::MediaType::MEDIA_TYPE_VIDEO:
@@ -58,19 +105,8 @@ std::string SdpForceCodecs(const std::string& message,
           if (!video_codec_name.empty()) {
             cricket::VideoContentDescription* const video_desc =
                 media_desc->as_video();
-            const std::vector<cricket::VideoCodec>& codecs =
-                video_desc->codecs();
-            auto it = std::find_if(
-                codecs.begin(), codecs.end(),
-                [&video_codec_name](const cricket::VideoCodec& codec) {
-                  return (codec.name == video_codec_name);
-                });
-            if (it == codecs.end()) {
-              break;
-            }
-            std::vector<cricket::VideoCodec> new_codecs;
-            new_codecs.push_back(*it);
-            video_desc->set_codecs(new_codecs);
+            SetPreferredCodec<cricket::VideoCodec>(video_codec_name, video_desc,
+                                                   extra_video_codec_params);
           }
           break;
         case cricket::MediaType::MEDIA_TYPE_DATA:

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/sdp_utils.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/sdp_utils.h
@@ -10,6 +10,11 @@
 
 namespace Microsoft::MixedReality::WebRTC {
 
+/// Parse a list of semicolon-separated pairs of "key=value" arguments into a
+/// map of (key, value) pairs.
+void SdpParseCodecParameters(const std::string& param_string,
+                             std::map<std::string, std::string>& params);
+
 /// Force audio and video codecs when advertizing capabilities in an SDP offer.
 /// This is a workaround for the lack of access to codec selection. Instead of
 /// selecting codecs in code, this can be used to intercept a generated SDP
@@ -23,8 +28,11 @@ namespace Microsoft::MixedReality::WebRTC {
 /// |audio_codec_name| SDP name of the audio codec to force, if supported.
 /// |video_codec_name| SDP name of the video codec to force, if supported.
 /// Returns the new SDP offer message string to be sent via the signaler.
-std::string SdpForceCodecs(const std::string& message,
-                           const std::string& audio_codec_name,
-                           const std::string& video_codec_name);
+std::string SdpForceCodecs(
+    const std::string& message,
+    const std::string& audio_codec_name,
+    const std::map<std::string, std::string>& extra_audio_codec_params,
+    const std::string& video_codec_name,
+    const std::map<std::string, std::string>& extra_video_codec_params);
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/sdp_utils_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/sdp_utils_tests.cpp
@@ -161,7 +161,10 @@ TEST(SdpUtils, ForceCodecs) {
   ASSERT_NE(nullptr, buffer._data);
   // Force audio to "opus" only. Don't change video because "h264" is not
   // advertized as supported in the input message
-  mrsSdpForceCodecs(kSdpFullString, "opus", "h264", buffer._data, &len);
+  SdpFilter audio_filter{"opus", ""};
+  SdpFilter video_filter{"h264", ""};
+  mrsSdpForceCodecs(kSdpFullString, audio_filter, video_filter, buffer._data,
+                    &len);
   ASSERT_EQ(sizeof(kSdpForcedAudioOpus), len);
   ASSERT_EQ(0, memcmp(kSdpForcedAudioOpus, buffer._data, len));
 }
@@ -171,8 +174,10 @@ TEST(SdpUtils, ForceCodecsNotSupported) {
   size_t len = sizeof(kSdpFullString) * 2;
   RaiiBuffer buffer(len);
   ASSERT_NE(nullptr, buffer._data);
-  mrsSdpForceCodecs(kSdpFullString, "random_non_existing_audio_codec",
-                    "random_non_existing_video_codec", buffer._data, &len);
+  SdpFilter audio_filter{"random_non_existing_audio_codec", ""};
+  SdpFilter video_filter{"random_non_existing_video_codec", ""};
+  mrsSdpForceCodecs(kSdpFullString, audio_filter, video_filter, buffer._data,
+                    &len);
   ASSERT_EQ(sizeof(kSdpFullString), len);
   ASSERT_EQ(0, memcmp(kSdpFullString, buffer._data, len));
 }
@@ -181,7 +186,9 @@ TEST(SdpUtils, ForceCodecsNotSupported) {
 TEST(SdpUtils, ForceCodecsShortBuffer) {
   size_t len = 32;  // too short on purpose
   char buffer[32];
-  ASSERT_EQ(false,
-            mrsSdpForceCodecs(kSdpFullString, "opus", "h264", buffer, &len));
+  SdpFilter audio_filter{"opus", ""};
+  SdpFilter video_filter{"h264", ""};
+  ASSERT_EQ(false, mrsSdpForceCodecs(kSdpFullString, audio_filter, video_filter,
+                                     buffer, &len));
   ASSERT_EQ(sizeof(kSdpForcedAudioOpus), len);
 }


### PR DESCRIPTION
Allow the caller to specify a semicolon-separated list of key=value
pairs of codec arguments passed directly to the preferred codec during
SDP filtering, to configure it.

This is a low-level interface for advanced use only, will no validation
checks whatsoever. This fixes #51 at least short term.