### PR TITLE
DataChannel: SendMessage(IntPtr,ulong) / MessageReceivedUnsafe callback

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/DataChannel.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/DataChannel.cs
@@ -198,10 +198,10 @@ namespace Microsoft.MixedReality.WebRTC
         /// <seealso cref="PeerConnection.InitializeAsync"/>
         /// <seealso cref="PeerConnection.Initialized"/>
         /// <seealso cref="BufferingChanged"/>
-        public void SendMessage(IntPtr message, ulong messageByteSize)
+        public void SendMessage(IntPtr message, ulong size)
         {
-            MainEventSource.Log.DataChannelSendMessage(ID, size);
-            uint res = DataChannelInterop.DataChannel_SendMessage(_interopHandle, message, messageByteSize);
+            MainEventSource.Log.DataChannelSendMessage(ID, (int)size);
+            uint res = DataChannelInterop.DataChannel_SendMessage(_interopHandle, message, size);
             Utils.ThrowOnErrorCode(res);
         }
 

--- a/libs/Microsoft.MixedReality.WebRTC/DataChannel.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/DataChannel.cs
@@ -193,6 +193,7 @@ namespace Microsoft.MixedReality.WebRTC
         /// The internal buffering is monitored via the <see cref="BufferingChanged"/> event.
         /// </summary>
         /// <param name="message">The message to send to the remote peer.</param>
+        /// <param name="size">The size of the message to send in octects.</param>
         /// <exception xref="InvalidOperationException">The native data channel is not initialized.</exception>
         /// <exception xref="Exception">The internal buffer is full.</exception>
         /// <seealso cref="PeerConnection.InitializeAsync"/>

--- a/libs/Microsoft.MixedReality.WebRTC/DataChannel.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/DataChannel.cs
@@ -231,13 +231,7 @@ namespace Microsoft.MixedReality.WebRTC
             var unsafeCallback = MessageReceivedUnsafe;
             if (unsafeCallback != null)
             {
-                unsafe
-                {
-                    fixed (void* ptr = msg)
-                    {
-                		unsafeCallback.Invoke((void*)data, size);
-                    }
-                }
+                unsafeCallback.Invoke(data, size);
             }
         }
 

--- a/libs/Microsoft.MixedReality.WebRTC/DataChannel.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/DataChannel.cs
@@ -119,6 +119,12 @@ namespace Microsoft.MixedReality.WebRTC
         public event Action<byte[]> MessageReceived;
 
         /// <summary>
+        /// Event fires when a message is received through the data channel.
+        /// </summary>
+        /// <seealso cref="SendMessage(IntPtr,ulong)"/>
+        public event Action<IntPtr, ulong> MessageReceivedUnsafe;
+
+        /// <summary>
         /// GC handle keeping the internal delegates alive while they are registered
         /// as callbacks with the native code.
         /// </summary>
@@ -181,6 +187,24 @@ namespace Microsoft.MixedReality.WebRTC
             Utils.ThrowOnErrorCode(res);
         }
 
+        /// <summary>
+        /// Send a message through the data channel. If the message cannot be sent, for example because of congestion
+        /// control, it is buffered internally. If this buffer gets full, an exception is thrown and this call is aborted.
+        /// The internal buffering is monitored via the <see cref="BufferingChanged"/> event.
+        /// </summary>
+        /// <param name="message">The message to send to the remote peer.</param>
+        /// <exception xref="InvalidOperationException">The native data channel is not initialized.</exception>
+        /// <exception xref="Exception">The internal buffer is full.</exception>
+        /// <seealso cref="PeerConnection.InitializeAsync"/>
+        /// <seealso cref="PeerConnection.Initialized"/>
+        /// <seealso cref="BufferingChanged"/>
+        public void SendMessage(IntPtr message, ulong messageByteSize)
+        {
+            MainEventSource.Log.DataChannelSendMessage(ID, size);
+            uint res = DataChannelInterop.DataChannel_SendMessage(_interopHandle, message, messageByteSize);
+            Utils.ThrowOnErrorCode(res);
+        }
+
         internal void OnMessageReceived(IntPtr data, ulong size)
         {
             MainEventSource.Log.DataChannelMessageReceived(ID, (int)size);
@@ -202,6 +226,18 @@ namespace Microsoft.MixedReality.WebRTC
                     }
                 }
                 callback.Invoke(msg);
+            }
+
+            var unsafeCallback = MessageReceivedUnsafe;
+            if (unsafeCallback != null)
+            {
+                unsafe
+                {
+                    fixed (void* ptr = msg)
+                    {
+                		unsafeCallback.Invoke((void*)data, size);
+                    }
+                }
             }
         }
 

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/DataChannelInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/DataChannelInterop.cs
@@ -15,6 +15,10 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             EntryPoint = "mrsDataChannelSendMessage")]
         public static extern uint DataChannel_SendMessage(IntPtr dataChannelHandle, byte[] data, ulong size);
 
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsDataChannelSendMessage")]
+        public static extern uint DataChannel_SendMessage(IntPtr dataChannelHandle, IntPtr data, ulong size);
+
         #endregion
 
 


### PR DESCRIPTION
avoids per-message byte[] array allocation, can be used in unsafe contexts.