### PR TITLE
Expose workaround for H.264 Hololens encoder bug

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
@@ -197,6 +197,15 @@ class PeerConnection : public TrackedObject {
   virtual webrtc::RTCError MRS_API
   RemoveLocalVideoTrack(LocalVideoTrack& video_track) noexcept = 0;
 
+  enum class FrameHeightRoundMode { NONE = 0, CROP = 1, PAD = 2 };
+
+  /// Use this function to select whether resolutions where height is not multiple of 16
+  /// should be cropped, padded or left unchanged.
+  /// Default is FrameHeightRoundMode::NONE, except on Hololens 1 where it is
+  /// FrameHeightRoundMode::CROP to avoid severe artifacts produced by
+  /// the H.264 hardware encoder.  
+  static void SetFrameHeightRoundMode(FrameHeightRoundMode value);
+
   //
   // Audio
   //

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
@@ -197,13 +197,28 @@ class PeerConnection : public TrackedObject {
   virtual webrtc::RTCError MRS_API
   RemoveLocalVideoTrack(LocalVideoTrack& video_track) noexcept = 0;
 
-  enum class FrameHeightRoundMode { NONE = 0, CROP = 1, PAD = 2 };
+  enum class FrameHeightRoundMode {
+    /// Leave frames unchanged.
+    NONE = 0,
+
+    /// Crop frame height to the nearest multiple of 16.
+    /// ((height - nearestLowerMultipleOf16) / 2) rows are cropped from the top
+    /// and (height - nearestLowerMultipleOf16 - croppedRowsTop) rows are
+    /// cropped from the bottom.
+    CROP = 1,
+
+    /// Pad frame height to the nearest multiple of 16.
+    /// ((nearestHigherMultipleOf16 - height) / 2) rows are added symmetrically
+    /// at the top and (nearestHigherMultipleOf16 - height - addedRowsTop) rows
+    /// are added symmetrically at the bottom.
+    PAD = 2
+  };
 
   /// Use this function to select whether resolutions where height is not multiple of 16
   /// should be cropped, padded or left unchanged.
   /// Default is FrameHeightRoundMode::NONE, except on Hololens 1 where it is
   /// FrameHeightRoundMode::CROP to avoid severe artifacts produced by
-  /// the H.264 hardware encoder.  
+  /// the H.264 hardware encoder.
   static void SetFrameHeightRoundMode(FrameHeightRoundMode value);
 
   //

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
@@ -999,14 +999,10 @@ mrsResult MRS_CALL mrsSdpForceCodecs(const char* message,
   return Result::kSuccess;
 }
 
-// Defined in
-// external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
-extern bool webrtc__WinUWPH264EncoderImpl__add_padding;
-
 void MRS_CALL
-mrsSetHololensH264EncoderWorkaround(HololensH264EncoderWorkaround value) {
-  webrtc__WinUWPH264EncoderImpl__add_padding =
-      (value == HololensH264EncoderWorkaround::PAD);
+mrsSetFrameHeightRoundMode(FrameHeightRoundMode value) {
+  PeerConnection::SetFrameHeightRoundMode(
+      (PeerConnection::FrameHeightRoundMode)value);
 }
 
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
@@ -1043,6 +1043,17 @@ mrsResult MRS_CALL mrsSdpForceCodecs(const char* message,
   return MRS_SUCCESS;
 }
 
+// Defined in
+// external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
+extern bool webrtc__WinUWPH264EncoderImpl__add_padding;
+
+void MRS_CALL
+mrsSetHololensH264EncoderWorkaround(HololensH264EncoderWorkaround value) {
+  webrtc__WinUWPH264EncoderImpl__add_padding =
+      (value == HololensH264EncoderWorkaround::PAD);
+}
+
+
 void MRS_CALL mrsMemCpy(void* dst, const void* src, uint64_t size) noexcept {
   memcpy(dst, src, static_cast<size_t>(size));
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.h
@@ -656,11 +656,12 @@ MRS_API mrsResult MRS_CALL mrsSdpForceCodecs(const char* message,
                                              char* buffer,
                                              uint64_t* buffer_size) noexcept;
 
-enum class HololensH264EncoderWorkaround : int32_t { CROP = 0, PAD = 1};
+/// Must be the same as PeerConnection::FrameHeightRoundMode.
+enum class FrameHeightRoundMode : int32_t { NONE = 0, CROP = 1, PAD = 2};
 
-/// See PeerConnection.SetHololensH264EncoderWorkaround for details.
+/// See PeerConnection::SetFrameHeightRoundMode.
 MRS_API void MRS_CALL
-mrsSetHololensH264EncoderWorkaround(HololensH264EncoderWorkaround value);
+mrsSetFrameHeightRoundMode(FrameHeightRoundMode value);
 
 //
 // Generic utilities

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.h
@@ -668,7 +668,7 @@ MRS_API mrsResult MRS_CALL mrsSdpForceCodecs(const char* message,
                                              char* buffer,
                                              uint64_t* buffer_size) noexcept;
 
-enum class HololensH264EncoderWorkaround : uint32_t { CROP = 0, PAD = 1};
+enum class HololensH264EncoderWorkaround : int32_t { CROP = 0, PAD = 1};
 
 /// See PeerConnection.SetHololensH264EncoderWorkaround for details.
 MRS_API void MRS_CALL

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.h
@@ -668,6 +668,12 @@ MRS_API mrsResult MRS_CALL mrsSdpForceCodecs(const char* message,
                                              char* buffer,
                                              uint64_t* buffer_size) noexcept;
 
+enum class HololensH264EncoderWorkaround : uint32_t { CROP = 0, PAD = 1};
+
+/// See PeerConnection.SetHololensH264EncoderWorkaround for details.
+MRS_API void MRS_CALL
+mrsSetHololensH264EncoderWorkaround(HololensH264EncoderWorkaround value);
+
 //
 // Generic utilities
 //

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
@@ -1234,6 +1234,10 @@ namespace Microsoft::MixedReality::WebRTC {
 ErrorOr<RefPtr<PeerConnection>> PeerConnection::create(
     const PeerConnectionConfiguration& config,
     mrsPeerConnectionInteropHandle interop_handle) {
+  // Set the default value for the HL1 workaround before creating any
+  // connection.
+  InitHololensH264Workaround();
+
   // Ensure the factory exists
   rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory;
   {
@@ -1272,6 +1276,8 @@ ErrorOr<RefPtr<PeerConnection>> PeerConnection::create(
 }
 
 void PeerConnection::SetFrameHeightRoundMode(FrameHeightRoundMode value) {
+  // Ensure that the default is set. This prevents following calls to
+  // InitHololensH264Workaround from overriding the explicitly set value.
   InitHololensH264Workaround();
   webrtc__WinUWPH264EncoderImpl__frame_height_round_mode = (int)value;
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
@@ -18,6 +18,85 @@
 
 #include <functional>
 
+// Defined in
+// external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
+static constexpr int kFrameHeightCrop = 1;
+extern int webrtc__WinUWPH264EncoderImpl__frame_height_round_mode;
+
+#if defined(_M_IX86) /* x86 */ && defined(WINAPI_FAMILY) && \
+    (WINAPI_FAMILY == WINAPI_FAMILY_APP) /* UWP app */ &&   \
+    defined(_WIN32_WINNT_WIN10) &&                          \
+    _WIN32_WINNT >= _WIN32_WINNT_WIN10 /* Win10 */
+
+#include <Windows.Foundation.h>
+#include <wrl\wrappers\corewrappers.h>
+#include <wrl\client.h>
+#include <windows.graphics.holographic.h>
+
+namespace {
+
+bool IsHololens() {
+  // The best way to check if we are running on Hololens is checking if this is
+  // a x86 Windows device with a transparent holographic display (AR).
+
+  using namespace Microsoft::WRL;
+  using namespace Microsoft::WRL::Wrappers;
+  using namespace ABI::Windows::Foundation;
+  using namespace ABI::Windows::Graphics::Holographic;
+
+#define RETURN_IF_ERROR(...) \
+  if (FAILED(__VA_ARGS__)) { \
+    return false;            \
+  }
+
+  RoInitializeWrapper initialize(RO_INIT_MULTITHREADED);
+
+  // HolographicSpace.IsAvailable
+  ComPtr<IHolographicSpaceStatics2> holo_space_statics;
+  RETURN_IF_ERROR(GetActivationFactory(
+      HStringReference(
+          RuntimeClass_Windows_Graphics_Holographic_HolographicSpace)
+          .Get(),
+      &holo_space_statics));
+  boolean is_holo_space_available;
+  RETURN_IF_ERROR(
+      holo_space_statics->get_IsAvailable(&is_holo_space_available));
+  if (!is_holo_space_available) {
+    // Not a holographic device.
+    return false;
+  }
+
+  // HolographicDisplay.GetDefault().IsOpaque
+  ComPtr<IHolographicDisplayStatics> holo_display_statics;
+  RETURN_IF_ERROR(GetActivationFactory(
+      HStringReference(
+          RuntimeClass_Windows_Graphics_Holographic_HolographicDisplay)
+          .Get(),
+      &holo_display_statics));
+  ComPtr<IHolographicDisplay> holo_display;
+  RETURN_IF_ERROR(holo_display_statics->GetDefault(&holo_display));
+  boolean is_opaque;
+  RETURN_IF_ERROR(holo_display->get_IsOpaque(&is_opaque));
+  // Hololens if not opaque (otherwise VR).
+  return !is_opaque;
+#undef RETURN_IF_ERROR
+}
+
+void InitHololensH264Workaround() {
+  static bool is_hololens_h264_workaround_initialized = false;
+  if (!is_hololens_h264_workaround_initialized && IsHololens()) {
+    is_hololens_h264_workaround_initialized = true;
+    webrtc__WinUWPH264EncoderImpl__frame_height_round_mode = kFrameHeightCrop;
+  }
+}
+
+}  // namespace
+#else
+namespace {
+void InitHololensH264Workaround() {}
+}  // namespace
+#endif
+
 namespace {
 
 using namespace Microsoft::MixedReality::WebRTC;
@@ -40,14 +119,17 @@ Result ResultFromRTCErrorType(webrtc::RTCErrorType type) {
   }
 }
 
-Error ErrorFromRTCError(const webrtc::RTCError& error) {
-  return Error(ResultFromRTCErrorType(error.type()), error.message());
+Microsoft::MixedReality::WebRTC::Error ErrorFromRTCError(
+    const webrtc::RTCError& error) {
+  return Microsoft::MixedReality::WebRTC::Error(
+      ResultFromRTCErrorType(error.type()), error.message());
 }
 
-Error ErrorFromRTCError(webrtc::RTCError&& error) {
+Microsoft::MixedReality::WebRTC::Error ErrorFromRTCError(webrtc::RTCError&& error) {
   // Ideally would move the std::string out of |error|, but doesn't look
   // possible at the moment.
-  return Error(ResultFromRTCErrorType(error.type()), error.message());
+  return Microsoft::MixedReality::WebRTC::Error(
+      ResultFromRTCErrorType(error.type()), error.message());
 }
 
 /// Implementation of PeerConnection, which also implements
@@ -469,7 +551,8 @@ IceConnectionState IceStateFromImpl(
 ErrorOr<RefPtr<LocalVideoTrack>> PeerConnectionImpl::AddLocalVideoTrack(
     rtc::scoped_refptr<webrtc::VideoTrackInterface> video_track) noexcept {
   if (IsClosed()) {
-    return Error(Result::kInvalidOperation, "The peer connection is closed.");
+    return Microsoft::MixedReality::WebRTC::Error(
+        Result::kInvalidOperation, "The peer connection is closed.");
   }
   auto result = peer_->AddTrack(video_track, {kAudioVideoStreamId});
   if (result.ok()) {
@@ -1186,6 +1269,11 @@ ErrorOr<RefPtr<PeerConnection>> PeerConnection::create(
   }
   peer->SetPeerImpl(std::move(impl));
   return RefPtr<PeerConnection>(peer);
+}
+
+void PeerConnection::SetFrameHeightRoundMode(FrameHeightRoundMode value) {
+  InitHololensH264Workaround();
+  webrtc__WinUWPH264EncoderImpl__frame_height_round_mode = (int)value;
 }
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
     /// Attribute to decorate managed delegates used as native callbacks (reverse P/Invoke).
     /// Required by Mono in Ahead-Of-Time (AOT) compiling, and Unity with the IL2CPP backend.
     /// </summary>
-    /// 
+    ///
     /// This attribute is required by Mono AOT and Unity IL2CPP, but not by .NET Core or Framework.
     /// The implementation was copied from the Mono source code (https://github.com/mono/mono).
     /// The type argument does not seem to be used anywhere in the code, and a stub implementation
@@ -96,13 +96,13 @@ namespace Microsoft.MixedReality.WebRTC.Interop
 
         /// <summary>
         /// Unsafe utility to copy a memory block with stride.
-        /// 
+        ///
         /// This utility loops over the rows of the input memory block, and copy them to the output
         /// memory block, then increment the read and write pointers by the source and destination
         /// strides, respectively. For each row, exactly <paramref name="elem_size"/> bytes are copied,
         /// even if the row stride is higher. The extra bytes in the destination buffer past the row
         /// size until the row stride are left untouched.
-        /// 
+        ///
         /// This is equivalent to the following pseudo-code:
         /// <code>
         /// for (int row = 0; row &lt; elem_count; ++row) {
@@ -168,5 +168,12 @@ namespace Microsoft.MixedReality.WebRTC.Interop
                 throw new ArgumentOutOfRangeException("Invalid ID passed to AddDataChannelAsync().");
             }
         }
+
+        /// <summary>
+        /// See <see cref="PeerConnection.SetHololensH264EncoderWorkaround(PeerConnection.HololensH264EncoderWorkaround)"/>.
+        /// </summary>
+        /// <param name="value"></param>
+        [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, EntryPoint = "mrsSetHololensH264EncoderWorkaround")]
+        public static unsafe extern void SetHololensH264EncoderWorkaround(int value);
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -174,10 +174,10 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         }
 
         /// <summary>
-        /// See <see cref="PeerConnection.SetHololensH264EncoderWorkaround(PeerConnection.HololensH264EncoderWorkaround)"/>.
+        /// See <see cref="PeerConnection.SetFrameHeightRoundMode(PeerConnection.FrameHeightRoundMode)"/>.
         /// </summary>
         /// <param name="value"></param>
-        [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, EntryPoint = "mrsSetHololensH264EncoderWorkaround")]
-        public static unsafe extern void SetHololensH264EncoderWorkaround(int value);
+        [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, EntryPoint = "mrsSetFrameHeightRoundMode")]
+        public static unsafe extern void SetFrameHeightRoundMode(int value);
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -178,6 +178,6 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         /// </summary>
         /// <param name="value"></param>
         [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, EntryPoint = "mrsSetFrameHeightRoundMode")]
-        public static unsafe extern void SetFrameHeightRoundMode(int value);
+        public static unsafe extern void SetFrameHeightRoundMode(PeerConnection.FrameHeightRoundMode value);
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -1321,6 +1321,30 @@ namespace Microsoft.MixedReality.WebRTC
             });
         }
 
+        /// <summary>
+        /// Configuration for the Hololens H.264 hardware encoder workaround.
+        /// </summary>
+        /// <seealso cref="SetHololensH264EncoderWorkaround"/>
+        public enum HololensH264EncoderWorkaround
+        {
+            // Crop frame height to the nearest multiple of 16.
+            CROP,
+            // Pad frame height to the nearest multiple of 16.
+            PAD
+        }
+
+        /// <summary>
+        /// The Hololens H.264 hardware encoder produces severe artifacts on resolutions where the
+        /// height is not multiple of 16. For this reason on Hololens these resolutions are either
+        /// cropped or padded before being encoded and streamed. Use this function to select the
+        /// rounding mode. Default is <see cref="HololensH264EncoderWorkaround.CROP"/>.
+        /// </summary>
+        /// <param name="value"></param>
+        public static void SetHololensH264EncoderWorkaround(HololensH264EncoderWorkaround value)
+        {
+            Utils.SetHololensH264EncoderWorkaround(value == HololensH264EncoderWorkaround.CROP ? 0 : 1);
+        }
+
         internal void OnConnected()
         {
             MainEventSource.Log.Connected();

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -1334,27 +1334,36 @@ namespace Microsoft.MixedReality.WebRTC
         }
 
         /// <summary>
-        /// Configuration for the Hololens H.264 hardware encoder workaround.
+        /// Frame height round mode.
         /// </summary>
-        /// <seealso cref="SetHololensH264EncoderWorkaround"/>
-        public enum HololensH264EncoderWorkaround
+        /// <seealso cref="SetFrameHeightRoundMode(FrameHeightRoundMode)"/>
+        public enum FrameHeightRoundMode
         {
-            // Crop frame height to the nearest multiple of 16.
-            CROP,
-            // Pad frame height to the nearest multiple of 16.
-            PAD
+            /// <summary>
+            /// Leave frames unchanged.
+            /// </summary>
+            NONE = 0,
+            /// <summary>
+            /// Crop frame height to the nearest multiple of 16.
+            /// </summary>
+            CROP = 1,
+            /// <summary>
+            /// Pad frame height to the nearest multiple of 16.
+            /// </summary>
+            PAD = 2
         }
 
         /// <summary>
-        /// The Hololens H.264 hardware encoder produces severe artifacts on resolutions where the
-        /// height is not multiple of 16. For this reason on Hololens these resolutions are either
-        /// cropped or padded before being encoded and streamed. Use this function to select the
-        /// rounding mode. Default is <see cref="HololensH264EncoderWorkaround.CROP"/>.
+        /// Use this function to select whether resolutions where height is not multiple of 16
+        /// should be cropped, padded or left unchanged.
+        /// Default is <see cref="FrameHeightRoundMode.NONE"/>, except on Hololens 1 where it is
+        /// <see cref="FrameHeightRoundMode.CROP"/> to avoid severe artifacts produced by
+        /// the H.264 hardware encoder.  
         /// </summary>
         /// <param name="value"></param>
-        public static void SetHololensH264EncoderWorkaround(HololensH264EncoderWorkaround value)
+        public static void SetFrameHeightRoundMode(FrameHeightRoundMode value)
         {
-            Utils.SetHololensH264EncoderWorkaround(value == HololensH264EncoderWorkaround.CROP ? 0 : 1);
+            Utils.SetFrameHeightRoundMode((int)value);
         }
 
         internal void OnConnected()

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -1343,12 +1343,18 @@ namespace Microsoft.MixedReality.WebRTC
             /// Leave frames unchanged.
             /// </summary>
             NONE = 0,
+
             /// <summary>
             /// Crop frame height to the nearest multiple of 16.
+            /// ((height - nearestLowerMultipleOf16) / 2) rows are cropped from the top and
+            /// (height - nearestLowerMultipleOf16 - croppedRowsTop) rows are cropped from the bottom.
             /// </summary>
             CROP = 1,
+
             /// <summary>
             /// Pad frame height to the nearest multiple of 16.
+            /// ((nearestHigherMultipleOf16 - height) / 2) rows are added symmetrically at the top and
+            /// (nearestHigherMultipleOf16 - height - addedRowsTop) rows are added symmetrically at the bottom.
             /// </summary>
             PAD = 2
         }
@@ -1358,12 +1364,12 @@ namespace Microsoft.MixedReality.WebRTC
         /// should be cropped, padded or left unchanged.
         /// Default is <see cref="FrameHeightRoundMode.NONE"/>, except on Hololens 1 where it is
         /// <see cref="FrameHeightRoundMode.CROP"/> to avoid severe artifacts produced by
-        /// the H.264 hardware encoder.  
+        /// the H.264 hardware encoder.
         /// </summary>
         /// <param name="value"></param>
         public static void SetFrameHeightRoundMode(FrameHeightRoundMode value)
         {
-            Utils.SetFrameHeightRoundMode((int)value);
+            Utils.SetFrameHeightRoundMode(value);
         }
 
         internal void OnConnected()


### PR DESCRIPTION
Mitigates https://github.com/webrtc-uwp/webrtc-uwp-sdk/issues/210.

TODO this is dependent on https://github.com/webrtc-uwp/webrtc-windows/pull/73