### PR TITLE
2-step external video track creation for callbacks

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/external_video_track_source_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/external_video_track_source_interop.h
@@ -41,6 +41,14 @@ MRS_API mrsResult MRS_CALL mrsExternalVideoTrackSourceCreateFromArgb32Callback(
     void* user_data,
     ExternalVideoTrackSourceHandle* source_handle_out) noexcept;
 
+/// Callback from the wrapper layer indicating that the wrapper has finished
+/// creation, and it is safe to start sending frame requests to it. This needs
+/// to be called after |mrsExternalVideoTrackSourceCreateFromI420ACallback()| or
+/// |mrsExternalVideoTrackSourceCreateFromArgb32Callback()| to finish the
+/// creation of the video track source and allow it to start capturing.
+MRS_API void MRS_CALL mrsExternalVideoTrackSourceFinishCreation(
+    ExternalVideoTrackSourceHandle source_handle) noexcept;
+
 /// Complete a video frame request with a provided I420A video frame.
 MRS_API mrsResult MRS_CALL mrsExternalVideoTrackSourceCompleteI420AFrameRequest(
     ExternalVideoTrackSourceHandle handle,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/external_video_track_source_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/external_video_track_source_interop.cpp
@@ -6,8 +6,8 @@
 #include "pch.h"
 
 #include "callback.h"
-#include "media/external_video_track_source.h"
 #include "external_video_track_source_interop.h"
+#include "media/external_video_track_source.h"
 
 using namespace Microsoft::MixedReality::WebRTC;
 
@@ -63,6 +63,13 @@ mrsResult MRS_CALL mrsExternalVideoTrackSourceCreateFromArgb32Callback(
   }
   *source_handle_out = track_source.release();
   return Result::kSuccess;
+}
+
+void MRS_CALL mrsExternalVideoTrackSourceFinishCreation(
+    ExternalVideoTrackSourceHandle source_handle) noexcept {
+  if (auto source = static_cast<ExternalVideoTrackSource*>(source_handle)) {
+    source->FinishCreation();
+  }
 }
 
 mrsResult MRS_CALL mrsExternalVideoTrackSourceCompleteI420AFrameRequest(

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source.cpp
@@ -118,12 +118,10 @@ constexpr const size_t kMaxPendingRequestCount = 64;
 RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceImpl::create(
     std::unique_ptr<BufferAdapter> adapter) {
   auto source = new ExternalVideoTrackSourceImpl(std::move(adapter));
-
-  // Video track sources start already capturing; there is no start/stop
-  // mechanism at the track level in WebRTC. A source is either being
-  // initialized, or is already live.
-  source->StartCapture();
-
+  // Note: Video track sources always start already capturing; there is no
+  // start/stop mechanism at the track level in WebRTC. A source is either being
+  // initialized, or is already live. However because of wrappers and interop
+  // this step is delayed until |FinishCreation()| is called by the wrapper.
   return source;
 }
 
@@ -141,6 +139,10 @@ ExternalVideoTrackSourceImpl::~ExternalVideoTrackSourceImpl() {
   StopCapture();
   GlobalFactory::Instance()->RemoveObject(ObjectType::kExternalVideoTrackSource,
                                           this);
+}
+
+void ExternalVideoTrackSourceImpl::FinishCreation() {
+  StartCapture();
 }
 
 void ExternalVideoTrackSourceImpl::StartCapture() {

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source.h
@@ -88,6 +88,10 @@ class ExternalVideoTrackSource : public TrackedObject {
   static RefPtr<ExternalVideoTrackSource> createFromArgb32(
       RefPtr<Argb32ExternalVideoSource> video_source);
 
+  /// Finish the creation of the video track source, and start capturing.
+  /// See |mrsExternalVideoTrackSourceFinishCreation()| for details.
+  virtual void FinishCreation() = 0;
+
   /// Start the video capture. This will begin to produce video frames and start
   /// calling the video frame callback.
   virtual void StartCapture() = 0;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source_impl.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source_impl.h
@@ -65,6 +65,8 @@ class ExternalVideoTrackSourceImpl : public ExternalVideoTrackSource,
   void SetName(std::string name) { name_ = std::move(name); }
   std::string GetName() const override { return name_; }
 
+  void FinishCreation() override;
+
   /// Start the video capture. This will begin to produce video frames and start
   /// calling the video frame callback.
   void StartCapture();

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/external_video_track_source_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/external_video_track_source_tests.cpp
@@ -117,6 +117,7 @@ TEST(ExternalVideoTrackSource, Simple) {
             mrsExternalVideoTrackSourceCreateFromArgb32Callback(
                 &GenerateQuadTestFrame, nullptr, &source_handle));
   ASSERT_NE(nullptr, source_handle);
+  mrsExternalVideoTrackSourceFinishCreation(source_handle);
 
   LocalVideoTrackHandle track_handle = nullptr;
   ASSERT_EQ(mrsResult::kSuccess,

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/ExternalVideoTrackSourceInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/ExternalVideoTrackSourceInterop.cs
@@ -57,20 +57,16 @@ namespace Microsoft.MixedReality.WebRTC.Interop
     {
         #region Unmanaged delegates
 
-        // Note: Unity IL2CPP doesn't support reverse-P/Invoke of SafeHandle
+        // Note - Those methods cannot use SafeHandle with reverse P/Invoke; use IntPtr instead.
+
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         public unsafe delegate void RequestExternalI420AVideoFrameCallback(IntPtr userData,
             /*ExternalVideoTrackSourceHandle*/IntPtr sourceHandle, uint requestId, long timestampMs);
 
-        // Note: Unity IL2CPP doesn't support reverse-P/Invoke of SafeHandle
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         public unsafe delegate void RequestExternalArgb32VideoFrameCallback(IntPtr userData,
             /*ExternalVideoTrackSourceHandle*/IntPtr sourceHandle, uint requestId, long timestampMs);
 
-        #endregion
-
-
-        // Note: Unity IL2CPP doesn't support reverse-P/Invoke of SafeHandle
         [MonoPInvokeCallback(typeof(RequestExternalI420AVideoFrameCallback))]
         public static void RequestI420AVideoFrameFromExternalSourceCallback(IntPtr userData,
             /*ExternalVideoTrackSourceHandle*/IntPtr sourceHandle, uint requestId, long timestampMs)
@@ -85,7 +81,6 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             args.FrameRequestCallback.Invoke(in request);
         }
 
-        // Note: Unity IL2CPP doesn't support reverse-P/Invoke of SafeHandle
         [MonoPInvokeCallback(typeof(RequestExternalArgb32VideoFrameCallback))]
         public static void RequestArgb32VideoFrameFromExternalSourceCallback(IntPtr userData,
             /*ExternalVideoTrackSourceHandle*/IntPtr sourceHandle, uint requestId, long timestampMs)
@@ -99,6 +94,8 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             };
             args.FrameRequestCallback.Invoke(in request);
         }
+
+        #endregion
 
 
         public class VideoFrameRequestCallbackArgs
@@ -131,6 +128,10 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             EntryPoint = "mrsExternalVideoTrackSourceCreateFromArgb32Callback")]
         public static unsafe extern uint ExternalVideoTrackSource_CreateFromArgb32Callback(
             RequestExternalArgb32VideoFrameCallback callback, IntPtr userData, out ExternalVideoTrackSourceHandle sourceHandle);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsExternalVideoTrackSourceFinishCreation")]
+        public static unsafe extern uint ExternalVideoTrackSource_FinishCreation(ExternalVideoTrackSourceHandle sourceHandle);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsExternalVideoTrackSourceAddRef")]
@@ -187,7 +188,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
                     out ExternalVideoTrackSourceHandle sourceHandle);
                     Utils.ThrowOnErrorCode(res);
                 source.OnCreated(sourceHandle);
-
+                ExternalVideoTrackSource_FinishCreation(sourceHandle);
                 return source;
             }
             catch (Exception e)
@@ -224,7 +225,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
                     out ExternalVideoTrackSourceHandle sourceHandle);
                 Utils.ThrowOnErrorCode(res);
                 source.OnCreated(sourceHandle);
-
+                ExternalVideoTrackSource_FinishCreation(sourceHandle);
                 return source;
             }
             catch (Exception e)


### PR DESCRIPTION
Split creation of external video tracks into 2 steps, the first creating the track object, and the second finalizing the creation and starting the track source capture.

In the current state of the API, the frame callbacks are owned by the peer connection, so there is little difference. However with the upcoming change adding standalone track objects, this change allows the user to register a frame callback before capture starts, and therefore be able to honor any frame request from the first one, while also keeping the WebRTC restriction that track sources must start in the capturing state.

This is only a breaking change if directly using the low-level C interop API. The C# library and Unity integration are not affected, as they will handle the change internally and transparently for the user.