### PR TITLE
Add RefPtr<GlobalFactory> to TrackedObject

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/external_video_track_source_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/external_video_track_source_interop.cpp
@@ -7,6 +7,7 @@
 
 #include "callback.h"
 #include "external_video_track_source_interop.h"
+#include "interop/global_factory.h"
 #include "media/external_video_track_source.h"
 
 using namespace Microsoft::MixedReality::WebRTC;
@@ -40,7 +41,8 @@ mrsResult MRS_CALL mrsExternalVideoTrackSourceCreateFromI420ACallback(
   }
   *source_handle_out = nullptr;
   RefPtr<ExternalVideoTrackSource> track_source =
-      detail::ExternalVideoTrackSourceCreateFromI420A(callback, user_data);
+      detail::ExternalVideoTrackSourceCreateFromI420A(
+          GlobalFactory::InstancePtr(), callback, user_data);
   if (!track_source) {
     return Result::kUnknownError;
   }
@@ -57,7 +59,8 @@ mrsResult MRS_CALL mrsExternalVideoTrackSourceCreateFromArgb32Callback(
   }
   *source_handle_out = nullptr;
   RefPtr<ExternalVideoTrackSource> track_source =
-      detail::ExternalVideoTrackSourceCreateFromArgb32(callback, user_data);
+      detail::ExternalVideoTrackSourceCreateFromArgb32(
+          GlobalFactory::InstancePtr(), callback, user_data);
   if (!track_source) {
     return Result::kUnknownError;
   }
@@ -158,6 +161,7 @@ struct Argb32InteropVideoSource : Argb32ExternalVideoSource {
 namespace Microsoft::MixedReality::WebRTC::detail {
 
 RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromI420A(
+    RefPtr<GlobalFactory> global_factory,
     mrsRequestExternalI420AVideoFrameCallback callback,
     void* user_data) {
   RefPtr<I420AInteropVideoSource> custom_source =
@@ -166,7 +170,8 @@ RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromI420A(
     return {};
   }
   RefPtr<ExternalVideoTrackSource> track_source =
-      ExternalVideoTrackSource::createFromI420A(custom_source);
+      ExternalVideoTrackSource::createFromI420A(std::move(global_factory),
+                                                custom_source);
   if (!track_source) {
     return {};
   }
@@ -175,6 +180,7 @@ RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromI420A(
 }
 
 RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromArgb32(
+    RefPtr<GlobalFactory> global_factory,
     mrsRequestExternalArgb32VideoFrameCallback callback,
     void* user_data) {
   RefPtr<Argb32InteropVideoSource> custom_source =
@@ -183,7 +189,8 @@ RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromArgb32(
     return {};
   }
   RefPtr<ExternalVideoTrackSource> track_source =
-      ExternalVideoTrackSource::createFromArgb32(custom_source);
+      ExternalVideoTrackSource::createFromArgb32(std::move(global_factory),
+                                                 custom_source);
   if (!track_source) {
     return {};
   }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/global_factory.h
@@ -9,17 +9,6 @@
 
 namespace Microsoft::MixedReality::WebRTC {
 
-/// Enumeration of all object types that the global factory keeps track of for
-/// the purpose of keeping itself alive. Each value correspond to a type of
-/// wrapper object. Wrapper objects must call |GlobalFactory::AddObject()| and
-/// |GlobalFactory::RemoveObject()| to register themselves with the global
-/// factory while alive.
-enum class ObjectType : int {
-  kPeerConnection,
-  kLocalVideoTrack,
-  kExternalVideoTrackSource,
-};
-
 /// The global factory is a helper class used to initialize and shutdown the
 /// internal WebRTC library, which adds extra functionalities over a classical
 /// init/shutdown pair of functions:
@@ -117,11 +106,11 @@ class GlobalFactory {
   /// monitored (via the library reference count) to know when it is safe to
   /// shutdown the library and terminate the WebRTC threads. This is generally
   /// called form a wrapper object's constructor for safety.
-  void AddObject(ObjectType type, TrackedObject* obj) noexcept;
+  void AddObject(TrackedObject* obj) noexcept;
 
   /// Remove an object added with |AddObject|. This is generally called from a
   /// wrapper object's destructor for safety.
-  void RemoveObject(ObjectType type, TrackedObject* obj) noexcept;
+  void RemoveObject(TrackedObject* obj) noexcept;
 
   /// Report live objects to WebRTC logging system for debugging.
   /// This is automatically called if the |mrsShutdownOptions::kLogLiveObjects|
@@ -218,13 +207,13 @@ class GlobalFactory {
   /// caller holds a reference to the library (|ref_count_| > 0).
   mutable std::recursive_mutex mutex_;
 
-  /// Collection of all tracked objects alive.
-  std::unordered_map<TrackedObject*, ObjectType> alive_objects_
-      RTC_GUARDED_BY(mutex_);
-
   /// Shutdown options.
   mrsShutdownOptions shutdown_options_ RTC_GUARDED_BY(mutex_) =
       mrsShutdownOptions::kDefault;
+
+  /// Collection of all tracked objects alive. This is solely used to display a
+  /// debugging report with |ReportLiveObjects()|.
+  std::vector<TrackedObject*> alive_objects_ RTC_GUARDED_BY(mutex_);
 };
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
+#include "external_video_track_source_interop.h"
 #include "mrs_errors.h"
 #include "refptr.h"
 #include "tracked_object.h"
 #include "video_frame.h"
-#include "external_video_track_source_interop.h"
 
 namespace Microsoft::MixedReality::WebRTC {
 
@@ -81,11 +81,13 @@ class ExternalVideoTrackSource : public TrackedObject {
   /// Helper to create an external video track source from a custom I420A video
   /// frame request callback.
   static RefPtr<ExternalVideoTrackSource> createFromI420A(
+      RefPtr<GlobalFactory> global_factory,
       RefPtr<I420AExternalVideoSource> video_source);
 
   /// Helper to create an external video track source from a custom ARGB32 video
   /// frame request callback.
   static RefPtr<ExternalVideoTrackSource> createFromArgb32(
+      RefPtr<GlobalFactory> global_factory,
       RefPtr<Argb32ExternalVideoSource> video_source);
 
   /// Finish the creation of the video track source, and start capturing.
@@ -100,21 +102,24 @@ class ExternalVideoTrackSource : public TrackedObject {
   /// The caller must know the source expects an I420A frame; there is no check
   /// to confirm the source is I420A-based or ARGB32-based.
   virtual Result CompleteRequest(uint32_t request_id,
-                                         int64_t timestamp_ms,
-                                         const I420AVideoFrame& frame) = 0;
+                                 int64_t timestamp_ms,
+                                 const I420AVideoFrame& frame) = 0;
 
   /// Complete a given video frame request with the provided ARGB32 frame.
   /// The caller must know the source expects an ARGB32 frame; there is no check
   /// to confirm the source is I420A-based or ARGB32-based.
   virtual Result CompleteRequest(uint32_t request_id,
-                                         int64_t timestamp_ms,
-                                         const Argb32VideoFrame& frame) = 0;
+                                 int64_t timestamp_ms,
+                                 const Argb32VideoFrame& frame) = 0;
 
   /// Stop the video capture. This will stop producing video frames.
   virtual void StopCapture() = 0;
 
   /// Shutdown the source and release the buffer adapter and its callback.
   virtual void Shutdown() noexcept = 0;
+
+ protected:
+  ExternalVideoTrackSource(RefPtr<GlobalFactory> global_factory);
 };
 
 namespace detail {
@@ -126,14 +131,17 @@ namespace detail {
 /// Create an I420A external video track source wrapping the given interop
 /// callback.
 RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromI420A(
+    RefPtr<GlobalFactory> global_factory,
     mrsRequestExternalI420AVideoFrameCallback callback,
     void* user_data);
 
 /// Create an ARGB32 external video track source wrapping the given interop
 /// callback.
 RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromArgb32(
+    RefPtr<GlobalFactory> global_factory,
     mrsRequestExternalArgb32VideoFrameCallback callback,
     void* user_data);
-} // namespace detail
+
+}  // namespace detail
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source_impl.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/external_video_track_source_impl.h
@@ -58,6 +58,7 @@ class ExternalVideoTrackSourceImpl : public ExternalVideoTrackSource,
   using SourceState = webrtc::MediaSourceInterface::SourceState;
 
   static RefPtr<ExternalVideoTrackSource> create(
+      RefPtr<GlobalFactory> global_factory,
       std::unique_ptr<BufferAdapter> adapter);
 
   ~ExternalVideoTrackSourceImpl() override;
@@ -90,7 +91,8 @@ class ExternalVideoTrackSourceImpl : public ExternalVideoTrackSource,
   webrtc::VideoTrackSourceInterface* impl() const { return track_source_; }
 
  protected:
-  ExternalVideoTrackSourceImpl(std::unique_ptr<BufferAdapter> adapter);
+  ExternalVideoTrackSourceImpl(RefPtr<GlobalFactory> global_factory,
+                               std::unique_ptr<BufferAdapter> adapter);
   // void Run(rtc::Thread* thread) override;
   void OnMessage(rtc::Message* message) override;
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_video_track.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_video_track.cpp
@@ -3,17 +3,20 @@
 
 #include "pch.h"
 
+#include "interop/global_factory.h"
 #include "local_video_track.h"
 #include "peer_connection.h"
 
 namespace Microsoft::MixedReality::WebRTC {
 
 LocalVideoTrack::LocalVideoTrack(
+    RefPtr<GlobalFactory> global_factory,
     PeerConnection& owner,
     rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
     rtc::scoped_refptr<webrtc::RtpSenderInterface> sender,
     mrsLocalVideoTrackInteropHandle interop_handle) noexcept
-    : owner_(&owner),
+    : TrackedObject(std::move(global_factory), ObjectType::kLocalVideoTrack),
+      owner_(&owner),
       track_(std::move(track)),
       sender_(std::move(sender)),
       interop_handle_(interop_handle) {

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_video_track.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_video_track.h
@@ -5,7 +5,6 @@
 
 #include "callback.h"
 #include "interop_api.h"
-#include "str.h"
 #include "tracked_object.h"
 #include "video_frame_observer.h"
 
@@ -37,7 +36,8 @@ class PeerConnection;
 /// has no knowledge about how the source produces the frames.
 class LocalVideoTrack : public VideoFrameObserver, public TrackedObject {
  public:
-  LocalVideoTrack(PeerConnection& owner,
+  LocalVideoTrack(RefPtr<GlobalFactory> global_factory,
+                  PeerConnection& owner,
                   rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
                   rtc::scoped_refptr<webrtc::RtpSenderInterface> sender,
                   mrsLocalVideoTrackInteropHandle interop_handle) noexcept;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -392,6 +392,9 @@ class PeerConnection : public TrackedObject {
   /// manually.
   virtual mrsResult RegisterInteropCallbacks(
       const mrsPeerConnectionInteropCallbacks& callbacks) noexcept = 0;
+
+ protected:
+  PeerConnection(RefPtr<GlobalFactory> global_factory);
 };
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/tracked_object.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/tracked_object.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "interop/global_factory.h"
+#include "tracked_object.h"
+
+namespace Microsoft::MixedReality::WebRTC {
+
+TrackedObject::TrackedObject(RefPtr<GlobalFactory> global_factory,
+                             ObjectType object_type)
+    : global_factory_(std::move(global_factory)), object_type_(object_type) {
+  global_factory_->AddObject(this);
+}
+
+TrackedObject::~TrackedObject() noexcept {
+  global_factory_->RemoveObject(this);
+}
+
+}  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/tracked_object.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/tracked_object.h
@@ -6,17 +6,45 @@
 #include <string>
 
 #include "ref_counted_base.h"
+#include "refptr.h"
 
 namespace Microsoft::MixedReality::WebRTC {
+
+class GlobalFactory;
+
+/// Enumeration of all object types that the global factory keeps track of for
+/// the purpose of keeping itself alive. Each value correspond to a type of
+/// wrapper object. Wrapper objects must call |GlobalFactory::AddObject()| and
+/// |GlobalFactory::RemoveObject()| to register themselves with the global
+/// factory while alive.
+enum class ObjectType : int {
+  kPeerConnection,
+  kLocalVideoTrack,
+  kExternalVideoTrackSource,
+};
 
 /// Object tracked for interop, exposing helper methods for debugging purpose.
 class TrackedObject : public RefCountedBase {
  public:
+  TrackedObject(RefPtr<GlobalFactory> global_factory, ObjectType object_type);
+  ~TrackedObject() noexcept override;
+
+  constexpr ObjectType GetObjectType() const noexcept { return object_type_; }
+
   /// Retrieve the name of the object. The exact meaning depends on the actual
   /// object, and may be user-set or reused from another field of the object,
   /// but will generally allow the user to identify the object instance during
   /// debugging. There is no other meaning to this.
+  /// Note that this may be called while the library is not initialized,
+  /// including during static deinitializing of the process, therefore the
+  /// implementation must not rely on WebRTC objects. Generally the
+  /// implementation should locally cache a string value to comply with this
+  /// limitation.
   virtual std::string GetName() const = 0;
+
+ protected:
+  RefPtr<GlobalFactory> global_factory_;
+  const ObjectType object_type_;
 };
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="..\peer_connection.cpp" />
     <ClCompile Include="..\sdp_utils.cpp" />
     <ClCompile Include="..\str.cpp" />
+    <ClCompile Include="..\tracked_object.cpp" />
     <ClCompile Include="..\video_frame_observer.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj.filters
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj.filters
@@ -30,6 +30,7 @@
     <ClCompile Include="..\media\local_video_track.cpp">
       <Filter>media</Filter>
     </ClCompile>
+    <ClCompile Include="..\tracked_object.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="../pch.h" />

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj
@@ -167,6 +167,7 @@
     <ClCompile Include="..\peer_connection.cpp" />
     <ClCompile Include="..\sdp_utils.cpp" />
     <ClCompile Include="..\str.cpp" />
+    <ClCompile Include="..\tracked_object.cpp" />
     <ClCompile Include="..\video_frame_observer.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj.filters
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj.filters
@@ -30,6 +30,7 @@
     <ClCompile Include="..\media\local_video_track.cpp">
       <Filter>media</Filter>
     </ClCompile>
+    <ClCompile Include="..\tracked_object.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="../pch.h" />


### PR DESCRIPTION
Simplify and clean-up the `GlobalFactory` ownership by injecting a `RefPtr<GlobalFactory>` directly inside all wrapper objects deriving from `TrackedObject`. This releases the `GlobalFactory::alive_objects_` collection from its duty of maintaining an object count, and makes
reference counting the sole mechanism for initializing and shutdown the library. This also reduces the number of locks needed, as tracker objects (which therefore own a ref) can create other tracker objects without the need to check if the library is initialized, since it obviously is.

This is a follow-up to #197.