### PR TITLE
Async SetRemoteDescription to avoid race condition

### DIFF
--- a/examples/TestAppUwp/MainPage.xaml.cs
+++ b/examples/TestAppUwp/MainPage.xaml.cs
@@ -862,18 +862,18 @@ namespace TestAppUwp
             {
                 // Ensure that the filtering values are up to date before passing the message on.
                 UpdateCodecFilters();
-            }).AsTask().ContinueWith(_ =>
+            }).AsTask().ContinueWith(async _ =>
             {
                 switch (message.MessageType)
                 {
                     case NodeDssSignaler.Message.WireMessageType.Offer:
-                        _peerConnection.SetRemoteDescription("offer", message.Data);
-                        // If we get an offer, we immediately send an answer back
+                        await _peerConnection.SetRemoteDescriptionAsync("offer", message.Data);
+                        // If we get an offer, we immediately send an answer back once the offer is applied
                         _peerConnection.CreateAnswer();
                         break;
 
                     case NodeDssSignaler.Message.WireMessageType.Answer:
-                        _peerConnection.SetRemoteDescription("answer", message.Data);
+                        _ = _peerConnection.SetRemoteDescriptionAsync("answer", message.Data);
                         break;
 
                     case NodeDssSignaler.Message.WireMessageType.Ice:

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
@@ -4,9 +4,9 @@
 #pragma once
 
 #include "audio_frame.h"
-#include "video_frame.h"
 #include "export.h"
 #include "result.h"
+#include "video_frame.h"
 
 extern "C" {
 
@@ -486,8 +486,8 @@ using mrsRequestExternalArgb32VideoFrameCallback =
 /// including generated or synthetic frames, for example for testing.
 /// The track source initially starts as capuring. Capture can be stopped with
 /// |mrsExternalVideoTrackSourceShutdown|.
-/// This returns a handle to a newly allocated object, which must be released once
-/// not used anymore with |mrsLocalVideoTrackRemoveRef()|.
+/// This returns a handle to a newly allocated object, which must be released
+/// once not used anymore with |mrsLocalVideoTrackRemoveRef()|.
 MRS_API mrsResult MRS_CALL
 mrsPeerConnectionAddLocalVideoTrackFromExternalSource(
     PeerConnectionHandle peerHandle,
@@ -619,12 +619,19 @@ mrsPeerConnectionSetBitrate(PeerConnectionHandle peer_handle,
                             int start_bitrate_bps,
                             int max_bitrate_bps) noexcept;
 
+/// Parameter-less callback.
+using ActionCallback = void(MRS_CALL*)(void* user_data);
+
 /// Set a remote description received from a remote peer via the signaling
-/// service.
+/// service. Once the remote description is applied, the action callback is
+/// invoked to signal the caller it is safe to continue the negotiation, and in
+/// particular it is safe to call |CreateAnswer()|.
 MRS_API mrsResult MRS_CALL
-mrsPeerConnectionSetRemoteDescription(PeerConnectionHandle peerHandle,
-                                      const char* type,
-                                      const char* sdp) noexcept;
+mrsPeerConnectionSetRemoteDescriptionAsync(PeerConnectionHandle peerHandle,
+                                           const char* type,
+                                           const char* sdp,
+                                           ActionCallback callback,
+                                           void* user_data) noexcept;
 
 /// Close a peer connection, removing all tracks and disconnecting from the
 /// remote peer currently connected. This does not invalidate the handle nor

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
@@ -208,8 +208,9 @@ class PeerConnectionImpl : public PeerConnection,
   bool AddIceCandidate(const char* sdp_mid,
                        const int sdp_mline_index,
                        const char* candidate) noexcept override;
-  bool SetRemoteDescription(const char* type,
-                            const char* sdp) noexcept override;
+  bool SetRemoteDescriptionAsync(const char* type,
+                                 const char* sdp,
+                                 Callback<> callback) noexcept override;
 
   void RegisterConnectedCallback(
       ConnectedCallback&& callback) noexcept override {
@@ -543,7 +544,19 @@ class SessionDescObserver : public webrtc::SetSessionDescriptionObserver {
 struct SetRemoteSessionDescObserver
     : public webrtc::SetRemoteDescriptionObserverInterface {
  public:
-  void OnSetRemoteDescriptionComplete(webrtc::RTCError error) override {}
+  SetRemoteSessionDescObserver() = default;
+  template <typename Closure>
+  SetRemoteSessionDescObserver(Closure&& callback)
+      : callback_(std::forward<Closure>(callback)) {}
+  void OnSetRemoteDescriptionComplete(webrtc::RTCError error) override {
+    RTC_LOG(LS_INFO) << "Remote description set. err=" << error.message();
+    if (error.ok() && callback_) {
+      callback_();
+    }
+  }
+
+ protected:
+  std::function<void()> callback_;
 };
 
 const std::string kAudioVideoStreamId("local_av_stream");
@@ -983,8 +996,10 @@ bool PeerConnectionImpl::IsClosed() const noexcept {
   return (peer_ == nullptr);
 }
 
-bool PeerConnectionImpl::SetRemoteDescription(const char* type,
-                                              const char* sdp) noexcept {
+bool PeerConnectionImpl::SetRemoteDescriptionAsync(
+    const char* type,
+    const char* sdp,
+    Callback<> callback) noexcept {
   if (!peer_) {
     return false;
   }
@@ -1005,7 +1020,10 @@ bool PeerConnectionImpl::SetRemoteDescription(const char* type,
   if (!session_description)
     return false;
   rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface> observer =
-      new rtc::RefCountedObject<SetRemoteSessionDescObserver>();
+      new rtc::RefCountedObject<SetRemoteSessionDescObserver>([this, callback] {
+        // Fire completed callback to signal remote description was applied.
+        callback();
+      });
   peer_->SetRemoteDescription(std::move(session_description),
                               std::move(observer));
   return true;
@@ -1351,6 +1369,5 @@ ErrorOr<RefPtr<PeerConnection>> PeerConnection::create(
 void PeerConnection::GetStats(webrtc::RTCStatsCollectorCallback* callback) {
   ((PeerConnectionImpl*)this)->peer_->GetStats(callback);
 }
-
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -122,12 +122,17 @@ class PeerConnection : public TrackedObject {
 
   /// Notify the WebRTC engine that an ICE candidate has been received.
   virtual bool AddIceCandidate(const char* sdp_mid,
-                                       const int sdp_mline_index,
-                                       const char* candidate) noexcept = 0;
+                               const int sdp_mline_index,
+                               const char* candidate) noexcept = 0;
 
-  /// Notify the WebRTC engine that an SDP offer message has been received.
-  virtual bool SetRemoteDescription(const char* type,
-                                            const char* sdp) noexcept = 0;
+  /// Notify the WebRTC engine that an SDP message has been received from the
+  /// remote peer. The parameters correspond to the SDP message data provided by
+  /// the |LocalSdpReadytoSendCallback|, after being transmitted to the
+  /// other peer.
+  virtual bool MRS_API
+  SetRemoteDescriptionAsync(const char* type,
+                            const char* sdp,
+                            Callback<> callback) noexcept = 0;
 
   //
   // Connection

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/data_channel_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/data_channel_tests.cpp
@@ -22,7 +22,7 @@ FakeIterop_DataChannelCreate(mrsPeerConnectionInteropHandle /*parent*/,
 using DataAddedCallback =
     InteropCallback<mrsDataChannelInteropHandle, DataChannelHandle>;
 
-void SetEventOnCompleted(void* user_data) {
+void MRS_CALL SetEventOnCompleted(void* user_data) {
   Event* ev = (Event*)user_data;
   ev->Set();
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/data_channel_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/data_channel_tests.cpp
@@ -22,6 +22,11 @@ FakeIterop_DataChannelCreate(mrsPeerConnectionInteropHandle /*parent*/,
 using DataAddedCallback =
     InteropCallback<mrsDataChannelInteropHandle, DataChannelHandle>;
 
+void SetEventOnCompleted(void* user_data) {
+  Event* ev = (Event*)user_data;
+  ev->Set();
+}
+
 }  // namespace
 
 TEST(DataChannel, AddChannelBeforeInit) {
@@ -57,20 +62,24 @@ TEST(DataChannel, InBand) {
   // Setup signaling
   SdpCallback sdp1_cb(pc1.handle(), [&pc2](const char* type,
                                            const char* sdp_data) {
-    ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescription(
-                                           pc2.handle(), type, sdp_data));
+    Event ev;
+    ASSERT_EQ(Result::kSuccess,
+              mrsPeerConnectionSetRemoteDescriptionAsync(
+                  pc2.handle(), type, sdp_data, &SetEventOnCompleted, &ev));
+    ev.Wait();
     if (kOfferString == type) {
-      ASSERT_EQ(Result::kSuccess,
-                mrsPeerConnectionCreateAnswer(pc2.handle()));
+      ASSERT_EQ(Result::kSuccess, mrsPeerConnectionCreateAnswer(pc2.handle()));
     }
   });
   SdpCallback sdp2_cb(pc2.handle(), [&pc1](const char* type,
                                            const char* sdp_data) {
-    ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescription(
-                                           pc1.handle(), type, sdp_data));
+    Event ev;
+    ASSERT_EQ(Result::kSuccess,
+              mrsPeerConnectionSetRemoteDescriptionAsync(
+                  pc1.handle(), type, sdp_data, &SetEventOnCompleted, &ev));
+    ev.Wait();
     if (kOfferString == type) {
-      ASSERT_EQ(Result::kSuccess,
-                mrsPeerConnectionCreateAnswer(pc1.handle()));
+      ASSERT_EQ(Result::kSuccess, mrsPeerConnectionCreateAnswer(pc1.handle()));
     }
   });
   IceCallback ice1_cb(
@@ -115,8 +124,7 @@ TEST(DataChannel, InBand) {
   connectec1_cb.is_registered_ = true;
   mrsPeerConnectionRegisterConnectedCallback(pc2.handle(), CB(connectec2_cb));
   connectec2_cb.is_registered_ = true;
-  ASSERT_EQ(Result::kSuccess,
-            mrsPeerConnectionCreateOffer(pc1.handle()));
+  ASSERT_EQ(Result::kSuccess, mrsPeerConnectionCreateOffer(pc1.handle()));
   ASSERT_EQ(true, ev1.WaitFor(55s));  // should complete within 5s (usually ~1s)
   ASSERT_EQ(true, ev2.WaitFor(55s));
 
@@ -131,7 +139,7 @@ TEST(DataChannel, InBand) {
         ASSERT_NE(nullptr, data_channel);
 
         // TODO expose label
-        //ASSERT_EQ(channel_label, data2->label());
+        // ASSERT_EQ(channel_label, data2->label());
 
         data2_ev.Set();
       };
@@ -148,14 +156,13 @@ TEST(DataChannel, InBand) {
     mrsDataChannelCallbacks callbacks{};
     DataChannelHandle data1_handle;
     mrsDataChannelInteropHandle interopHandle = kFakeInteropDataChannelHandle;
-    ASSERT_EQ(
-        Result::kSuccess,
-        mrsPeerConnectionAddDataChannel(pc1.handle(), interopHandle,
-                                        data_config, callbacks, &data1_handle));
+    ASSERT_EQ(Result::kSuccess, mrsPeerConnectionAddDataChannel(
+                                    pc1.handle(), interopHandle, data_config,
+                                    callbacks, &data1_handle));
     ASSERT_NE(nullptr, data1_handle);
 
     // TODO expose label
-    //ASSERT_EQ(channel_label, data1->label());
+    // ASSERT_EQ(channel_label, data1->label());
 
     ASSERT_EQ(true, data2_ev.WaitFor(30s));
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_test_helpers.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_test_helpers.h
@@ -273,7 +273,7 @@ class LocalPeerPairRaii {
     }
   }
 
-  static void SetEventOnCompleted(void* user_data) {
+  static void MRS_CALL SetEventOnCompleted(void* user_data) {
     Event* ev = (Event*)user_data;
     ev->Set();
   }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_test_helpers.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_test_helpers.h
@@ -227,16 +227,22 @@ class LocalPeerPairRaii {
   InteropCallback<> connected2_cb_;
   void setup() {
     sdp1_cb_ = [this](const char* type, const char* sdp_data) {
-      ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescription(
-                                      pc2_.handle(), type, sdp_data));
+      Event ev;
+      ASSERT_EQ(Result::kSuccess,
+                mrsPeerConnectionSetRemoteDescriptionAsync(
+                    pc2_.handle(), type, sdp_data, &SetEventOnCompleted, &ev));
+      ev.Wait();
       if (kOfferString == type) {
         ASSERT_EQ(Result::kSuccess,
                   mrsPeerConnectionCreateAnswer(pc2_.handle()));
       }
     };
     sdp2_cb_ = [this](const char* type, const char* sdp_data) {
-      ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescription(
-                                      pc1_.handle(), type, sdp_data));
+      Event ev;
+      ASSERT_EQ(Result::kSuccess,
+                mrsPeerConnectionSetRemoteDescriptionAsync(
+                    pc1_.handle(), type, sdp_data, &SetEventOnCompleted, &ev));
+      ev.Wait();
       if (kOfferString == type) {
         ASSERT_EQ(Result::kSuccess,
                   mrsPeerConnectionCreateAnswer(pc1_.handle()));
@@ -265,5 +271,10 @@ class LocalPeerPairRaii {
       mrsPeerConnectionRegisterConnectedCallback(pc2(), nullptr, nullptr);
       connected2_cb_.is_registered_ = false;
     }
+  }
+
+  static void SetEventOnCompleted(void* user_data) {
+    Event* ev = (Event*)user_data;
+    ev->Set();
   }
 };

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_tests.cpp
@@ -7,7 +7,7 @@
 
 namespace {
 
-void SetEventOnCompleted(void* user_data) {
+void MRS_CALL SetEventOnCompleted(void* user_data) {
   Event* ev = (Event*)user_data;
   ev->Set();
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_tests.cpp
@@ -5,6 +5,15 @@
 
 #include "interop_api.h"
 
+namespace {
+
+void SetEventOnCompleted(void* user_data) {
+  Event* ev = (Event*)user_data;
+  ev->Set();
+}
+
+}  // namespace
+
 TEST(PeerConnection, LocalNoIce) {
   for (int i = 0; i < 3; ++i) {
     // Create PC
@@ -15,24 +24,30 @@ TEST(PeerConnection, LocalNoIce) {
     ASSERT_NE(nullptr, pc2.handle());
 
     // Setup signaling
-    SdpCallback sdp1_cb(
-        pc1.handle(), [&pc2](const char* type, const char* sdp_data) {
-          ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescription(
-                                          pc2.handle(), type, sdp_data));
-          if (kOfferString == type) {
-            ASSERT_EQ(Result::kSuccess,
-                      mrsPeerConnectionCreateAnswer(pc2.handle()));
-          }
-        });
-    SdpCallback sdp2_cb(
-        pc2.handle(), [&pc1](const char* type, const char* sdp_data) {
-          ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescription(
-                                          pc1.handle(), type, sdp_data));
-          if (kOfferString == type) {
-            ASSERT_EQ(Result::kSuccess,
-                      mrsPeerConnectionCreateAnswer(pc1.handle()));
-          }
-        });
+    SdpCallback sdp1_cb(pc1.handle(), [&pc2](const char* type,
+                                             const char* sdp_data) {
+      Event ev;
+      ASSERT_EQ(Result::kSuccess,
+                mrsPeerConnectionSetRemoteDescriptionAsync(
+                    pc2.handle(), type, sdp_data, &SetEventOnCompleted, &ev));
+      ev.Wait();
+      if (kOfferString == type) {
+        ASSERT_EQ(Result::kSuccess,
+                  mrsPeerConnectionCreateAnswer(pc2.handle()));
+      }
+    });
+    SdpCallback sdp2_cb(pc2.handle(), [&pc1](const char* type,
+                                             const char* sdp_data) {
+      Event ev;
+      ASSERT_EQ(Result::kSuccess,
+                mrsPeerConnectionSetRemoteDescriptionAsync(
+                    pc1.handle(), type, sdp_data, &SetEventOnCompleted, &ev));
+      ev.Wait();
+      if (kOfferString == type) {
+        ASSERT_EQ(Result::kSuccess,
+                  mrsPeerConnectionCreateAnswer(pc1.handle()));
+      }
+    });
 
     // Connect
     Event ev;
@@ -53,24 +68,30 @@ TEST(PeerConnection, LocalIce) {
     ASSERT_NE(nullptr, pc2.handle());
 
     // Setup signaling
-    SdpCallback sdp1_cb(
-        pc1.handle(), [&pc2](const char* type, const char* sdp_data) {
-          ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescription(
-                                          pc2.handle(), type, sdp_data));
-          if (kOfferString == type) {
-            ASSERT_EQ(Result::kSuccess,
-                      mrsPeerConnectionCreateAnswer(pc2.handle()));
-          }
-        });
-    SdpCallback sdp2_cb(
-        pc2.handle(), [&pc1](const char* type, const char* sdp_data) {
-          ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescription(
-                                          pc1.handle(), type, sdp_data));
-          if (kOfferString == type) {
-            ASSERT_EQ(Result::kSuccess,
-                      mrsPeerConnectionCreateAnswer(pc1.handle()));
-          }
-        });
+    SdpCallback sdp1_cb(pc1.handle(), [&pc2](const char* type,
+                                             const char* sdp_data) {
+      Event ev;
+      ASSERT_EQ(Result::kSuccess,
+                mrsPeerConnectionSetRemoteDescriptionAsync(
+                    pc2.handle(), type, sdp_data, &SetEventOnCompleted, &ev));
+      ev.Wait();
+      if (kOfferString == type) {
+        ASSERT_EQ(Result::kSuccess,
+                  mrsPeerConnectionCreateAnswer(pc2.handle()));
+      }
+    });
+    SdpCallback sdp2_cb(pc2.handle(), [&pc1](const char* type,
+                                             const char* sdp_data) {
+      Event ev;
+      ASSERT_EQ(Result::kSuccess,
+                mrsPeerConnectionSetRemoteDescriptionAsync(
+                    pc1.handle(), type, sdp_data, &SetEventOnCompleted, &ev));
+      ev.Wait();
+      if (kOfferString == type) {
+        ASSERT_EQ(Result::kSuccess,
+                  mrsPeerConnectionCreateAnswer(pc1.handle()));
+      }
+    });
     IceCallback ice1_cb(
         pc1.handle(),
         [&pc2](const char* candidate, int sdpMlineindex, const char* sdpMid) {

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Editor/EditorTests.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Editor/EditorTests.cs
@@ -58,17 +58,17 @@ namespace Microsoft.MixedReality.WebRTC.Tests
                     await pc2.InitializeAsync();
 
                     // Prepare SDP event handlers
-                    pc1.LocalSdpReadytoSend += (string type, string sdp) =>
+                    pc1.LocalSdpReadytoSend += async (string type, string sdp) =>
                     {
-                        pc2.SetRemoteDescription(type, sdp);
+                        await pc2.SetRemoteDescriptionAsync(type, sdp);
                         if (type == "offer")
                         {
                             pc2.CreateAnswer();
                         }
                     };
-                    pc2.LocalSdpReadytoSend += (string type, string sdp) =>
+                    pc2.LocalSdpReadytoSend += async (string type, string sdp) =>
                     {
-                        pc1.SetRemoteDescription(type, sdp);
+                        await pc1.SetRemoteDescriptionAsync(type, sdp);
                         if (type == "offer")
                         {
                             pc1.CreateAnswer();

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/NodeDssSignaler.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/NodeDssSignaler.cs
@@ -223,12 +223,12 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                     switch (msg.MessageType)
                     {
                         case Message.WireMessageType.Offer:
-                            _nativePeer.SetRemoteDescription("offer", msg.Data);
+                            _nativePeer.SetRemoteDescriptionAsync("offer", msg.Data).Wait();
                             // if we get an offer, we immediately send an answer
                             _nativePeer.CreateAnswer();
                             break;
                         case Message.WireMessageType.Answer:
-                            _nativePeer.SetRemoteDescription("answer", msg.Data);
+                            _ = _nativePeer.SetRemoteDescriptionAsync("answer", msg.Data);
                             break;
                         case Message.WireMessageType.Ice:
                             // this "parts" protocol is defined above, in OnIceCandiateReadyToSend listener

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -1259,26 +1259,18 @@ namespace Microsoft.MixedReality.WebRTC
         /// Pass the given SDP description received from the remote peer via signaling to the
         /// underlying WebRTC implementation, which will parse and use it.
         ///
-        /// This must be called by the signaler when receiving a message.
+        /// This must be called by the signaler when receiving a message. Once this operation
+        /// has completed, it is safe to call <see cref="CreateAnswer"/>.
         /// </summary>
         /// <param name="type">The type of SDP message ("offer" or "answer")</param>
         /// <param name="sdp">The content of the SDP message</param>
+        /// <returns>Returns a task which completes once the remote description has been applied and transceivers
+        /// have been updated.</returns>
         /// <exception xref="InvalidOperationException">The peer connection is not initialized.</exception>
-        public void SetRemoteDescription(string type, string sdp)
+        public Task SetRemoteDescriptionAsync(string type, string sdp)
         {
             ThrowIfConnectionNotOpen();
-
-            // If the user specified a preferred audio or video codec, manipulate the SDP message
-            // to exclude other codecs if the preferred one is supported.
-            // We set the local codec params by forcing them here. There seems to be no direct way to set
-            // local codec params so we "pretend" that the remote endpoint is asking for them.
-            string newSdp = ForceSdpCodecs(sdp: sdp,
-                audio: PreferredAudioCodec,
-                audioParams: PreferredAudioCodecExtraParamsLocal,
-                video: PreferredVideoCodec,
-                videoParams: PreferredVideoCodecExtraParamsLocal);
-
-            PeerConnectionInterop.PeerConnection_SetRemoteDescription(_nativePeerhandle, type, newSdp);
+            return PeerConnectionInterop.SetRemoteDescriptionAsync(_nativePeerhandle, type, sdp);
         }
 
         #endregion

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/DataChannelTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/DataChannelTests.cs
@@ -22,15 +22,15 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             var pc2 = new PeerConnection();
             await pc1.InitializeAsync(config);
             await pc2.InitializeAsync(config);
-            pc1.LocalSdpReadytoSend += (string type, string sdp) =>
+            pc1.LocalSdpReadytoSend += async (string type, string sdp) =>
             {
-                pc2.SetRemoteDescription(type, sdp);
+                await pc2.SetRemoteDescriptionAsync(type, sdp);
                 if (type == "offer")
                     pc2.CreateAnswer();
             };
-            pc2.LocalSdpReadytoSend += (string type, string sdp) =>
+            pc2.LocalSdpReadytoSend += async (string type, string sdp) =>
             {
-                pc1.SetRemoteDescription(type, sdp);
+                await pc1.SetRemoteDescriptionAsync(type, sdp);
                 if (type == "offer")
                     pc1.CreateAnswer();
             };
@@ -107,15 +107,15 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             var pc2 = new PeerConnection();
             await pc1.InitializeAsync(config);
             await pc2.InitializeAsync(config);
-            pc1.LocalSdpReadytoSend += (string type, string sdp) =>
+            pc1.LocalSdpReadytoSend += async (string type, string sdp) =>
             {
-                pc2.SetRemoteDescription(type, sdp);
+                await pc2.SetRemoteDescriptionAsync(type, sdp);
                 if (type == "offer")
                     pc2.CreateAnswer();
             };
-            pc2.LocalSdpReadytoSend += (string type, string sdp) =>
+            pc2.LocalSdpReadytoSend += async (string type, string sdp) =>
             {
-                pc1.SetRemoteDescription(type, sdp);
+               await pc1.SetRemoteDescriptionAsync(type, sdp);
                 if (type == "offer")
                     pc1.CreateAnswer();
             };

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/LocalVideoTrackTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/LocalVideoTrackTests.cs
@@ -120,18 +120,18 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             connectedEvent2_.Set();
         }
 
-        private void OnLocalSdpReady1(string type, string sdp)
+        private async void OnLocalSdpReady1(string type, string sdp)
         {
-            pc2_.SetRemoteDescription(type, sdp);
+            await pc2_.SetRemoteDescriptionAsync(type, sdp);
             if (type == "offer")
             {
                 pc2_.CreateAnswer();
             }
         }
 
-        private void OnLocalSdpReady2(string type, string sdp)
+        private async void OnLocalSdpReady2(string type, string sdp)
         {
-            pc1_.SetRemoteDescription(type, sdp);
+            await pc1_.SetRemoteDescriptionAsync(type, sdp);
             if (type == "offer")
             {
                 pc1_.CreateAnswer();

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/PeerConnectionTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/PeerConnectionTests.cs
@@ -16,17 +16,17 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             var pc1 = new PeerConnection();
             var pc2 = new PeerConnection();
 
-            pc1.LocalSdpReadytoSend += (string type, string sdp) =>
+            pc1.LocalSdpReadytoSend += async (string type, string sdp) =>
             {
-                pc2.SetRemoteDescription(type, sdp);
+                await pc2.SetRemoteDescriptionAsync(type, sdp);
                 if (type == "offer")
                 {
                     pc2.CreateAnswer();
                 }
             };
-            pc2.LocalSdpReadytoSend += (string type, string sdp) =>
+            pc2.LocalSdpReadytoSend += async (string type, string sdp) =>
             {
-                pc1.SetRemoteDescription(type, sdp);
+                await pc1.SetRemoteDescriptionAsync(type, sdp);
                 if (type == "offer")
                 {
                     pc1.CreateAnswer();
@@ -48,17 +48,17 @@ namespace Microsoft.MixedReality.WebRTC.Tests
 
         protected async Task MakeICECall(PeerConnection pc1, PeerConnection pc2)
         {
-            pc1.LocalSdpReadytoSend += (string type, string sdp) =>
+            pc1.LocalSdpReadytoSend += async (string type, string sdp) =>
             {
-                pc2.SetRemoteDescription(type, sdp);
+                await pc2.SetRemoteDescriptionAsync(type, sdp);
                 if (type == "offer")
                 {
                     pc2.CreateAnswer();
                 }
             };
-            pc2.LocalSdpReadytoSend += (string type, string sdp) =>
+            pc2.LocalSdpReadytoSend += async (string type, string sdp) =>
             {
-                pc1.SetRemoteDescription(type, sdp);
+                await pc1.SetRemoteDescriptionAsync(type, sdp);
                 if (type == "offer")
                 {
                     pc1.CreateAnswer();


### PR DESCRIPTION
Make `mrsSetRemoteDescriptionAsync()` invoke a callback on completion, and change the signature of C# methods to be async. This allows the caller to know when the remote description has been applied, which informs that it is safe to call `CreateAnswer()`. Otherwise the call setting the remote
description may race against the call creating the answer, preventing the answer from being created if the remote description was not applied yet.

Rename all related methods and functions with the "async" suffix for readability and to force a breaking change and avoid silently ignoring the async task, which was an error in existing code.