### PR TITLE
Improve the codec filtering mechanism

### DIFF
--- a/examples/TestAppUwp/MainPage.xaml
+++ b/examples/TestAppUwp/MainPage.xaml
@@ -128,26 +128,34 @@
                         <RadioButton x:Name="PreferredAudioCodec_Default" GroupName="PreferredAudioCodecGroup" Checked="PreferredAudioCodecChecked" Content="(default)" IsChecked="True" />
                         <RadioButton x:Name="PreferredAudioCodec_OPUS" GroupName="PreferredAudioCodecGroup" Checked="PreferredAudioCodecChecked" Content="OPUS" />
                         <RadioButton x:Name="PreferredAudioCodec_Custom" GroupName="PreferredAudioCodecGroup" Checked="PreferredAudioCodecChecked" Content="Custom value" />
-                        <TextBlock VerticalAlignment="Center" Margin="64,0,0,0">Additional params:</TextBlock>
-                        <TextBox x:Name="PreferredAudioCodecExtraParamsTextBox" Margin="16,0,0,0" Width="200"></TextBox>
                     </StackPanel>
                     <TextBlock x:Name="CustomPreferredAudioCodecHelpText" FontStyle="Italic" Margin="48,6,0,0">
                             Leave blank to use the default video codec. A partial list is <Hyperlink NavigateUri="https://en.wikipedia.org/wiki/RTP_payload_formats">available from Wikipedia</Hyperlink>.<LineBreak />Common values include "opus" or "ISAC". Names are case sensitive.
                     </TextBlock>
                     <TextBox x:Name="CustomPreferredAudioCodec" Text="" PlaceholderText="(use default)" Margin="48,6,0,6" Width="400" HorizontalAlignment="Left" />
                     <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Local params:</TextBlock>
+                        <TextBox x:Name="PreferredAudioCodecExtraParamsLocalTextBox" Margin="16,0,0,0" Width="250"></TextBox>
+                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Remote params:</TextBlock>
+                        <TextBox x:Name="PreferredAudioCodecExtraParamsRemoteTextBox" Margin="16,0,0,0" Width="250"></TextBox>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
                         <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Video :</TextBlock>
                         <RadioButton x:Name="PreferredVideoCodec_Default" GroupName="PreferredVideoCodecGroup" Checked="PreferredVideoCodecChecked" Content="(default)" />
                         <RadioButton x:Name="PreferredVideoCodec_H264" GroupName="PreferredVideoCodecGroup" Checked="PreferredVideoCodecChecked" Content="H.264" IsChecked="True" />
                         <RadioButton x:Name="PreferredVideoCodec_VP8" GroupName="PreferredVideoCodecGroup" Checked="PreferredVideoCodecChecked" Content="VP8" />
                         <RadioButton x:Name="PreferredVideoCodec_Custom" GroupName="PreferredVideoCodecGroup" Checked="PreferredVideoCodecChecked" Content="Custom value" />
-                        <TextBlock VerticalAlignment="Center" Margin="64,0,0,0">Additional params: </TextBlock>
-                        <TextBox x:Name="PreferredVideoCodecExtraParamsTextBox" Margin="16,0,0,0" Width="200"></TextBox>
                     </StackPanel>
                     <TextBlock x:Name="CustomPreferredVideoCodecHelpText" FontStyle="Italic" Margin="48,6,0,0">
                             Leave blank to use the default video codec. A partial list is <Hyperlink NavigateUri="https://en.wikipedia.org/wiki/RTP_payload_formats">available from Wikipedia</Hyperlink>.<LineBreak />Common values include "H264" or "VP8". Names are case sensitive.
                     </TextBlock>
                     <TextBox x:Name="CustomPreferredVideoCodec" PlaceholderText="(use default)" Margin="48,6,0,6" Width="400" HorizontalAlignment="Left" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Local params:</TextBlock>
+                        <TextBox x:Name="PreferredVideoCodecExtraParamsLocalTextBox" Margin="16,0,0,0" Width="250"></TextBox>
+                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Remote params:</TextBlock>
+                        <TextBox x:Name="PreferredVideoCodecExtraParamsRemoteTextBox" Margin="16,0,0,0" Width="250"></TextBox>
+                    </StackPanel>
                     <TextBlock Text="SDP connection offer" FontWeight="Bold" Margin="0,12,0,0" FontFamily="Segoe UI" />
                     <Button Name="createOfferButton" IsEnabled="False" Content="Create offer" HorizontalAlignment="Left" VerticalAlignment="Top" RenderTransformOrigin="0.511,0.634" Click="CreateOfferButtonClicked" Width="125" Margin="0,12,0,0"/>
                     <Button Name="addExtraDataChannelButton" Content="Add extra data channel" HorizontalAlignment="Left" VerticalAlignment="Top" RenderTransformOrigin="0.511,0.634" Click="AddExtraDataChannelButtonClicked" Width="250" Margin="0,12,0,0"/>

--- a/examples/TestAppUwp/MainPage.xaml.cs
+++ b/examples/TestAppUwp/MainPage.xaml.cs
@@ -312,10 +312,12 @@ namespace TestAppUwp
             localSettings.Values["LocalPeerID"] = localPeerUidTextBox.Text;
             localSettings.Values["RemotePeerID"] = remotePeerUidTextBox.Text;
             localSettings.Values["PreferredAudioCodec"] = PreferredAudioCodec;
-            localSettings.Values["PreferredAudioCodecExtraParams"] = PreferredAudioCodecExtraParamsTextBox.Text;
+            localSettings.Values["PreferredAudioCodecExtraParamsLocal"] = PreferredAudioCodecExtraParamsLocalTextBox.Text;
+            localSettings.Values["PreferredAudioCodecExtraParamsRemote"] = PreferredAudioCodecExtraParamsRemoteTextBox.Text;
             localSettings.Values["PreferredAudioCodec_Custom"] = PreferredAudioCodec_Custom.IsChecked.GetValueOrDefault() ? CustomPreferredAudioCodec.Text : "";
             localSettings.Values["PreferredVideoCodec"] = PreferredVideoCodec;
-            localSettings.Values["PreferredVideoCodecExtraParams"] = PreferredVideoCodecExtraParamsTextBox.Text;
+            localSettings.Values["PreferredVideoCodecExtraParamsLocal"] = PreferredVideoCodecExtraParamsLocalTextBox.Text;
+            localSettings.Values["PreferredVideoCodecExtraParamsRemote"] = PreferredVideoCodecExtraParamsRemoteTextBox.Text;
             localSettings.Values["PreferredVideoCodec_Custom"] = PreferredVideoCodec_Custom.IsChecked.GetValueOrDefault() ? CustomPreferredVideoCodec.Text : "";
         }
 
@@ -409,14 +411,21 @@ namespace TestAppUwp
                     }
                 }
             }
-
-            if (localSettings.Values.TryGetValue("PreferredAudioCodecExtraParams", out object preferredAudioExtraObj))
+            if (localSettings.Values.TryGetValue("PreferredAudioCodecExtraParamsLocal", out object preferredAudioParamsLocalObj))
             {
-                if (preferredAudioExtraObj is string str)
+                if (preferredAudioParamsLocalObj is string str)
                 {
-                    PreferredAudioCodecExtraParamsTextBox.Text = str;
+                    PreferredAudioCodecExtraParamsLocalTextBox.Text = str;
                 }
             }
+            if (localSettings.Values.TryGetValue("PreferredAudioCodecExtraParamsRemote", out object preferredAudioParamsRemoteObj))
+            {
+                if (preferredAudioParamsRemoteObj is string str)
+                {
+                    PreferredAudioCodecExtraParamsRemoteTextBox.Text = str;
+                }
+            }
+
             if (localSettings.Values.TryGetValue("PreferredVideoCodec", out object preferredVideoObj))
             {
                 if (preferredVideoObj is string str)
@@ -447,12 +456,18 @@ namespace TestAppUwp
                     }
                 }
             }
-
-            if (localSettings.Values.TryGetValue("PreferredVideoCodecExtraParams", out object preferredVideoExtraObj))
+            if (localSettings.Values.TryGetValue("PreferredVideoCodecExtraParamsLocal", out object preferredVideoParamsLocalObj))
             {
-                if (preferredVideoExtraObj is string str)
+                if (preferredVideoParamsLocalObj is string str)
                 {
-                    PreferredVideoCodecExtraParamsTextBox.Text = str;
+                    PreferredVideoCodecExtraParamsLocalTextBox.Text = str;
+                }
+            }
+            if (localSettings.Values.TryGetValue("PreferredVideoCodecExtraParamsRemote", out object preferredVideoParamsRemoteObj))
+            {
+                if (preferredVideoParamsRemoteObj is string str)
+                {
+                    PreferredVideoCodecExtraParamsRemoteTextBox.Text = str;
                 }
             }
         }
@@ -843,29 +858,36 @@ namespace TestAppUwp
 
         private void DssSignaler_OnMessage(NodeDssSignaler.Message message)
         {
-            switch (message.MessageType)
+            Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
-            case NodeDssSignaler.Message.WireMessageType.Offer:
-                _peerConnection.SetRemoteDescription("offer", message.Data);
-                // If we get an offer, we immediately send an answer back
-                _peerConnection.CreateAnswer();
-                break;
+                // Ensure that the filtering values are up to date before passing the message on.
+                UpdateCodecFilters();
+            }).AsTask().ContinueWith(_ =>
+            {
+                switch (message.MessageType)
+                {
+                    case NodeDssSignaler.Message.WireMessageType.Offer:
+                        _peerConnection.SetRemoteDescription("offer", message.Data);
+                        // If we get an offer, we immediately send an answer back
+                        _peerConnection.CreateAnswer();
+                        break;
 
-            case NodeDssSignaler.Message.WireMessageType.Answer:
-                _peerConnection.SetRemoteDescription("answer", message.Data);
-                break;
+                    case NodeDssSignaler.Message.WireMessageType.Answer:
+                        _peerConnection.SetRemoteDescription("answer", message.Data);
+                        break;
 
-            case NodeDssSignaler.Message.WireMessageType.Ice:
-                // TODO - This is NodeDSS-specific
-                // this "parts" protocol is defined above, in OnIceCandiateReadyToSend listener
-                var parts = message.Data.Split(new string[] { message.IceDataSeparator }, StringSplitOptions.RemoveEmptyEntries);
-                // Note the inverted arguments; candidate is last here, but first in OnIceCandiateReadyToSend
-                _peerConnection.AddIceCandidate(parts[2], int.Parse(parts[1]), parts[0]);
-                break;
+                    case NodeDssSignaler.Message.WireMessageType.Ice:
+                        // TODO - This is NodeDSS-specific
+                        // this "parts" protocol is defined above, in OnIceCandiateReadyToSend listener
+                        var parts = message.Data.Split(new string[] { message.IceDataSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                        // Note the inverted arguments; candidate is last here, but first in OnIceCandiateReadyToSend
+                        _peerConnection.AddIceCandidate(parts[2], int.Parse(parts[1]), parts[0]);
+                        break;
 
-            default:
-                throw new InvalidOperationException($"Unhandled signaler message type '{message.MessageType}'");
-            }
+                    default:
+                        throw new InvalidOperationException($"Unhandled signaler message type '{message.MessageType}'");
+                }
+            }, TaskScheduler.Default);
         }
 
         private void DssSignaler_OnFailure(Exception e)
@@ -1421,12 +1443,15 @@ namespace TestAppUwp
                 // and is in kStable state, and it will get discarded so remote video will not start).
                 _renegotiationOfferEnabled = false;
 
+                // Ensure that the filtering values are up to date before creating new tracks.
+                UpdateCodecFilters();
+
+                // The default start bitrate is quite low (300 kbps); use a higher value to get
+                // better quality on local network.
+                _peerConnection.SetBitrate(maxBitrateBps: 100000);
+
                 try
                 {
-                    // The default start bitrate is quite low (300 kbps); use a higher value to get
-                    // better quality on local network.
-                    _peerConnection.SetBitrate(startBitrateBps: (uint)(width * height * framerate / 20));
-
                     // Add the local audio track captured from the local microphone
                     await _peerConnection.AddLocalAudioTrackAsync();
 
@@ -1495,6 +1520,16 @@ namespace TestAppUwp
             //remoteLateText.Text = $"Late: {remoteVideoBridge.LateFrame:F2}";
         }
 
+        void UpdateCodecFilters()
+        {
+            _peerConnection.PreferredAudioCodec = PreferredAudioCodec;
+            _peerConnection.PreferredAudioCodecExtraParams = PreferredAudioCodecExtraParamsRemoteTextBox.Text;
+            _peerConnection.PreferredAudioCodecExtraParamsLocal = PreferredAudioCodecExtraParamsLocalTextBox.Text;
+            _peerConnection.PreferredVideoCodec = PreferredVideoCodec;
+            _peerConnection.PreferredVideoCodecExtraParams = PreferredVideoCodecExtraParamsRemoteTextBox.Text;
+            _peerConnection.PreferredVideoCodecExtraParamsLocal = PreferredVideoCodecExtraParamsLocalTextBox.Text;
+        }
+
         private void CreateOfferButtonClicked(object sender, RoutedEventArgs e)
         {
             if (!PluginInitialized)
@@ -1505,10 +1540,8 @@ namespace TestAppUwp
             createOfferButton.IsEnabled = false;
             createOfferButton.Content = "Joining...";
 
-            _peerConnection.PreferredAudioCodec = PreferredAudioCodec;
-            _peerConnection.PreferredAudioCodecExtraParams = PreferredAudioCodecExtraParamsTextBox.Text;
-            _peerConnection.PreferredVideoCodec = PreferredVideoCodec;
-            _peerConnection.PreferredVideoCodecExtraParams = PreferredVideoCodecExtraParamsTextBox.Text;
+            // Ensure that the filtering values are up to date before starting to create messages.
+            UpdateCodecFilters();
             _peerConnection.CreateOffer();
         }
 

--- a/examples/TestAppUwp/MainPage.xaml.cs
+++ b/examples/TestAppUwp/MainPage.xaml.cs
@@ -1523,10 +1523,10 @@ namespace TestAppUwp
         void UpdateCodecFilters()
         {
             _peerConnection.PreferredAudioCodec = PreferredAudioCodec;
-            _peerConnection.PreferredAudioCodecExtraParams = PreferredAudioCodecExtraParamsRemoteTextBox.Text;
+            _peerConnection.PreferredAudioCodecExtraParamsRemote = PreferredAudioCodecExtraParamsRemoteTextBox.Text;
             _peerConnection.PreferredAudioCodecExtraParamsLocal = PreferredAudioCodecExtraParamsLocalTextBox.Text;
             _peerConnection.PreferredVideoCodec = PreferredVideoCodec;
-            _peerConnection.PreferredVideoCodecExtraParams = PreferredVideoCodecExtraParamsRemoteTextBox.Text;
+            _peerConnection.PreferredVideoCodecExtraParamsRemote = PreferredVideoCodecExtraParamsRemoteTextBox.Text;
             _peerConnection.PreferredVideoCodecExtraParamsLocal = PreferredVideoCodecExtraParamsLocalTextBox.Text;
         }
 

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -506,29 +506,30 @@ namespace Microsoft.MixedReality.WebRTC
         public string PreferredAudioCodec = string.Empty;
 
         /// <summary>
-        /// Advanced use only. A semicolon-separated list of "key=value" pairs of arguments
-        /// passed as extra parameters to the remote preferred audio codec during SDP filtering.
+        /// Advanced use only. List of additional codec-specific arguments requested to the
+        /// remote endpoint.
         /// </summary>
         /// <remarks>
-        /// This enables configuring codec-specific parameters. Arguments are passed as is,
+        /// This must be a semicolon-separated list of "key=value" pairs. Arguments are passed as is,
         /// and there is no check on the validity of the parameter names nor their value.
+        /// Arguments are added to the audio codec section of SDP messages sent to the remote endpoint.
+        ///
         /// This is ignored if <see cref="PreferredAudioCodec"/> is an empty string, or is not
         /// a valid codec name found in the SDP message offer.
         /// </remarks>
-        public string PreferredAudioCodecExtraParams = string.Empty;
+        public string PreferredAudioCodecExtraParamsRemote = string.Empty;
 
         /// <summary>
-        /// Advanced use only. A semicolon-separated list of "key=value" pairs of arguments
-        /// passed as extra parameters to the local preferred audio codec during SDP filtering.
+        /// Advanced use only. List of additional codec-specific arguments set on the local endpoint.
         /// </summary>
         /// <remarks>
-        /// This enables configuring codec-specific parameters. Arguments are passed as is,
+        /// This must be a semicolon-separated list of "key=value" pairs. Arguments are passed as is,
         /// and there is no check on the validity of the parameter names nor their value.
+        /// Arguments are set locally by adding them to the audio codec section of SDP messages
+        /// received from the remote endpoint.
+        ///
         /// This is ignored if <see cref="PreferredAudioCodec"/> is an empty string, or is not
         /// a valid codec name found in the SDP message offer.
-        ///
-        /// Note that the parameters are passed to the local codec by adding them to remote
-        /// SDP descriptions when they are received.
         /// </remarks>
         public string PreferredAudioCodecExtraParamsLocal = string.Empty;
 
@@ -539,29 +540,30 @@ namespace Microsoft.MixedReality.WebRTC
         public string PreferredVideoCodec = string.Empty;
 
         /// <summary>
-        /// Advanced use only. A semicolon-separated list of "key=value" pairs of arguments
-        /// passed as extra parameters to the remote preferred video codec during SDP filtering.
+        /// Advanced use only. List of additional codec-specific arguments requested to the
+        /// remote endpoint.
         /// </summary>
         /// <remarks>
-        /// This enables configuring codec-specific parameters. Arguments are passed as is,
+        /// This must be a semicolon-separated list of "key=value" pairs. Arguments are passed as is,
         /// and there is no check on the validity of the parameter names nor their value.
+        /// Arguments are added to the video codec section of SDP messages sent to the remote endpoint.
+        ///
         /// This is ignored if <see cref="PreferredVideoCodec"/> is an empty string, or is not
         /// a valid codec name found in the SDP message offer.
         /// </remarks>
-        public string PreferredVideoCodecExtraParams = string.Empty;
+        public string PreferredVideoCodecExtraParamsRemote = string.Empty;
 
         /// <summary>
-        /// Advanced use only. A semicolon-separated list of "key=value" pairs of arguments
-        /// passed as extra parameters to the local preferred video codec during SDP filtering.
+        /// Advanced use only. List of additional codec-specific arguments set on the local endpoint.
         /// </summary>
         /// <remarks>
-        /// This enables configuring codec-specific parameters. Arguments are passed as is,
+        /// This must be a semicolon-separated list of "key=value" pairs. Arguments are passed as is,
         /// and there is no check on the validity of the parameter names nor their value.
+        /// Arguments are set locally by adding them to the video codec section of SDP messages
+        /// received from the remote endpoint.
+        ///
         /// This is ignored if <see cref="PreferredVideoCodec"/> is an empty string, or is not
         /// a valid codec name found in the SDP message offer.
-        ///
-        /// Note that the parameters are passed to the local codec by adding them to remote
-        /// SDP descriptions when they are received.
         /// </remarks>
         public string PreferredVideoCodecExtraParamsLocal = string.Empty;
 
@@ -1680,9 +1682,9 @@ namespace Microsoft.MixedReality.WebRTC
             // the offer first will leave the connection in an inconsistent state.
             string newSdp = ForceSdpCodecs(sdp: sdp,
                 audio: PreferredAudioCodec,
-                audioParams: PreferredAudioCodecExtraParams,
+                audioParams: PreferredAudioCodecExtraParamsRemote,
                 video: PreferredVideoCodec,
-                videoParams: PreferredVideoCodecExtraParams);
+                videoParams: PreferredVideoCodecExtraParamsRemote);
 
             LocalSdpReadytoSend?.Invoke(type, newSdp);
         }


### PR DESCRIPTION
- Add support for setting extra parameters on local codecs. Since there seems to
 be no easier way, we filter remote SDP messages before delivery.
- Allow endpoints which receive offers to filter codecs/request codec parameters
 to the counterpart (before this change, only endpoints creating an offer did
 SDP filtering).

Note that we now filter outgoing SDP answers as well as offers. Before this
change, we didn't filter answers, because removing codecs from an answer without
removing them from the corresponding offer left the connection in an
inconsistent state (e.g. A sends an offer to B with VP8 and H264; B internally
chooses VP8, replies with both codecs, but the answer is filtered to remove VP8;
A gets the filtered answer and chooses H264). Now we use the same filter on
incoming offers and outgoing answers so there is no possibility of inconsistency.