### PR TITLE
Backport #132 HL1 frame height workaround

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
@@ -244,6 +244,30 @@ class PeerConnection : public webrtc::PeerConnectionObserver,
   /// connection.
   bool IsLocalVideoTrackEnabled() const noexcept;
 
+  enum class FrameHeightRoundMode {
+    /// Leave frames unchanged.
+    NONE = 0,
+
+    /// Crop frame height to the nearest multiple of 16.
+    /// ((height - nearestLowerMultipleOf16) / 2) rows are cropped from the top
+    /// and (height - nearestLowerMultipleOf16 - croppedRowsTop) rows are
+    /// cropped from the bottom.
+    CROP = 1,
+
+    /// Pad frame height to the nearest multiple of 16.
+    /// ((nearestHigherMultipleOf16 - height) / 2) rows are added symmetrically
+    /// at the top and (nearestHigherMultipleOf16 - height - addedRowsTop) rows
+    /// are added symmetrically at the bottom.
+    PAD = 2
+  };
+
+  /// Use this function to select whether resolutions where height is not multiple of 16
+  /// should be cropped, padded or left unchanged.
+  /// Default is FrameHeightRoundMode::NONE, except on Hololens 1 where it is
+  /// FrameHeightRoundMode::CROP to avoid severe artifacts produced by
+  /// the H.264 hardware encoder.
+  static void SetFrameHeightRoundMode(FrameHeightRoundMode value);
+
   //
   // Audio
   //

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
@@ -244,29 +244,31 @@ class PeerConnection : public webrtc::PeerConnectionObserver,
   /// connection.
   bool IsLocalVideoTrackEnabled() const noexcept;
 
+  /// Rounding mode of video frame height for |SetFrameHeightRoundMode()|.
+  /// This is only used on HoloLens 1 (UWP x86).
   enum class FrameHeightRoundMode {
     /// Leave frames unchanged.
-    NONE = 0,
+    kNone = 0,
 
     /// Crop frame height to the nearest multiple of 16.
     /// ((height - nearestLowerMultipleOf16) / 2) rows are cropped from the top
     /// and (height - nearestLowerMultipleOf16 - croppedRowsTop) rows are
     /// cropped from the bottom.
-    CROP = 1,
+    kCrop = 1,
 
     /// Pad frame height to the nearest multiple of 16.
     /// ((nearestHigherMultipleOf16 - height) / 2) rows are added symmetrically
     /// at the top and (nearestHigherMultipleOf16 - height - addedRowsTop) rows
     /// are added symmetrically at the bottom.
-    PAD = 2
+    kPad = 2
   };
 
   /// [HoloLens 1 only]
-  /// Use this function to select whether resolutions where height is not multiple of 16
-  /// should be cropped, padded or left unchanged.
-  /// Default is FrameHeightRoundMode::NONE, except on Hololens 1 where it is
-  /// FrameHeightRoundMode::CROP to avoid severe artifacts produced by
-  /// the H.264 hardware encoder.
+  /// Use this function to select whether resolutions where height is not
+  /// multiple of 16 should be cropped, padded or left unchanged. Defaults to
+  /// FrameHeightRoundMode::kCrop to avoid severe artifacts produced by the
+  /// H.264 hardware encoder. The default value is applied when creating the
+  /// first peer connection, so can be overridden after it.
   static void SetFrameHeightRoundMode(FrameHeightRoundMode value);
 
   //

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection.h
@@ -261,6 +261,7 @@ class PeerConnection : public webrtc::PeerConnectionObserver,
     PAD = 2
   };
 
+  /// [HoloLens 1 only]
   /// Use this function to select whether resolutions where height is not multiple of 16
   /// should be cropped, padded or left unchanged.
   /// Default is FrameHeightRoundMode::NONE, except on Hololens 1 where it is

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
@@ -1278,6 +1278,12 @@ mrsResult MRS_CALL mrsSdpForceCodecs(const char* message,
   return MRS_SUCCESS;
 }
 
+void MRS_CALL
+mrsSetFrameHeightRoundMode(FrameHeightRoundMode value) {
+  PeerConnection::SetFrameHeightRoundMode(
+      (PeerConnection::FrameHeightRoundMode)value);
+}
+
 void MRS_CALL mrsMemCpy(void* dst, const void* src, uint64_t size) {
   memcpy(dst, src, static_cast<size_t>(size));
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.h
@@ -680,6 +680,13 @@ MRS_API mrsResult MRS_CALL mrsSdpForceCodecs(const char* message,
                                              char* buffer,
                                              uint64_t* buffer_size);
 
+/// Must be the same as PeerConnection::FrameHeightRoundMode.
+enum class FrameHeightRoundMode : int32_t { NONE = 0, CROP = 1, PAD = 2};
+
+/// See PeerConnection::SetFrameHeightRoundMode.
+MRS_API void MRS_CALL
+mrsSetFrameHeightRoundMode(FrameHeightRoundMode value);
+
 //
 // Generic utilities
 //

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
@@ -16,15 +16,15 @@
 
 #include <functional>
 
-// Defined in
-// external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
-static constexpr int kFrameHeightCrop = 1;
-extern int webrtc__WinUWPH264EncoderImpl__frame_height_round_mode;
-
 #if defined(_M_IX86) /* x86 */ && defined(WINAPI_FAMILY) && \
     (WINAPI_FAMILY == WINAPI_FAMILY_APP) /* UWP app */ &&   \
     defined(_WIN32_WINNT_WIN10) &&                          \
     _WIN32_WINNT >= _WIN32_WINNT_WIN10 /* Win10 */
+
+// Defined in
+// external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
+static constexpr int kFrameHeightCrop = 1;
+extern int webrtc__WinUWPH264EncoderImpl__frame_height_round_mode;
 
 #include <Windows.Foundation.h>
 #include <wrl\wrappers\corewrappers.h>
@@ -33,7 +33,7 @@ extern int webrtc__WinUWPH264EncoderImpl__frame_height_round_mode;
 
 namespace {
 
-bool IsHololens() {
+bool CheckIfHololens() {
   // The best way to check if we are running on Hololens is checking if this is
   // a x86 Windows device with a transparent holographic display (AR).
 
@@ -80,19 +80,27 @@ bool IsHololens() {
 #undef RETURN_IF_ERROR
 }
 
-void InitHololensH264Workaround() {
-  static bool is_hololens_h264_workaround_initialized = false;
-  if (!is_hololens_h264_workaround_initialized && IsHololens()) {
-    is_hololens_h264_workaround_initialized = true;
-    webrtc__WinUWPH264EncoderImpl__frame_height_round_mode = kFrameHeightCrop;
+bool IsHololens() {
+  static bool is_hololens = CheckIfHololens();
+  return is_hololens;
+}
+}  // namespace
+
+namespace Microsoft::MixedReality::WebRTC {
+void PeerConnection::SetFrameHeightRoundMode(FrameHeightRoundMode value) {
+  if (IsHololens()) {
+    webrtc__WinUWPH264EncoderImpl__frame_height_round_mode = (int)value;
   }
 }
+}  // namespace Microsoft::MixedReality::WebRTC
 
-}  // namespace
 #else
-namespace {
-void InitHololensH264Workaround() {}
-}  // namespace
+
+namespace Microsoft::MixedReality::WebRTC {
+void PeerConnection::SetFrameHeightRoundMode(FrameHeightRoundMode /*value*/) {
+}
+}  // namespace Microsoft::MixedReality::WebRTC
+
 #endif
 
 namespace {
@@ -165,8 +173,8 @@ rtc::scoped_refptr<PeerConnection> PeerConnection::create(
     const webrtc::PeerConnectionInterface::RTCConfiguration& config,
     mrsPeerConnectionInteropHandle interop_handle) {
   // Set the default value for the HL1 workaround before creating any
-  // connection.
-  InitHololensH264Workaround();
+  // connection. This has no effect on other platforms.
+  SetFrameHeightRoundMode(FrameHeightRoundMode::CROP);
   
   // Create the PeerConnection object
   rtc::scoped_refptr<PeerConnection> peer =
@@ -815,13 +823,6 @@ void PeerConnection::OnSuccess(
   // will in turn invoke the |local_sdp_ready_to_send_callback_| registered if
   // any, or do nothing otherwise. The observer is a mandatory parameter.
   peer_->SetLocalDescription(observer, desc);
-}
-
-void PeerConnection::SetFrameHeightRoundMode(FrameHeightRoundMode value) {
-  // Ensure that the default is set. This prevents following calls to
-  // InitHololensH264Workaround from overriding the explicitly set value.
-  InitHololensH264Workaround();
-  webrtc__WinUWPH264EncoderImpl__frame_height_round_mode = (int)value;
 }
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
@@ -174,7 +174,7 @@ rtc::scoped_refptr<PeerConnection> PeerConnection::create(
     mrsPeerConnectionInteropHandle interop_handle) {
   // Set the default value for the HL1 workaround before creating any
   // connection. This has no effect on other platforms.
-  SetFrameHeightRoundMode(FrameHeightRoundMode::CROP);
+  SetFrameHeightRoundMode(FrameHeightRoundMode::kCrop);
   
   // Create the PeerConnection object
   rtc::scoped_refptr<PeerConnection> peer =

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
     /// Attribute to decorate managed delegates used as native callbacks (reverse P/Invoke).
     /// Required by Mono in Ahead-Of-Time (AOT) compiling, and Unity with the IL2CPP backend.
     /// </summary>
-    /// 
+    ///
     /// This attribute is required by Mono AOT and Unity IL2CPP, but not by .NET Core or Framework.
     /// The implementation was copied from the Mono source code (https://github.com/mono/mono).
     /// The type argument does not seem to be used anywhere in the code, and a stub implementation
@@ -85,13 +85,13 @@ namespace Microsoft.MixedReality.WebRTC.Interop
 
         /// <summary>
         /// Unsafe utility to copy a memory block with stride.
-        /// 
+        ///
         /// This utility loops over the rows of the input memory block, and copy them to the output
         /// memory block, then increment the read and write pointers by the source and destination
         /// strides, respectively. For each row, exactly <paramref name="elem_size"/> bytes are copied,
         /// even if the row stride is higher. The extra bytes in the destination buffer past the row
         /// size until the row stride are left untouched.
-        /// 
+        ///
         /// This is equivalent to the following pseudo-code:
         /// <code>
         /// for (int row = 0; row &lt; elem_count; ++row) {
@@ -153,5 +153,12 @@ namespace Microsoft.MixedReality.WebRTC.Interop
                 throw new ArgumentOutOfRangeException("Invalid ID passed to AddDataChannelAsync().");
             }
         }
+
+        /// <summary>
+        /// See <see cref="PeerConnection.SetFrameHeightRoundMode(PeerConnection.FrameHeightRoundMode)"/>.
+        /// </summary>
+        /// <param name="value"></param>
+        [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, EntryPoint = "mrsSetFrameHeightRoundMode")]
+        public static unsafe extern void SetFrameHeightRoundMode(PeerConnection.FrameHeightRoundMode value);
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -1310,31 +1310,32 @@ namespace Microsoft.MixedReality.WebRTC
             /// <summary>
             /// Leave frames unchanged.
             /// </summary>
-            NONE = 0,
+            None = 0,
 
             /// <summary>
             /// Crop frame height to the nearest multiple of 16.
             /// ((height - nearestLowerMultipleOf16) / 2) rows are cropped from the top and
             /// (height - nearestLowerMultipleOf16 - croppedRowsTop) rows are cropped from the bottom.
             /// </summary>
-            CROP = 1,
+            Crop = 1,
 
             /// <summary>
             /// Pad frame height to the nearest multiple of 16.
             /// ((nearestHigherMultipleOf16 - height) / 2) rows are added symmetrically at the top and
             /// (nearestHigherMultipleOf16 - height - addedRowsTop) rows are added symmetrically at the bottom.
             /// </summary>
-            PAD = 2
+            Pad = 2
         }
 
         /// <summary>
+        /// [HoloLens 1 only]
         /// Use this function to select whether resolutions where height is not multiple of 16
         /// should be cropped, padded or left unchanged.
-        /// Default is <see cref="FrameHeightRoundMode.NONE"/>, except on Hololens 1 where it is
-        /// <see cref="FrameHeightRoundMode.CROP"/> to avoid severe artifacts produced by
-        /// the H.264 hardware encoder.
+        /// Default is <see cref="FrameHeightRoundMode.Crop"/> to avoid severe artifacts produced by
+        /// the H.264 hardware encoder on HoloLens 1.
+        /// This has no effect on other platforms.
         /// </summary>
-        /// <param name="value"></param>
+        /// <param name="value">The rounding mode for video frames.</param>
         public static void SetFrameHeightRoundMode(FrameHeightRoundMode value)
         {
             Utils.SetFrameHeightRoundMode(value);

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -1301,6 +1301,45 @@ namespace Microsoft.MixedReality.WebRTC
             });
         }
 
+        /// <summary>
+        /// Frame height round mode.
+        /// </summary>
+        /// <seealso cref="SetFrameHeightRoundMode(FrameHeightRoundMode)"/>
+        public enum FrameHeightRoundMode
+        {
+            /// <summary>
+            /// Leave frames unchanged.
+            /// </summary>
+            NONE = 0,
+
+            /// <summary>
+            /// Crop frame height to the nearest multiple of 16.
+            /// ((height - nearestLowerMultipleOf16) / 2) rows are cropped from the top and
+            /// (height - nearestLowerMultipleOf16 - croppedRowsTop) rows are cropped from the bottom.
+            /// </summary>
+            CROP = 1,
+
+            /// <summary>
+            /// Pad frame height to the nearest multiple of 16.
+            /// ((nearestHigherMultipleOf16 - height) / 2) rows are added symmetrically at the top and
+            /// (nearestHigherMultipleOf16 - height - addedRowsTop) rows are added symmetrically at the bottom.
+            /// </summary>
+            PAD = 2
+        }
+
+        /// <summary>
+        /// Use this function to select whether resolutions where height is not multiple of 16
+        /// should be cropped, padded or left unchanged.
+        /// Default is <see cref="FrameHeightRoundMode.NONE"/>, except on Hololens 1 where it is
+        /// <see cref="FrameHeightRoundMode.CROP"/> to avoid severe artifacts produced by
+        /// the H.264 hardware encoder.
+        /// </summary>
+        /// <param name="value"></param>
+        public static void SetFrameHeightRoundMode(FrameHeightRoundMode value)
+        {
+            Utils.SetFrameHeightRoundMode(value);
+        }
+
         internal void OnConnected()
         {
             IsConnected = true;


### PR DESCRIPTION
This backport changes the original code due to some link error on Desktop.
Making a PR for it, then that change will be forward-ported to `master` to fix the same issue there.