### PR TITLE
Make GlobalFactory thread-safe to initialize

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
@@ -25,31 +25,6 @@ enum class mrsShutdownOptions : uint32_t {
   /// debugging. This flag is set by default.
   kLogLiveObjects = 0x1,
 
-  /// Advanced use only. Not set by default.
-  ///
-  /// Determine the behavior of the library on abnormal shutdown, when some
-  /// objects are still alive yet the internal factory is being destroyed, which
-  /// generally indicates some reference counting leaks. This flag has no effect
-  /// under normal use when the library is properly shut down after all objects
-  /// have been destroyed.
-  ///
-  /// - When cleared (default), this flag leaves the library in a dangling state
-  /// where the background WebRTC threads continue running forever. This means
-  /// WebRTC objects can continue to be proxied to those threads, and will not
-  /// deadlock waiting for them. However this means that the module (DLL) cannot
-  /// be unloaded as threads are still running, which might be problematic in
-  /// some use cases (e.g. Unity Editor hot-reload).
-  ///
-  /// - When set, this flag allows shutting down the library even if some
-  /// objects are still alive. This should be used with care as this makes the
-  /// library prone to deadlocking, since WebRTC calls are proxied on background
-  /// threads which would be destroyed by the shutdown, causing objects still
-  /// alive to deadlock when making such calls. However it might prove useful in
-  /// a controlled context where such objects are ensured not to be used any
-  /// further, like a unit test failing, to allow shutting down all threads and
-  /// forcefully unloading the module (DLL).
-  kIgnoreLiveObjectsAndForceShutdown = 0x2,
-
   /// Default flags value.
   kDefault = kLogLiveObjects
 };

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
@@ -17,6 +17,24 @@ enum class mrsBool : int32_t { kTrue = -1, kFalse = 0 };
 // Generic utilities
 //
 
+/// Global MixedReality-WebRTC library shutdown options.
+enum class mrsShutdownOptions : uint32_t {
+  kNone = 0,
+
+  /// Fail to shutdown if some objects are still alive. This is set by default
+  /// and provides safety against deadlocking, since WebRTC calls are proxied on
+  /// background threads which would be destroyed by the shutdown, causing
+  /// objects still alive to deadlock when making such calls. Note however that
+  /// keeping the library alive, and in particular the WebRTC background
+  /// threads, means that the module (DLL) cannot be unloaded, which might be
+  /// problematic in some use cases (e.g. Unity Editor hot-reload).
+  kFailOnLiveObjects = 0x1,
+
+  /// Log some report about live objects when trying to shutdown, to help
+  /// debugging.
+  kLogLiveObjects = 0x2
+};
+
 /// Opaque enumerator type.
 struct mrsEnumerator;
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.cpp
@@ -97,8 +97,8 @@ GlobalFactory* GlobalFactory::GetInstance() {
   // Use C++11 thread-safety guarantee to ensure a single instance is created.
   // It will be destroyed automatically on module unload. The "library
   // initialized" concept refers to this instance being initialized or not.
-  static std::unique_ptr<GlobalFactory> g_factory(new GlobalFactory());
-  return g_factory.get();
+  static std::unique_ptr<GlobalFactory> s_factory(new GlobalFactory());
+  return s_factory.get();
 }
 
 RefPtr<GlobalFactory> GlobalFactory::GetInstancePtrImpl(

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.cpp
@@ -10,6 +10,8 @@
 #include "peer_connection.h"
 #include "utils.h"
 
+#include <exception>
+
 namespace {
 
 using namespace Microsoft::MixedReality::WebRTC;
@@ -76,7 +78,11 @@ void GlobalFactory::ForceShutdown() noexcept {
   }
   try {
     factory->ShutdownImplNoLock(ShutdownAction::kForceShutdown);
+  } catch (std::exception& e) {
+    RTC_LOG(LS_ERROR) << "Failed to shutdown library with exception: "
+                      << e.what();
   } catch (...) {
+    RTC_LOG(LS_ERROR) << "Failed to shutdown library due to unknown exception.";
   }
 }
 
@@ -88,9 +94,14 @@ bool GlobalFactory::TryShutdown() noexcept {
   }
   try {
     return factory->ShutdownImplNoLock(ShutdownAction::kTryShutdownIfSafe);
+  } catch (std::exception& e) {
+    RTC_LOG(LS_ERROR)
+        << "Failed to attempt to shutdown library with exception: " << e.what();
   } catch (...) {
-    return false;  // failed to shutdown
+    RTC_LOG(LS_ERROR)
+        << "Failed to attempt to shutdown library due to unknown exception.";
   }
+  return false;  // failed to shutdown
 }
 
 GlobalFactory* GlobalFactory::GetInstance() {

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
@@ -16,24 +16,59 @@ enum class ObjectType : int {
 
 /// Global factory wrapper adding thread safety to all global objects, including
 /// the peer connection factory, and on UWP the so-called "WebRTC factory".
+/// Usage pattern:
+///   - Get a RefPtr<> to the singleton instance using |InstancePtr()|. This may
+///   initialize a new instance. This also adds a temporary reference to the
+///   factory to keep it alive until the RefPtr<> goes out of scope.
+///   - Use the factory, for example to get the peer connection factory or to
+///   add/remove some wrapper objects. Whether or not any operation fails, the
+///   factory cannot be destroyed due to the temporary reference, even if no
+///   alive object is present anymore.
+///   - When the RefPtr<> goes out of scope, it releases its temporary reference
+///   to the factory. If that reference is the last one, then the factory
+///   attempts to shutdown, that is goes to check the alive objects, which
+///   constitutes long-term references and will also prevent its destruction.
+///
+/// The delayed call to |TryShutdown()| from releasing the temporary reference
+/// when RefPtr<GlobalFactory> goes out of scope instead of when no object is
+/// alive anymore allows the caller to create a wrapper object and fail
+/// initializing it, and remove it from the global factory but without the
+/// factory destroying itself yet. This works around a problem where the object
+/// removing itself triggers the destruction of the global factory singleton
+/// instance while another thread already acquired a reference to the global
+/// factory but did not yet add any wrapper object so cannot prevent its
+/// destruction, and is left with a dangling reference to a destroyed singleton.
+/// The temporary reference count allows delaying that destruction for as long
+/// as any thread has a reference to the singleton instance. This is not a real
+/// reference count because the global factory is a singleton, and to avoid
+/// circular references. Users must never store a RefPtr<> to the global
+/// factory, but must use a local variable instead to temporarily block
+/// destruction during a single API call.
+///
+/// Usage:
+///   RefPtr<GlobalFactory> global_factory = GlobalFactory::InstancePtr();
+///   RefPtr<Wrapper> dummy = new Wrapper(); // calls GlobalFactory::AddObject()
+///
 class GlobalFactory {
  public:
-  ~GlobalFactory();
+  /// Force-shutdown the library.
+  static void ForceShutdown() noexcept;
 
   /// Global factory of all global objects, including the peer connection
   /// factory itself, with added thread safety.
-  static const std::unique_ptr<GlobalFactory>& Instance();
+  static RefPtr<GlobalFactory> InstancePtr();
 
-  /// Get or create the peer connection factory.
-  rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> GetOrCreate();
+  /// Attempt to shutdown the global factory if no live object is present
+  /// anymore. This is always conservative and safe, and will do nothing if any
+  /// object is still live.
+  static bool TryShutdown() noexcept;
 
-  /// Get or create the peer connection factory.
-  mrsResult GetOrCreate(
-      rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>& factory);
+  GlobalFactory() = default;
+  ~GlobalFactory();
 
   /// Get the existing peer connection factory, or NULL if not created.
   rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>
-  GetExisting() noexcept;
+  GetPeerConnectionFactory() noexcept;
 
   /// Get the worker thread. This is only valid if initialized.
   rtc::Thread* GetWorkerThread() noexcept;
@@ -47,6 +82,12 @@ class GlobalFactory {
   /// object's destructor for safety.
   void RemoveObject(ObjectType type, TrackedObject* obj) noexcept;
 
+  /// Report live objects to WebRTC logging system for debugging.
+  /// This is automatically called if the |mrsShutdownOptions::kLogLiveObjects|
+  /// shutdown option is set, but can also be called manually at any time.
+  /// Return the number of live objects at the time of the call.
+  uint32_t ReportLiveObjects();
+
 #if defined(WINUWP)
   using WebRtcFactoryPtr =
       std::shared_ptr<wrapper::impl::org::webRtc::WebRtcFactory>;
@@ -54,9 +95,25 @@ class GlobalFactory {
   mrsResult GetOrCreateWebRtcFactory(WebRtcFactoryPtr& factory);
 #endif  // defined(WINUWP)
 
+  void AddRef() const noexcept {
+    temp_ref_count_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void RemoveRef() const noexcept {
+    if (temp_ref_count_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      GlobalFactory::TryShutdown();
+    }
+  }
+
  private:
-  mrsResult Initialize();
-  void ShutdownNoLock();
+  GlobalFactory(const GlobalFactory&) = delete;
+  GlobalFactory& operator=(const GlobalFactory&) = delete;
+  static std::unique_ptr<GlobalFactory>& MutableInstance(
+      bool createIfNotExist = true);
+  mrsResult InitializeImplNoLock();
+  void ForceShutdownImpl();
+  bool TryShutdownImpl();
+  void ReportLiveObjectsNoLock();
 
  private:
   rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory_
@@ -73,6 +130,17 @@ class GlobalFactory {
   /// Collection of all objects alive.
   std::unordered_map<TrackedObject*, ObjectType> alive_objects_
       RTC_GUARDED_BY(mutex_);
+
+  /// Shutdown options.
+  mrsShutdownOptions shutdown_options_;
+
+  /// Reference count for RAII-style shutdown. This is not used as a true
+  /// reference count, but instead as a marker of temporary acquiring a
+  /// reference to the GlobalFactory while trying to create some objects, and as
+  /// a notification mechanism when said reference is released to check for
+  /// shutdown. Therefore most of the time the reference count is zero, yet the
+  /// instance stays alive.
+  mutable std::atomic_uint32_t temp_ref_count_{0};
 };
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
@@ -7,8 +7,6 @@
 #include "peer_connection.h"
 #include "utils.h"
 
-#include <shared_mutex>
-
 namespace Microsoft::MixedReality::WebRTC {
 
 /// Enumeration of all object types that the global factory keeps track of for

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
@@ -159,7 +159,7 @@ class GlobalFactory {
   std::unordered_map<TrackedObject*, ObjectType> alive_objects_
       RTC_GUARDED_BY(mutex_);
 
-  mrsShutdownOptions shutdown_options_;
+  mrsShutdownOptions shutdown_options_ = mrsShutdownOptions::kDefault;
 
   /// Reference count for RAII-style shutdown. This is not used as a true
   /// reference count, but instead as a lock to temporarily prevent the

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
@@ -96,7 +96,9 @@ class GlobalFactory {
     // call |AddRef()| under the lock too so will block.
     std::scoped_lock lock(init_mutex_);
     RTC_DCHECK(peer_factory_);
-    if (ref_count_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    // Usually this is memory_order_acq_rel, but here the |init_mutex_| forces
+    // the necessary memory barrier, so only the atomicity is relevant.
+    if (ref_count_.fetch_sub(1, std::memory_order_relaxed) == 1) {
       const_cast<GlobalFactory*>(this)->ShutdownImplNoLock(
           ShutdownAction::kTryShutdownIfSafe);
     }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
@@ -26,10 +26,6 @@ struct mrsEnumerator {
 
 namespace {
 
-inline bool IsStringNullOrEmpty(const char* str) noexcept {
-  return ((str == nullptr) || (str[0] == '\0'));
-}
-
 mrsResult RTCToAPIError(const webrtc::RTCError& error) {
   if (error.ok()) {
     return Result::kSuccess;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source.cpp
@@ -131,14 +131,14 @@ ExternalVideoTrackSourceImpl::ExternalVideoTrackSourceImpl(
       adapter_(std::forward<std::unique_ptr<BufferAdapter>>(adapter)),
       capture_thread_(rtc::Thread::Create()) {
   capture_thread_->SetName("ExternalVideoTrackSource capture thread", this);
-  GlobalFactory::Instance()->AddObject(ObjectType::kExternalVideoTrackSource,
-                                       this);
+  GlobalFactory::InstancePtr()->AddObject(ObjectType::kExternalVideoTrackSource,
+                                          this);
 }
 
 ExternalVideoTrackSourceImpl::~ExternalVideoTrackSourceImpl() {
   StopCapture();
-  GlobalFactory::Instance()->RemoveObject(ObjectType::kExternalVideoTrackSource,
-                                          this);
+  GlobalFactory::InstancePtr()->RemoveObject(
+      ObjectType::kExternalVideoTrackSource, this);
 }
 
 void ExternalVideoTrackSourceImpl::FinishCreation() {

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/utils.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/utils.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+
+inline bool IsStringNullOrEmpty(const char* str) noexcept {
+  return ((str == nullptr) || (str[0] == '\0'));
+}
+
+enum class mrsShutdownOptions : uint32_t;
+
+inline mrsShutdownOptions operator|(mrsShutdownOptions a,
+                                    mrsShutdownOptions b) noexcept {
+  return (mrsShutdownOptions)((uint32_t)a | (uint32_t)b);
+}
+
+inline mrsShutdownOptions operator&(mrsShutdownOptions a,
+                                    mrsShutdownOptions b) noexcept {
+  return (mrsShutdownOptions)((uint32_t)a & (uint32_t)b);
+}
+
+inline bool operator==(mrsShutdownOptions a, uint32_t b) noexcept {
+  return ((uint32_t)a == b);
+}
+
+inline bool operator!=(mrsShutdownOptions a, uint32_t b) noexcept {
+  return ((uint32_t)a != b);
+}

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj
@@ -133,6 +133,7 @@
     <ClInclude Include="..\str.h" />
     <ClInclude Include="..\targetver.h" />
     <ClInclude Include="..\tracked_object.h" />
+    <ClInclude Include="..\utils.h" />
     <ClInclude Include="..\video_frame_observer.h" />
   </ItemGroup>
   <ItemGroup>

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj.filters
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj.filters
@@ -58,6 +58,7 @@
       <Filter>media</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\result.h" />
+    <ClInclude Include="..\utils.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../../docs/design.md" />

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="..\str.h" />
     <ClInclude Include="..\targetver.h" />
     <ClInclude Include="..\tracked_object.h" />
+    <ClInclude Include="..\utils.h" />
     <ClInclude Include="..\video_frame_observer.h" />
   </ItemGroup>
   <ItemGroup>

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj.filters
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj.filters
@@ -65,6 +65,7 @@
     <ClInclude Include="..\media\local_video_track.h">
       <Filter>media</Filter>
     </ClInclude>
+    <ClInclude Include="..\utils.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../../docs/design.md" />

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/video_track_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/video_track_tests.cpp
@@ -211,6 +211,7 @@ TEST(VideoTrack, ExternalI420) {
             mrsExternalVideoTrackSourceCreateFromI420ACallback(
                 &MakeTestFrame, nullptr, &source_handle));
   ASSERT_NE(nullptr, source_handle);
+  mrsExternalVideoTrackSourceFinishCreation(source_handle);
 
   LocalVideoTrackHandle track_handle = nullptr;
   ASSERT_EQ(


### PR DESCRIPTION
Make `GlobalFactory` thread-safe to initialize and shutdown by using reference counting.

Previously `RemoveObject()` was attempting to destroy the `GlobalFactory` singleton instance as soon as the number of tracked objects alive reached zero. This was problematic for two reasons:
1. If thread A retrieves a pointer to the singleton before thread B, then thread B creates a new wrapper (which calls `AddObject()`) but later fails to complete the initializing of that object and has to destroy it before thread A itself added an object, then `RemoveObject()` (called from the wrapper destructor) will find no object alive and will destroy the `GlobalFactory` singleton instance, which leaves thread A with a dangling pointer.
2. Destroying the singleton instance was done outside the lock, and access to that pointer was therefore prone to concurrent writes.

This change introduces a different approach where the singleton instance is created on first use via member function static initializing, which is thread-safe in C++11, and never destroyed until static de-initializing at the end of the process or when the module (DLL) is unloaded. Instead, reference counting and number of tracked objects alive are used to initialize and shutdown the singleton instance, which now can be reused after shutdown.

The addition of reference counting, and returning a proper `RefPtr<GlobalFactory>` instead of a unique pointer, make it easier to understand for users that the `RefPtr` instance will prevent the library from shutting down while it is in scope, and therefore that keeping that `RefPtr` around while creating a wrapper object prevents the first issue described above since having no tracked object alive is necessary but not sufficient anymore to trigger a library shutdown.

NB: To improve on this change, another subsequent PR will actually add a `RefPtr<GlobalFactory>` member to all tracked objects, making the reference count the sole mechanism to decide whether the factory needs to be shut down or not, leaving `alive_objects_` as a simple debug-only container. This will also cut down the number of mutex locks by allowing a tracked object to pass a copy of its own `RefPtr` to a new tracked object it created without the need to check if the library needs to be initialized (since it obviously is initialized already). For clarity that additional change is not added to this PR and will be reviewed separately.

