### PR TITLE
Remove packaging of Org.WebRtc.dll

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.UWP.ARM.nuspec
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.UWP.ARM.nuspec
@@ -17,13 +17,6 @@
         <!-- UWP static library wrapper Org.WebRtc.WrapperGlue -->
         <file src="Build\Output\Org.WebRtc.WrapperGlue\Release\ARM\Org.WebRtc.WrapperGlue.lib" target="lib\native\lib\uap10.0\arm\release" />
 
-        <!-- UWP WinRT wrapper Org.WebRtc -->
-        <!-- WinMd and IntelliSense -->
-        <file src="Build\Output\Org.WebRtc\Release\ARM\Org.WebRtc.winmd" target="lib\uap10.0" />
-        <file src="Build\Output\Org.WebRtc\Release\ARM\Org.WebRtc.xml" target="lib\uap10.0" />
-        <!-- DLLs and resources -->
-        <file src="Build\Output\Org.WebRtc\Release\ARM\Org.WebRtc.dll" target="runtimes\win10-arm\native" />
-        <file src="Build\Output\Org.WebRtc\Release\ARM\Org.WebRtc.pri" target="runtimes\win10-arm\native" />
         <!-- .props -->
         <file src="libs\Microsoft.MixedReality.WebRTC.Native.Core\Microsoft.MixedReality.WebRTC.Native.Core.UWP.ARM.props" target="build\native" />
     </files>

--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.UWP.x64.nuspec
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.UWP.x64.nuspec
@@ -17,13 +17,6 @@
         <!-- UWP static library wrapper Org.WebRtc.WrapperGlue -->
         <file src="Build\Output\Org.WebRtc.WrapperGlue\Release\x64\Org.WebRtc.WrapperGlue.lib" target="lib\native\lib\uap10.0\x64\release" />
 
-        <!-- UWP WinRT wrapper Org.WebRtc -->
-        <!-- WinMd and IntelliSense -->
-        <file src="Build\Output\Org.WebRtc\Release\x64\Org.WebRtc.winmd" target="lib\uap10.0" />
-        <file src="Build\Output\Org.WebRtc\Release\x64\Org.WebRtc.xml" target="lib\uap10.0" />
-        <!-- DLLs and resources -->
-        <file src="Build\Output\Org.WebRtc\Release\x64\Org.WebRtc.dll" target="runtimes\win10-x64\native" />
-        <file src="Build\Output\Org.WebRtc\Release\x64\Org.WebRtc.pri" target="runtimes\win10-x64\native" />
         <!-- .props -->
         <file src="libs\Microsoft.MixedReality.WebRTC.Native.Core\Microsoft.MixedReality.WebRTC.Native.Core.UWP.x64.props" target="build\native" />
     </files>

--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.UWP.x86.nuspec
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.UWP.x86.nuspec
@@ -17,13 +17,6 @@
         <!-- UWP static library wrapper Org.WebRtc.WrapperGlue -->
         <file src="Build\Output\Org.WebRtc.WrapperGlue\Release\x86\Org.WebRtc.WrapperGlue.lib" target="lib\native\lib\uap10.0\x86\release" />
 
-        <!-- UWP WinRT wrapper Org.WebRtc -->
-        <!-- WinMd and IntelliSense -->
-        <file src="Build\Output\Org.WebRtc\Release\x86\Org.WebRtc.winmd" target="lib\uap10.0" />
-        <file src="Build\Output\Org.WebRtc\Release\x86\Org.WebRtc.xml" target="lib\uap10.0" />
-        <!-- DLLs and resources -->
-        <file src="Build\Output\Org.WebRtc\Release\x86\Org.WebRtc.dll" target="runtimes\win10-x86\native" />
-        <file src="Build\Output\Org.WebRtc\Release\x86\Org.WebRtc.pri" target="runtimes\win10-x86\native" />
         <!-- .props -->
         <file src="libs\Microsoft.MixedReality.WebRTC.Native.Core\Microsoft.MixedReality.WebRTC.Native.Core.UWP.x86.props" target="build\native" />
     </files>

--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.ARM.Debug.props
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.ARM.Debug.props
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-        <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Org.WebRtc.winmd">
-            <Implementation>Org.WebRtc.dll</Implementation>
-        </Reference>
-        <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-arm\native\$(Configuration)\Org.WebRtc.dll" />
-    </ItemGroup>
     <ItemDefinitionGroup Condition="'$(Platform)' == 'ARM'">
         <Link>
             <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\lib\uap10.0\arm\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.ARM.Release.props
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.ARM.Release.props
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-        <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Org.WebRtc.winmd">
-            <Implementation>Org.WebRtc.dll</Implementation>
-        </Reference>
-        <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-arm\native\$(Configuration)\Org.WebRtc.dll" />
-    </ItemGroup>
     <ItemDefinitionGroup Condition="'$(Platform)' == 'ARM'">
         <Link>
             <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\lib\uap10.0\arm\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.x64.Debug.props
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.x64.Debug.props
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-        <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Org.WebRtc.winmd">
-            <Implementation>Org.WebRtc.dll</Implementation>
-        </Reference>
-        <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x64\native\Org.WebRtc.dll" />
-    </ItemGroup>
     <ItemDefinitionGroup Condition="'$(Platform)' == 'x64'">
         <Link>
             <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\lib\uap10.0\x64\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.x64.Release.props
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.x64.Release.props
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-        <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Org.WebRtc.winmd">
-            <Implementation>Org.WebRtc.dll</Implementation>
-        </Reference>
-        <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x64\native\Org.WebRtc.dll" />
-    </ItemGroup>
     <ItemDefinitionGroup Condition="'$(Platform)' == 'x64'">
         <Link>
             <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\lib\uap10.0\x64\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.x86.Debug.props
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.x86.Debug.props
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-        <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Org.WebRtc.winmd">
-            <Implementation>Org.WebRtc.dll</Implementation>
-        </Reference>
-        <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x86\native\Org.WebRtc.dll" />
-    </ItemGroup>
     <ItemDefinitionGroup Condition="'$(Platform)' == 'Win32'">
         <Link>
             <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\lib\uap10.0\x86\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.x86.Release.props
+++ b/libs/Microsoft.MixedReality.WebRTC.Native.Core/Microsoft.MixedReality.WebRTC.Native.Core.WinRT.x86.Release.props
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-        <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Org.WebRtc.winmd">
-            <Implementation>Org.WebRtc.dll</Implementation>
-        </Reference>
-        <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x86\native\Org.WebRtc.dll" />
-    </ItemGroup>
     <ItemDefinitionGroup Condition="'$(Platform)' == 'Win32'">
         <Link>
             <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\lib\uap10.0\x86\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION
WebRtc is consumed via the webrtc.lib
Fixes #87 