### PR TITLE
Replace interop handles with opaque user data

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/data_channel_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/data_channel_interop.h
@@ -55,6 +55,12 @@ MRS_API void MRS_CALL mrsDataChannelRegisterCallbacks(
     mrsDataChannelHandle handle,
     const mrsDataChannelCallbacks* callbacks) noexcept;
 
+/// Send through the given data channel a raw message |data| of byte length
+/// |size|. The message may be buffered internally, and the caller should
+/// monitor the buffering event to avoid overflowing the internal buffer.
+///
+/// This returns an error if the data channel is not open. The caller should
+/// monitor the state change event to know when it is safe to send a message.
 MRS_API mrsResult MRS_CALL
 mrsDataChannelSendMessage(mrsDataChannelHandle data_channel_handle,
                           const void* data,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/data_channel_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/data_channel_interop.h
@@ -20,25 +20,26 @@ MRS_API void MRS_CALL mrsDataChannelSetUserData(mrsDataChannelHandle handle,
 MRS_API void* MRS_CALL
 mrsDataChannelGetUserData(mrsDataChannelHandle handle) noexcept;
 
-/// Callback fired when a message is received on a data channel.
-using mrsDataChannelMessageCallback = void(MRS_CALL*)(void* user_data,
-                                                      const void* data,
-                                                      const uint64_t size);
+/// Callback fired when a message |data| of byte size |size| is received on a
+/// data channel.
+using mrsDataChannelMessageCallback = void(
+    MRS_CALL*)(void* user_data, const void* data, const uint64_t size) noexcept;
 
-/// Callback fired when a data channel buffering changes.
-/// The |previous| and |current| values are the old and new sizes in byte of the
-/// buffering buffer. The |limit| is the capacity of the buffer.
-/// Note that when the buffer is full, any attempt to send data will result is
-/// an abrupt closing of the data channel. So monitoring this state is critical.
-using mrsDataChannelBufferingCallback = void(MRS_CALL*)(void* user_data,
-                                                        const uint64_t previous,
-                                                        const uint64_t current,
-                                                        const uint64_t limit);
+/// Callback invoked when a data channel internal buffering changes.
+/// The |previous| and |current| values are the old and new sizes in bytes of
+/// the buffering buffer. The |limit| is the capacity of the buffer. Note that
+/// when the buffer is full, any attempt to send data will result is an abrupt
+/// closing of the data channel. So monitoring the buffering state is critical.
+using mrsDataChannelBufferingCallback =
+    void(MRS_CALL*)(void* user_data,
+                    const uint64_t previous,
+                    const uint64_t current,
+                    const uint64_t limit) noexcept;
 
 /// Callback fired when the state of a data channel changed.
 using mrsDataChannelStateCallback = void(MRS_CALL*)(void* user_data,
                                                     int32_t state,
-                                                    int32_t id);
+                                                    int32_t id) noexcept;
 
 /// Helper to register a group of data channel callbacks.
 struct mrsDataChannelCallbacks {
@@ -50,7 +51,7 @@ struct mrsDataChannelCallbacks {
   void* state_user_data{};
 };
 
-/// Register callbacks for managing a data channel
+/// Register callbacks for managing a data channel.
 MRS_API void MRS_CALL mrsDataChannelRegisterCallbacks(
     mrsDataChannelHandle handle,
     const mrsDataChannelCallbacks* callbacks) noexcept;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/data_channel_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/data_channel_interop.h
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "interop_api.h"
+
+extern "C" {
+
+/// Assign some opaque user data to the data channel. The implementation will
+/// store the pointer in the data channel object and not touch it. It can be
+/// retrieved with |mrsDataChannelGetUserData()| at any point during the data
+/// channel lifetime. This is not multithread-safe.
+MRS_API void MRS_CALL mrsDataChannelSetUserData(mrsDataChannelHandle handle,
+                                                void* user_data) noexcept;
+
+/// Get the opaque user data pointer previously assigned to the data channel
+/// with |mrsDataChannelSetUserData()|. If no value was previously assigned,
+/// return |nullptr|. This is not multithread-safe.
+MRS_API void* MRS_CALL
+mrsDataChannelGetUserData(mrsDataChannelHandle handle) noexcept;
+
+/// Callback fired when a message is received on a data channel.
+using mrsDataChannelMessageCallback = void(MRS_CALL*)(void* user_data,
+                                                      const void* data,
+                                                      const uint64_t size);
+
+/// Callback fired when a data channel buffering changes.
+/// The |previous| and |current| values are the old and new sizes in byte of the
+/// buffering buffer. The |limit| is the capacity of the buffer.
+/// Note that when the buffer is full, any attempt to send data will result is
+/// an abrupt closing of the data channel. So monitoring this state is critical.
+using mrsDataChannelBufferingCallback = void(MRS_CALL*)(void* user_data,
+                                                        const uint64_t previous,
+                                                        const uint64_t current,
+                                                        const uint64_t limit);
+
+/// Callback fired when the state of a data channel changed.
+using mrsDataChannelStateCallback = void(MRS_CALL*)(void* user_data,
+                                                    int32_t state,
+                                                    int32_t id);
+
+/// Helper to register a group of data channel callbacks.
+struct mrsDataChannelCallbacks {
+  mrsDataChannelMessageCallback message_callback{};
+  void* message_user_data{};
+  mrsDataChannelBufferingCallback buffering_callback{};
+  void* buffering_user_data{};
+  mrsDataChannelStateCallback state_callback{};
+  void* state_user_data{};
+};
+
+/// Register callbacks for managing a data channel
+MRS_API void MRS_CALL mrsDataChannelRegisterCallbacks(
+    mrsDataChannelHandle handle,
+    const mrsDataChannelCallbacks* callbacks) noexcept;
+
+MRS_API mrsResult MRS_CALL
+mrsDataChannelSendMessage(mrsDataChannelHandle data_channel_handle,
+                          const void* data,
+                          uint64_t size) noexcept;
+
+}  // extern "C"

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
@@ -618,16 +618,15 @@ struct mrsDataChannelConfig {
 /// Add a new data channel to a peer connection.
 ///
 /// The initial configuration of the data channel is provided by |config|, and
-/// is mandatory. The caller can optionally provide a set of callbacks to
-/// register with the data channel via the |callbacks| optional argument. The
-/// function returns in |data_channel_handle_out| the handle to the
-/// newly-created data channel after it was added to the peer connection.
+/// is mandatory. The function returns in |data_channel_handle_out| the handle
+/// to the newly-created data channel after it was added to the peer connection.
 ///
 /// The type of data channel created depends on the |config.id| value:
 /// - If |config.id| < 0, then it adds a new in-band data channel with an ID
 /// that will be selected by the WebRTC implementation itself, and will be
 /// available later. In that case the channel is announced to the remote peer
 /// for it to create a channel with the same ID. This requires a renegotiation.
+/// Once the renegotiation is completed, the ID is available on both peers.
 /// - If |config.id| >= 0, then it adds a new out-of-band negotiated channel
 /// with the given ID, and it is the responsibility of the app to create a
 /// channel with the same ID on the remote peer to be able to use the channel.

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
@@ -25,12 +25,12 @@ enum class mrsShutdownOptions : uint32_t {
   kNone = 0,
 
   /// Log some report about live objects when trying to shutdown, to help
-  /// debugging. This flag is set by default.
+  /// debugging.
   kLogLiveObjects = 0x1,
 
   /// When forcing shutdown, either because |mrsForceShutdown()| is called or
   /// because the program terminates, and some objects are still alive, attempt
-  /// to break into the debugger. This is not available for all platforms.
+  /// to break into the debugger. This is not available on all platforms.
   kDebugBreakOnForceShutdown = 0x2,
 
   /// Default flags value.
@@ -76,8 +76,6 @@ struct mrsRemoteVideoTrackConfig;
 struct mrsDataChannelConfig;
 struct mrsDataChannelCallbacks;
 
-// Handles to interop objects (internal implementation)
-
 /// Opaque handle to a native PeerConnection interop object.
 using mrsPeerConnectionHandle = void*;
 
@@ -104,60 +102,6 @@ using mrsDataChannelHandle = void*;
 
 /// Opaque handle to a native ExternalVideoTrackSource interop object.
 using mrsExternalVideoTrackSourceHandle = void*;
-
-// Handles to wrapper objects
-
-/// Opaque handle to the interop wrapper of a peer connection.
-using mrsPeerConnectionInteropHandle = void*;
-
-/// Opaque handle to the interop wrapper of a transceiver.
-using mrsTransceiverInteropHandle = void*;
-
-/// Opaque handle to the interop wrapper of a local audio track.
-using mrsLocalAudioTrackInteropHandle = void*;
-
-/// Opaque handle to the interop wrapper of a local video track.
-using mrsLocalVideoTrackInteropHandle = void*;
-
-/// Opaque handle to the interop wrapper of a remote audio track.
-using mrsRemoteAudioTrackInteropHandle = void*;
-
-/// Opaque handle to the interop wrapper of a remote video track.
-using mrsRemoteVideoTrackInteropHandle = void*;
-
-/// Opaque handle to the interop wrapper of a data channel.
-using mrsDataChannelInteropHandle = void*;
-
-/// Callback to create an interop wrapper for a transceiver.
-/// The callback must return the handle of the created interop wrapper.
-using mrsTransceiverCreateObjectCallback = mrsTransceiverInteropHandle(
-    MRS_CALL*)(mrsPeerConnectionInteropHandle parent,
-               const mrsTransceiverWrapperInitConfig& config) noexcept;
-
-/// Callback to finish the creation of the interop wrapper by assigning to it
-/// the handle of the Transceiver native object it wraps.
-/// This is called shortly after |mrsTransceiverCreateObjectCallback|, with
-/// the same |mrsTransceiverInteropHandle| returned by that callback.
-using mrsTransceiverFinishCreateCallback =
-    void(MRS_CALL*)(mrsTransceiverInteropHandle, mrsTransceiverHandle);
-
-/// Callback to create an interop wrapper for a remote audio track.
-using mrsRemoteAudioTrackCreateObjectCallback =
-    mrsRemoteAudioTrackInteropHandle(MRS_CALL*)(
-        mrsPeerConnectionInteropHandle parent,
-        const mrsRemoteAudioTrackConfig& config) noexcept;
-
-/// Callback to create an interop wrapper for a remote video track.
-using mrsRemoteVideoTrackCreateObjectCallback =
-    mrsRemoteVideoTrackInteropHandle(MRS_CALL*)(
-        mrsPeerConnectionInteropHandle parent,
-        const mrsRemoteVideoTrackConfig& config) noexcept;
-
-/// Callback to create an interop wrapper for a data channel.
-using mrsDataChannelCreateObjectCallback = mrsDataChannelInteropHandle(
-    MRS_CALL*)(mrsPeerConnectionInteropHandle parent,
-               const mrsDataChannelConfig& config,
-               mrsDataChannelCallbacks* callbacks) noexcept;
 
 //
 // Video capture enumeration
@@ -274,10 +218,8 @@ enum class mrsTrackKind : uint32_t {
 /// released with |mrsLocalAudioTrackRemoveRef()| and
 /// |mrsTransceiverRemoveRef()|, respectively, to avoid memory leaks.
 using mrsPeerConnectionAudioTrackAddedCallback =
-    void(MRS_CALL*)(mrsPeerConnectionInteropHandle peer,
-                    mrsRemoteAudioTrackInteropHandle audio_track_wrapper,
+    void(MRS_CALL*)(void* user_data,
                     mrsRemoteAudioTrackHandle audio_track,
-                    mrsTransceiverInteropHandle transceiver_wrapper,
                     mrsTransceiverHandle transceiver);
 
 /// Callback fired when a remote audio track is removed from a connection.
@@ -286,10 +228,8 @@ using mrsPeerConnectionAudioTrackAddedCallback =
 /// released with |mrsLocalAudioTrackRemoveRef()| and
 /// |mrsTransceiverRemoveRef()|, respectively, to avoid memory leaks.
 using mrsPeerConnectionAudioTrackRemovedCallback =
-    void(MRS_CALL*)(mrsPeerConnectionInteropHandle peer,
-                    mrsRemoteAudioTrackInteropHandle audio_track_wrapper,
+    void(MRS_CALL*)(void* user_data,
                     mrsRemoteAudioTrackHandle audio_track,
-                    mrsTransceiverInteropHandle transceiver_wrapper,
                     mrsTransceiverHandle transceiver);
 
 /// Callback fired when a remote video track is added to a connection.
@@ -298,10 +238,8 @@ using mrsPeerConnectionAudioTrackRemovedCallback =
 /// released with |mrsLocalVideoTrackRemoveRef()| and
 /// |mrsTransceiverRemoveRef()|, respectively, to avoid memory leaks.
 using mrsPeerConnectionVideoTrackAddedCallback =
-    void(MRS_CALL*)(mrsPeerConnectionInteropHandle peer,
-                    mrsRemoteVideoTrackInteropHandle video_track_wrapper,
+    void(MRS_CALL*)(void* user_data,
                     mrsRemoteVideoTrackHandle video_track,
-                    mrsTransceiverInteropHandle transceiver_wrapper,
                     mrsTransceiverHandle transceiver);
 
 /// Callback fired when a remote video track is removed from a connection.
@@ -310,24 +248,18 @@ using mrsPeerConnectionVideoTrackAddedCallback =
 /// released with |mrsLocalVideoTrackRemoveRef()| and
 /// |mrsTransceiverRemoveRef()|, respectively, to avoid memory leaks.
 using mrsPeerConnectionVideoTrackRemovedCallback =
-    void(MRS_CALL*)(mrsPeerConnectionInteropHandle peer,
-                    mrsRemoteVideoTrackInteropHandle video_track_wrapper,
+    void(MRS_CALL*)(void* user_data,
                     mrsRemoteVideoTrackHandle video_track,
-                    mrsTransceiverInteropHandle transceiver_wrapper,
                     mrsTransceiverHandle transceiver);
 
 /// Callback fired when a data channel is added to the peer connection after
 /// being negotiated with the remote peer.
 using mrsPeerConnectionDataChannelAddedCallback =
-    void(MRS_CALL*)(mrsPeerConnectionInteropHandle peer,
-                    mrsDataChannelInteropHandle data_channel_wrapper,
-                    mrsDataChannelHandle data_channel);
+    void(MRS_CALL*)(void* user_data, mrsDataChannelHandle data_channel);
 
 /// Callback fired when a data channel is remoted from the peer connection.
 using mrsPeerConnectionDataChannelRemovedCallback =
-    void(MRS_CALL*)(mrsPeerConnectionInteropHandle peer,
-                    mrsDataChannelInteropHandle data_channel_wrapper,
-                    mrsDataChannelHandle data_channel);
+    void(MRS_CALL*)(void* user_data, mrsDataChannelHandle data_channel);
 
 using mrsI420AVideoFrame = Microsoft::MixedReality::WebRTC::I420AVideoFrame;
 
@@ -444,43 +376,13 @@ struct mrsPeerConnectionConfiguration {
 /// object is destroyed.
 MRS_API mrsResult MRS_CALL
 mrsPeerConnectionCreate(const mrsPeerConnectionConfiguration* config,
-                        mrsPeerConnectionInteropHandle interop_handle,
-                        mrsPeerConnectionHandle* peerHandleOut) noexcept;
-
-/// Callbacks needed to allow the native implementation to interact with the
-/// interop layer, and in particular to react to events which necessitate
-/// creating a new interop wrapper for a new native instance (whose creation was
-/// not initiated by the interop, so for which the native instance is created
-/// first).
-struct mrsPeerConnectionInteropCallbacks {
-  /// Construct an interop object for a Transceiver instance.
-  mrsTransceiverCreateObjectCallback transceiver_create_object{};
-
-  /// Finish the construction of the interop object of a Transceiver.
-  mrsTransceiverFinishCreateCallback transceiver_finish_create{};
-
-  /// Construct an interop object for a RemoteAudioTrack instance.
-  mrsRemoteAudioTrackCreateObjectCallback remote_audio_track_create_object{};
-
-  /// Construct an interop object for a RemoteVideooTrack instance.
-  mrsRemoteVideoTrackCreateObjectCallback remote_video_track_create_object{};
-
-  /// Construct an interop object for a DataChannel instance.
-  mrsDataChannelCreateObjectCallback data_channel_create_object{};
-};
-
-/// Register the interop callbacks necessary to make interop work. To
-/// unregister, simply pass nullptr as the callback pointer. Only one set of
-/// callbacks can be registered at a time.
-MRS_API mrsResult MRS_CALL mrsPeerConnectionRegisterInteropCallbacks(
-    mrsPeerConnectionHandle peerHandle,
-    mrsPeerConnectionInteropCallbacks* callbacks) noexcept;
+                        mrsPeerConnectionHandle* peer_handle_out) noexcept;
 
 /// Register a callback invoked once connected to a remote peer. To unregister,
 /// simply pass nullptr as the callback pointer. Only one callback can be
 /// registered at a time.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterConnectedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionConnectedCallback callback,
     void* user_data) noexcept;
 
@@ -488,7 +390,7 @@ MRS_API void MRS_CALL mrsPeerConnectionRegisterConnectedCallback(
 /// signaling service to a remote peer. Only one callback can be registered at a
 /// time.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterLocalSdpReadytoSendCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionLocalSdpReadytoSendCallback callback,
     void* user_data) noexcept;
 
@@ -496,21 +398,21 @@ MRS_API void MRS_CALL mrsPeerConnectionRegisterLocalSdpReadytoSendCallback(
 /// sent via the signaling service to a remote peer. Only one callback can be
 /// registered at a time.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterIceCandidateReadytoSendCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionIceCandidateReadytoSendCallback callback,
     void* user_data) noexcept;
 
 /// Register a callback invoked when the ICE connection state changes. Only one
 /// callback can be registered at a time.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterIceStateChangedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionIceStateChangedCallback callback,
     void* user_data) noexcept;
 
 /// Register a callback fired when a renegotiation of the current session needs
 /// to occur to account for new parameters (e.g. added or removed tracks).
 MRS_API void MRS_CALL mrsPeerConnectionRegisterRenegotiationNeededCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionRenegotiationNeededCallback callback,
     void* user_data) noexcept;
 
@@ -520,7 +422,7 @@ MRS_API void MRS_CALL mrsPeerConnectionRegisterRenegotiationNeededCallback(
 /// reference to the corresponding object and therefore must be released, even
 /// if the user does not make use of them in the callback.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterAudioTrackAddedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionAudioTrackAddedCallback callback,
     void* user_data) noexcept;
 
@@ -530,7 +432,7 @@ MRS_API void MRS_CALL mrsPeerConnectionRegisterAudioTrackAddedCallback(
 /// reference to the corresponding object and therefore must be released, even
 /// if the user does not make use of them in the callback.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterAudioTrackRemovedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionAudioTrackRemovedCallback callback,
     void* user_data) noexcept;
 
@@ -540,7 +442,7 @@ MRS_API void MRS_CALL mrsPeerConnectionRegisterAudioTrackRemovedCallback(
 /// reference to the corresponding object and therefore must be released, even
 /// if the user does not make use of them in the callback.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterVideoTrackAddedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionVideoTrackAddedCallback callback,
     void* user_data) noexcept;
 
@@ -550,21 +452,21 @@ MRS_API void MRS_CALL mrsPeerConnectionRegisterVideoTrackAddedCallback(
 /// reference to the corresponding object and therefore must be released, even
 /// if the user does not make use of them in the callback.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterVideoTrackRemovedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionVideoTrackRemovedCallback callback,
     void* user_data) noexcept;
 
 /// Register a callback fired when a remote data channel is removed from the
 /// current peer connection.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterDataChannelAddedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionDataChannelAddedCallback callback,
     void* user_data) noexcept;
 
 /// Register a callback fired when a remote data channel is removed from the
 /// current peer connection.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterDataChannelRemovedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionDataChannelRemovedCallback callback,
     void* user_data) noexcept;
 
@@ -617,22 +519,20 @@ struct mrsTransceiverInitConfig {
   /// Optional name of the transceiver. This must be a valid SDP token; see
   /// |mrsSdpIsValidToken()|. If no name is provided (empty or null string),
   /// then the implementation will generate a random one.
-  const char* name = nullptr;
+  const char* name{nullptr};
 
   /// Kind of media the transceiver transports.
   mrsMediaKind media_kind{(mrsMediaKind)-1};  // invalid value to catch errors
 
   /// Initial desired direction of the transceiver media when created.
-  mrsTransceiverDirection desired_direction =
-      mrsTransceiverDirection::kSendRecv;
+  mrsTransceiverDirection desired_direction{mrsTransceiverDirection::kSendRecv};
 
   /// Optional semi-colon separated list of stream IDs associated with the
   /// transceiver, or null/empty string for none.
-  const char* stream_ids = nullptr;
+  const char* stream_ids{nullptr};
 
-  /// Handle of the transceiver interop wrapper, if any, which will be
-  /// associated with the native transceiver object.
-  mrsTransceiverInteropHandle transceiver_interop_handle{};
+  /// Optional user data.
+  void* user_data{nullptr};
 };
 
 using mrsRequestExternalI420AVideoFrameCallback =
@@ -724,21 +624,20 @@ struct mrsDataChannelCallbacks {
 /// given ID, and it is the responsibility of the app to create a channel with
 /// the same ID on the remote peer to be able to use the channel.
 MRS_API mrsResult MRS_CALL mrsPeerConnectionAddDataChannel(
-    mrsPeerConnectionHandle peerHandle,
-    mrsDataChannelInteropHandle dataChannelInteropHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsDataChannelConfig config,
     mrsDataChannelCallbacks callbacks,
-    mrsDataChannelHandle* dataChannelHandleOut) noexcept;
+    mrsDataChannelHandle* data_channel_handle_out) noexcept;
 
 /// Remove an existing data channel from a peer connection and destroy it. If
 /// the channel was an in-band data channel, then the change triggers a
 /// renegotiation needed event.
 MRS_API mrsResult MRS_CALL mrsPeerConnectionRemoveDataChannel(
-    mrsPeerConnectionHandle peerHandle,
-    mrsDataChannelHandle dataChannelHandle) noexcept;
+    mrsPeerConnectionHandle peer_handle,
+    mrsDataChannelHandle data_channel_handle) noexcept;
 
 MRS_API mrsResult MRS_CALL
-mrsDataChannelSendMessage(mrsDataChannelHandle dataChannelHandle,
+mrsDataChannelSendMessage(mrsDataChannelHandle data_channel_handle,
                           const void* data,
                           uint64_t size) noexcept;
 
@@ -750,7 +649,7 @@ mrsDataChannelSendMessage(mrsDataChannelHandle dataChannelHandle,
 /// index it is associated with |sdp_mline_index|. The raw SDP candidate content
 /// is passed in |candidate|.
 MRS_API mrsResult MRS_CALL
-mrsPeerConnectionAddIceCandidate(mrsPeerConnectionHandle peerHandle,
+mrsPeerConnectionAddIceCandidate(mrsPeerConnectionHandle peer_handle,
                                  const char* sdp_mid,
                                  const int sdp_mline_index,
                                  const char* candidate) noexcept;
@@ -764,7 +663,7 @@ mrsPeerConnectionAddIceCandidate(mrsPeerConnectionHandle peerHandle,
 /// Therefore the user must wait for a previous exchange to complete in order to
 /// be able to initiate a new offer.
 MRS_API mrsResult MRS_CALL
-mrsPeerConnectionCreateOffer(mrsPeerConnectionHandle peerHandle) noexcept;
+mrsPeerConnectionCreateOffer(mrsPeerConnectionHandle peer_handle) noexcept;
 
 /// Create a new JSEP answer to a received offer to try to establish a
 /// connection with a remote peer. This will generate a local answer message,
@@ -775,7 +674,7 @@ mrsPeerConnectionCreateOffer(mrsPeerConnectionHandle peerHandle) noexcept;
 /// remote offer via |mrsPeerConnectionSetRemoteDescriptionAsync| and the async
 /// callback completed successfully.
 MRS_API mrsResult MRS_CALL
-mrsPeerConnectionCreateAnswer(mrsPeerConnectionHandle peerHandle) noexcept;
+mrsPeerConnectionCreateAnswer(mrsPeerConnectionHandle peer_handle) noexcept;
 
 /// Set the bitrate allocated to all RTP streams sent by this connection.
 /// Other limitations might affect these limits and are respected (for example
@@ -800,7 +699,7 @@ using ActionCallback = void(MRS_CALL*)(void* user_data);
 /// the action callback is invoked to signal the caller it is safe to continue
 /// the negotiation, and in particular it is safe to call |CreateAnswer()|.
 MRS_API mrsResult MRS_CALL
-mrsPeerConnectionSetRemoteDescriptionAsync(mrsPeerConnectionHandle peerHandle,
+mrsPeerConnectionSetRemoteDescriptionAsync(mrsPeerConnectionHandle peer_handle,
                                            const char* type,
                                            const char* sdp,
                                            ActionCallback callback,
@@ -811,7 +710,7 @@ mrsPeerConnectionSetRemoteDescriptionAsync(mrsPeerConnectionHandle peerHandle,
 /// destroy the native peer connection object, but leaves it in a state where it
 /// can only be destroyed by calling |mrsPeerConnectionRemoveRef()|.
 MRS_API mrsResult MRS_CALL
-mrsPeerConnectionClose(mrsPeerConnectionHandle peerHandle) noexcept;
+mrsPeerConnectionClose(mrsPeerConnectionHandle peer_handle) noexcept;
 
 //
 // SDP utilities

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
@@ -212,15 +212,39 @@ enum class mrsTrackKind : uint32_t {
   kDataTrack = 3,
 };
 
+/// Information about a newly added remote audio track provided to the audio
+/// track added callback.
+struct mrsRemoteAudioTrackAddedInfo {
+  /// Handle of the newly-created remote audio track.
+  mrsRemoteAudioTrackHandle track_handle;
+
+  /// Handle of the audio transeiver the track was added to.
+  mrsTransceiverHandle audio_transceiver_handle;
+
+  /// Name of the newly-added remote audio track.
+  const char* track_name;
+};
+
+/// Information about a newly added remote video track provided to the video
+/// track added callback.
+struct mrsRemoteVideoTrackAddedInfo {
+  /// Handle of the newly-created remote video track.
+  mrsRemoteVideoTrackHandle track_handle;
+
+  /// Handle of the video transeiver the track was added to.
+  mrsTransceiverHandle audio_transceiver_handle;
+
+  /// Name of the newly-added remote video track.
+  const char* track_name;
+};
+
 /// Callback fired when a remote audio track is added to a connection.
 /// The |audio_track| and |audio_transceiver| handle hold a reference to the
 /// underlying native object they are associated with, and therefore must be
 /// released with |mrsLocalAudioTrackRemoveRef()| and
 /// |mrsTransceiverRemoveRef()|, respectively, to avoid memory leaks.
 using mrsPeerConnectionAudioTrackAddedCallback =
-    void(MRS_CALL*)(void* user_data,
-                    mrsRemoteAudioTrackHandle audio_track,
-                    mrsTransceiverHandle transceiver);
+    void(MRS_CALL*)(void* user_data, const mrsRemoteAudioTrackAddedInfo* info);
 
 /// Callback fired when a remote audio track is removed from a connection.
 /// The |audio_track| and |audio_transceiver| handle hold a reference to the
@@ -238,9 +262,7 @@ using mrsPeerConnectionAudioTrackRemovedCallback =
 /// released with |mrsLocalVideoTrackRemoveRef()| and
 /// |mrsTransceiverRemoveRef()|, respectively, to avoid memory leaks.
 using mrsPeerConnectionVideoTrackAddedCallback =
-    void(MRS_CALL*)(void* user_data,
-                    mrsRemoteVideoTrackHandle video_track,
-                    mrsTransceiverHandle transceiver);
+    void(MRS_CALL*)(void* user_data, const mrsRemoteVideoTrackAddedInfo* info);
 
 /// Callback fired when a remote video track is removed from a connection.
 /// The |video_track| and |video_transceiver| handle hold a reference to the

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/local_audio_track_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/local_audio_track_interop.h
@@ -11,11 +11,7 @@ extern "C" {
 
 /// Configuration for opening a local audio capture device and creating a local
 /// audio track.
-struct mrsLocalAudioTrackInitConfig {
-  /// Handle of the local audio track interop wrapper, if any, which will be
-  /// associated with the native local audio track object.
-  mrsLocalAudioTrackInteropHandle track_interop_handle{};
-};
+struct mrsLocalAudioTrackInitConfig {};
 
 /// Add a reference to the native object associated with the given handle.
 MRS_API void MRS_CALL

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/local_video_track_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/local_video_track_interop.h
@@ -10,10 +10,6 @@ extern "C" {
 /// Configuration for opening a local video capture device and creating a local
 /// video track.
 struct mrsLocalVideoTrackInitConfig {
-  /// Handle of the local video track interop wrapper, if any, which will be
-  /// associated with the native local video track object.
-  mrsLocalVideoTrackInteropHandle track_interop_handle{};
-
   /// Unique identifier of the video capture device to select, as returned by
   /// |mrsEnumVideoCaptureDevicesAsync|, or a null or empty string to select the
   /// default device.
@@ -61,9 +57,8 @@ struct mrsLocalVideoTrackInitConfig {
 
 /// Configuration for creating a local video track from an external source.
 struct mrsLocalVideoTrackFromExternalSourceInitConfig {
-  /// Handle of the local video track interop wrapper, if any, which will be
-  /// associated with the native local video track object.
-  mrsLocalVideoTrackInteropHandle track_interop_handle{};
+  mrsExternalVideoTrackSourceHandle source_handle;
+  const char* track_name;
 };
 
 /// Add a reference to the native object associated with the given handle.
@@ -84,9 +79,7 @@ MRS_API mrsResult MRS_CALL mrsLocalVideoTrackCreateFromDevice(
 
 /// Create a new local video track by using an existing external video source.
 MRS_API mrsResult MRS_CALL mrsLocalVideoTrackCreateFromExternalSource(
-    mrsExternalVideoTrackSourceHandle source_handle,
     const mrsLocalVideoTrackFromExternalSourceInitConfig* config,
-    const char* track_name,
     mrsLocalVideoTrackHandle* track_handle_out) noexcept;
 
 /// Register a custom callback to be called when the local video track captured

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/peer_connection_interop.h
@@ -19,11 +19,43 @@ mrsPeerConnectionAddRef(mrsPeerConnectionHandle handle) noexcept;
 MRS_API void MRS_CALL
 mrsPeerConnectionRemoveRef(mrsPeerConnectionHandle handle) noexcept;
 
-/// Callback fired when the state of the ICE connection changed.
+/// Information provided to the TransceiverAdded event handler about a
+/// transceiver newly created as a result of applying a remote description on
+/// the local peer connection, and newly added to that peer connection.
+struct mrsTransceiverAddedInfo {
+  /// Handle of the newly-created transceiver.
+  mrsTransceiverHandle transceiver_handle{nullptr};
+
+  /// Name of the newly-added transceiver.
+  const char* transceiver_name{nullptr};
+
+  /// Media kind of the newly-create transceiver.
+  mrsMediaKind media_kind{(mrsMediaKind)-1};
+
+  /// Media line index of the transceiver in the peer connection.
+  int mline_index{-1};
+
+  /// Initial value of the desired transceiver direction.
+  mrsTransceiverDirection desired_direction{mrsTransceiverDirection::kInactive};
+};
+
+/// Callback invoked when a transceiver is added to the peer connection as a
+/// result of a remote description being applied.
+using mrsPeerConnectionTransceiverAddedCallback =
+    void(MRS_CALL*)(void* user_data, const mrsTransceiverAddedInfo* info);
+
+/// Register a callback invoked when a new transceiver is added to the peer
+/// connection as a result of applying a remote description from a remote peer.
+MRS_API void MRS_CALL mrsPeerConnectionRegisterTransceiverAddedCallback(
+    mrsPeerConnectionHandle peer_handle,
+    mrsPeerConnectionTransceiverAddedCallback callback,
+    void* user_data) noexcept;
+
+/// Callback invoked when the state of the ICE connection changed.
 using mrsPeerConnectionIceGatheringStateChangedCallback =
     void(MRS_CALL*)(void* user_data, mrsIceGatheringState new_state);
 
-/// Register a callback fired when the ICE connection state changes.
+/// Register a callback invoked when the ICE connection state changes.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterIceGatheringStateChangedCallback(
     mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionIceGatheringStateChangedCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/remote_audio_track_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/remote_audio_track_interop.h
@@ -9,18 +9,6 @@
 
 extern "C" {
 
-//
-// Wrapper
-//
-
-/// Add a reference to the native object associated with the given handle.
-MRS_API void MRS_CALL
-mrsRemoteAudioTrackAddRef(mrsRemoteAudioTrackHandle handle) noexcept;
-
-/// Remove a reference from the native object associated with the given handle.
-MRS_API void MRS_CALL
-mrsRemoteAudioTrackRemoveRef(mrsRemoteAudioTrackHandle handle) noexcept;
-
 /// Register a custom callback to be called when the local audio track received
 /// a frame.
 MRS_API void MRS_CALL

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/remote_audio_track_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/remote_audio_track_interop.h
@@ -9,6 +9,20 @@
 
 extern "C" {
 
+/// Assign some opaque user data to the remote audio track. The implementation
+/// will store the pointer in the remote audio track object and not touch it. It
+/// can be retrieved with |mrsRemoteAudioTrackGetUserData()| at any point during
+/// the remote audio track lifetime. This is not multithread-safe.
+MRS_API void MRS_CALL
+mrsRemoteAudioTrackSetUserData(mrsRemoteAudioTrackHandle handle,
+                               void* user_data) noexcept;
+
+/// Get the opaque user data pointer previously assigned to the remote audio
+/// track with |mrsRemoteAudioTrackSetUserData()|. If no value was previously
+/// assigned, return |nullptr|. This is not multithread-safe.
+MRS_API void* MRS_CALL
+mrsRemoteAudioTrackGetUserData(mrsRemoteAudioTrackHandle handle) noexcept;
+
 /// Register a custom callback to be called when the local audio track received
 /// a frame.
 MRS_API void MRS_CALL

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/remote_video_track_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/remote_video_track_interop.h
@@ -8,18 +8,6 @@
 
 extern "C" {
 
-//
-// Wrapper
-//
-
-/// Add a reference to the native object associated with the given handle.
-MRS_API void MRS_CALL
-mrsRemoteVideoTrackAddRef(mrsRemoteVideoTrackHandle handle) noexcept;
-
-/// Remove a reference from the native object associated with the given handle.
-MRS_API void MRS_CALL
-mrsRemoteVideoTrackRemoveRef(mrsRemoteVideoTrackHandle handle) noexcept;
-
 /// Register a custom callback to be called when the remote video track received
 /// a frame. The received frames is passed to the registered callback in I420
 /// encoding.

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/remote_video_track_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/remote_video_track_interop.h
@@ -8,6 +8,20 @@
 
 extern "C" {
 
+/// Assign some opaque user data to the remote video track. The implementation
+/// will store the pointer in the remote video track object and not touch it. It
+/// can be retrieved with |mrsRemoteVideoTrackGetUserData()| at any point during
+/// the remote video track lifetime. This is not multithread-safe.
+MRS_API void MRS_CALL
+mrsRemoteVideoTrackSetUserData(mrsRemoteVideoTrackHandle handle,
+                               void* user_data) noexcept;
+
+/// Get the opaque user data pointer previously assigned to the remote video
+/// track with |mrsRemoteVideoTrackSetUserData()|. If no value was previously
+/// assigned, return |nullptr|. This is not multithread-safe.
+MRS_API void* MRS_CALL
+mrsRemoteVideoTrackGetUserData(mrsRemoteVideoTrackHandle handle) noexcept;
+
 /// Register a custom callback to be called when the remote video track received
 /// a frame. The received frames is passed to the registered callback in I420
 /// encoding.

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/transceiver_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/transceiver_interop.h
@@ -14,14 +14,6 @@ using mrsTransceiverStateUpdatedCallback =
                     mrsTransceiverOptDirection negotiated_direction,
                     mrsTransceiverDirection desired_direction);
 
-/// Add a reference to the native object associated with the given handle.
-MRS_API void MRS_CALL
-mrsTransceiverAddRef(mrsTransceiverHandle handle) noexcept;
-
-/// Remove a reference from the native object associated with the given handle.
-MRS_API void MRS_CALL
-mrsTransceiverRemoveRef(mrsTransceiverHandle handle) noexcept;
-
 MRS_API void MRS_CALL mrsTransceiverRegisterStateUpdatedCallback(
     mrsTransceiverHandle handle,
     mrsTransceiverStateUpdatedCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/transceiver_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/transceiver_interop.h
@@ -8,6 +8,19 @@
 
 extern "C" {
 
+/// Assign some opaque user data to the transceiver. The implementation will
+/// store the pointer in the transceiver object and not touch it. It can be
+/// retrieved with |mrsTransceiverGetUserData()| at any point during the
+/// transceiver lifetime. This is not multithread-safe.
+MRS_API void MRS_CALL mrsTransceiverSetUserData(mrsTransceiverHandle handle,
+                                                void* user_data) noexcept;
+
+/// Get the opaque user data pointer previously assigned to the transceiver with
+/// |mrsTransceiverSetUserData()|. If no value was previously assigned, return
+/// |nullptr|. This is not multithread-safe.
+MRS_API void* MRS_CALL
+mrsTransceiverGetUserData(mrsTransceiverHandle handle) noexcept;
+
 using mrsTransceiverStateUpdatedCallback =
     void(MRS_CALL*)(void* user_data,
                     mrsTransceiverStateUpdatedReason reason,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/data_channel.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/data_channel.cpp
@@ -29,11 +29,8 @@ namespace Microsoft::MixedReality::WebRTC {
 
 DataChannel::DataChannel(
     PeerConnection* owner,
-    rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel,
-    mrsDataChannelInteropHandle interop_handle) noexcept
-    : owner_(owner),
-      data_channel_(std::move(data_channel)),
-      interop_handle_(interop_handle) {
+    rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel) noexcept
+    : owner_(owner), data_channel_(std::move(data_channel)) {
   RTC_CHECK(owner_);
   data_channel_->RegisterObserver(this);
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/data_channel.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/data_channel.h
@@ -71,8 +71,27 @@ class DataChannel : public webrtc::DataChannelObserver {
   /// Remove the data channel from its parent PeerConnection and close it.
   ~DataChannel() override;
 
+  [[nodiscard]] constexpr void* GetUserData() const noexcept {
+    return user_data_;
+  }
+
+  constexpr void SetUserData(void* user_data) noexcept {
+    user_data_ = user_data;
+  }
+
   /// Get the unique channel identifier.
   [[nodiscard]] int id() const { return data_channel_->id(); }
+
+  [[nodiscard]] mrsDataChannelConfigFlags flags() const noexcept {
+    mrsDataChannelConfigFlags flags{0};
+    if (data_channel_->ordered()) {
+      flags = flags | mrsDataChannelConfigFlags::kOrdered;
+    }
+    if (data_channel_->reliable()) {
+      flags = flags | mrsDataChannelConfigFlags::kReliable;
+    }
+    return flags;
+  }
 
   /// Get the friendly channel name.
   [[nodiscard]] str label() const;
@@ -126,7 +145,7 @@ class DataChannel : public webrtc::DataChannelObserver {
   std::mutex mutex_;
 
   /// Opaque user data.
-  void* user_data{nullptr};
+  void* user_data_{nullptr};
 };
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/data_channel.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/data_channel.h
@@ -64,9 +64,9 @@ class DataChannel : public webrtc::DataChannelObserver {
   /// Callback fired when the data channel state changed.
   using StateCallback = Callback</*DataChannelState*/ int, int>;
 
-  DataChannel(PeerConnection* owner,
-              rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel,
-              mrsDataChannelInteropHandle interop_handle = nullptr) noexcept;
+  DataChannel(
+      PeerConnection* owner,
+      rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel) noexcept;
 
   /// Remove the data channel from its parent PeerConnection and close it.
   ~DataChannel() override;
@@ -94,10 +94,6 @@ class DataChannel : public webrtc::DataChannelObserver {
 
   [[nodiscard]] webrtc::DataChannelInterface* impl() const {
     return data_channel_.get();
-  }
-
-  mrsDataChannelInteropHandle GetInteropHandle() const noexcept {
-    return interop_handle_;
   }
 
   /// This is invoked automatically by PeerConnection::RemoveDataChannel().
@@ -129,8 +125,8 @@ class DataChannel : public webrtc::DataChannelObserver {
   StateCallback state_callback_ RTC_GUARDED_BY(mutex_);
   std::mutex mutex_;
 
-  /// Optional interop handle, if associated with an interop wrapper.
-  mrsDataChannelInteropHandle interop_handle_{};
+  /// Opaque user data.
+  void* user_data{nullptr};
 };
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/data_channel_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/data_channel_interop.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This is a precompiled header, it must be on its own, followed by a blank
+// line, to prevent clang-format from reordering it with other headers.
+#include "pch.h"
+
+#include "callback.h"
+#include "data_channel.h"
+#include "data_channel_interop.h"
+
+using namespace Microsoft::MixedReality::WebRTC;
+
+MRS_API void MRS_CALL
+mrsDataChannelSetUserData(mrsDataChannelHandle handle,
+                               void* user_data) noexcept {
+  if (auto data_channel = static_cast<DataChannel*>(handle)) {
+    data_channel->SetUserData(user_data);
+  }
+}
+
+MRS_API void* MRS_CALL
+mrsDataChannelGetUserData(mrsDataChannelHandle handle) noexcept {
+  if (auto data_channel = static_cast<DataChannel*>(handle)) {
+    return data_channel->GetUserData();
+  }
+  return nullptr;
+}
+
+void MRS_CALL mrsDataChannelRegisterCallbacks(
+    mrsDataChannelHandle handle,
+    const mrsDataChannelCallbacks* callbacks) noexcept {
+  if (auto data_channel = static_cast<DataChannel*>(handle)) {
+    data_channel->SetMessageCallback(Callback<const void*, const uint64_t>{
+        callbacks->message_callback, callbacks->message_user_data});
+    data_channel->SetBufferingCallback(
+        Callback<const uint64_t, const uint64_t, const uint64_t>{
+            callbacks->buffering_callback, callbacks->buffering_user_data});
+    data_channel->SetStateCallback(Callback<int, int>{
+        callbacks->state_callback, callbacks->state_user_data});
+  }
+}
+
+mrsResult MRS_CALL
+mrsDataChannelSendMessage(mrsDataChannelHandle dataChannelHandle,
+                          const void* data,
+                          uint64_t size) noexcept {
+  auto data_channel = static_cast<DataChannel*>(dataChannelHandle);
+  if (!data_channel) {
+    return Result::kInvalidNativeHandle;
+  }
+  return (data_channel->Send(data, (size_t)size) ? Result::kSuccess
+                                                 : Result::kUnknownError);
+}

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
@@ -558,154 +558,135 @@ mrsResult MRS_CALL mrsEnumVideoCaptureFormatsAsync(
 }
 mrsResult MRS_CALL
 mrsPeerConnectionCreate(const mrsPeerConnectionConfiguration* config,
-                        mrsPeerConnectionInteropHandle interop_handle,
-                        mrsPeerConnectionHandle* peerHandleOut) noexcept {
-  if (!peerHandleOut || !interop_handle) {
+                        mrsPeerConnectionHandle* peer_handle_out) noexcept {
+  if (!peer_handle_out) {
     return Result::kInvalidParameter;
   }
-  *peerHandleOut = nullptr;
+  *peer_handle_out = nullptr;
 
   // Create the new peer connection
-  auto result = PeerConnection::create(*config, interop_handle);
+  auto result = PeerConnection::create(*config);
   if (!result.ok()) {
     return result.error().result();
   }
-  *peerHandleOut = (mrsPeerConnectionHandle)result.value().release();
+  *peer_handle_out = (mrsPeerConnectionHandle)result.value().release();
   return Result::kSuccess;
 }
 
-mrsResult MRS_CALL mrsPeerConnectionRegisterInteropCallbacks(
-    mrsPeerConnectionHandle peerHandle,
-    mrsPeerConnectionInteropCallbacks* callbacks) noexcept {
-  if (!callbacks) {
-    return Result::kInvalidParameter;
-  }
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
-    return peer->RegisterInteropCallbacks(*callbacks);
-  }
-  return Result::kInvalidNativeHandle;
-}
-
 void MRS_CALL mrsPeerConnectionRegisterConnectedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionConnectedCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterConnectedCallback(Callback<>{callback, user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterLocalSdpReadytoSendCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionLocalSdpReadytoSendCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterLocalSdpReadytoSendCallback(
         Callback<const char*, const char*>{callback, user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterIceCandidateReadytoSendCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionIceCandidateReadytoSendCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterIceCandidateReadytoSendCallback(
         Callback<const char*, int, const char*>{callback, user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterIceStateChangedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionIceStateChangedCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterIceStateChangedCallback(
         Callback<mrsIceConnectionState>{callback, user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterRenegotiationNeededCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionRenegotiationNeededCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterRenegotiationNeededCallback(Callback<>{callback, user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterAudioTrackAddedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionAudioTrackAddedCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterAudioTrackAddedCallback(
-        Callback<mrsRemoteAudioTrackInteropHandle, mrsRemoteAudioTrackHandle,
-                 mrsTransceiverInteropHandle, mrsTransceiverHandle>{
-            callback, user_data});
+        Callback<mrsRemoteAudioTrackHandle, mrsTransceiverHandle>{callback,
+                                                                  user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterAudioTrackRemovedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionAudioTrackRemovedCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterAudioTrackRemovedCallback(
-        Callback<mrsRemoteAudioTrackInteropHandle, mrsRemoteAudioTrackHandle,
-                 mrsTransceiverInteropHandle, mrsTransceiverHandle>{
-            callback, user_data});
+        Callback<mrsRemoteAudioTrackHandle, mrsTransceiverHandle>{callback,
+                                                                  user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterVideoTrackAddedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionVideoTrackAddedCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterVideoTrackAddedCallback(
-        Callback<mrsRemoteVideoTrackInteropHandle, mrsRemoteVideoTrackHandle,
-                 mrsTransceiverInteropHandle, mrsTransceiverHandle>{
-            callback, user_data});
+        Callback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>{callback,
+                                                                  user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterVideoTrackRemovedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionVideoTrackRemovedCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterVideoTrackRemovedCallback(
-        Callback<mrsRemoteVideoTrackInteropHandle, mrsRemoteVideoTrackHandle,
-                 mrsTransceiverInteropHandle, mrsTransceiverHandle>{
-            callback, user_data});
+        Callback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>{callback,
+                                                                  user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterDataChannelAddedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionDataChannelAddedCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterDataChannelAddedCallback(
-        Callback<mrsDataChannelInteropHandle, mrsDataChannelHandle>{callback,
-                                                                    user_data});
+        Callback<mrsDataChannelHandle>{callback, user_data});
   }
 }
 
 void MRS_CALL mrsPeerConnectionRegisterDataChannelRemovedCallback(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionDataChannelRemovedCallback callback,
     void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterDataChannelRemovedCallback(
-        Callback<mrsDataChannelInteropHandle, mrsDataChannelHandle>{callback,
-                                                                    user_data});
+        Callback<mrsDataChannelHandle>{callback, user_data});
   }
 }
 
 mrsResult MRS_CALL mrsLocalAudioTrackCreateFromDevice(
-    const mrsLocalAudioTrackInitConfig* config,
+    const mrsLocalAudioTrackInitConfig* /*config*/,
     const char* track_name,
     mrsLocalAudioTrackHandle* track_handle_out) noexcept {
   if (IsStringNullOrEmpty(track_name)) {
@@ -742,8 +723,7 @@ mrsResult MRS_CALL mrsLocalAudioTrackCreateFromDevice(
 
   // Create the audio track wrapper
   RefPtr<LocalAudioTrack> track =
-      new LocalAudioTrack(std::move(global_factory), std::move(audio_track),
-                          config->track_interop_handle);
+      new LocalAudioTrack(std::move(global_factory), std::move(audio_track));
   *track_handle_out = track.release();
   return Result::kSuccess;
 }
@@ -820,26 +800,24 @@ mrsResult MRS_CALL mrsLocalVideoTrackCreateFromDevice(
 
   // Create the video track wrapper
   RefPtr<LocalVideoTrack> track =
-      new LocalVideoTrack(std::move(global_factory), std::move(video_track),
-                          config->track_interop_handle);
+      new LocalVideoTrack(std::move(global_factory), std::move(video_track));
   *track_handle_out = track.release();
   return Result::kSuccess;
 }
 
 mrsResult MRS_CALL mrsPeerConnectionAddDataChannel(
-    mrsPeerConnectionHandle peerHandle,
-    mrsDataChannelInteropHandle dataChannelInteropHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsDataChannelConfig config,
     mrsDataChannelCallbacks callbacks,
-    mrsDataChannelHandle* dataChannelHandleOut) noexcept
+    mrsDataChannelHandle* data_channel_handle_out) noexcept
 
 {
-  if (!dataChannelHandleOut || !dataChannelInteropHandle) {
+  if (!data_channel_handle_out) {
     return Result::kInvalidParameter;
   }
-  *dataChannelHandleOut = nullptr;
+  *data_channel_handle_out = nullptr;
 
-  auto peer = static_cast<PeerConnection*>(peerHandle);
+  auto peer = static_cast<PeerConnection*>(peer_handle);
   if (!peer) {
     return Result::kInvalidNativeHandle;
   }
@@ -847,8 +825,8 @@ mrsResult MRS_CALL mrsPeerConnectionAddDataChannel(
   const bool ordered = (config.flags & mrsDataChannelConfigFlags::kOrdered);
   const bool reliable = (config.flags & mrsDataChannelConfigFlags::kReliable);
   const std::string_view label = (config.label ? config.label : "");
-  ErrorOr<std::shared_ptr<DataChannel>> data_channel = peer->AddDataChannel(
-      config.id, label, ordered, reliable, dataChannelInteropHandle);
+  ErrorOr<std::shared_ptr<DataChannel>> data_channel =
+      peer->AddDataChannel(config.id, label, ordered, reliable);
   if (data_channel.ok()) {
     data_channel.value()->SetMessageCallback(DataChannel::MessageCallback{
         callbacks.message_callback, callbacks.message_user_data});
@@ -856,16 +834,16 @@ mrsResult MRS_CALL mrsPeerConnectionAddDataChannel(
         callbacks.buffering_callback, callbacks.buffering_user_data});
     data_channel.value()->SetStateCallback(DataChannel::StateCallback{
         callbacks.state_callback, callbacks.state_user_data});
-    *dataChannelHandleOut = data_channel.value().operator->();
+    *data_channel_handle_out = data_channel.value().operator->();
     return Result::kSuccess;
   }
   return data_channel.error().result();
 }
 
 mrsResult MRS_CALL mrsPeerConnectionRemoveDataChannel(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsDataChannelHandle dataChannelHandle) noexcept {
-  auto peer = static_cast<PeerConnection*>(peerHandle);
+  auto peer = static_cast<PeerConnection*>(peer_handle);
   if (!peer) {
     return Result::kInvalidNativeHandle;
   }
@@ -890,11 +868,11 @@ mrsDataChannelSendMessage(mrsDataChannelHandle dataChannelHandle,
 }
 
 mrsResult MRS_CALL
-mrsPeerConnectionAddIceCandidate(mrsPeerConnectionHandle peerHandle,
+mrsPeerConnectionAddIceCandidate(mrsPeerConnectionHandle peer_handle,
                                  const char* sdp,
                                  const int sdp_mline_index,
                                  const char* sdp_mid) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     return (peer->AddIceCandidate(sdp, sdp_mline_index, sdp_mid)
                 ? Result::kSuccess
                 : Result::kUnknownError);
@@ -903,16 +881,16 @@ mrsPeerConnectionAddIceCandidate(mrsPeerConnectionHandle peerHandle,
 }
 
 mrsResult MRS_CALL
-mrsPeerConnectionCreateOffer(mrsPeerConnectionHandle peerHandle) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+mrsPeerConnectionCreateOffer(mrsPeerConnectionHandle peer_handle) noexcept {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     return (peer->CreateOffer() ? Result::kSuccess : Result::kUnknownError);
   }
   return Result::kInvalidNativeHandle;
 }
 
 mrsResult MRS_CALL
-mrsPeerConnectionCreateAnswer(mrsPeerConnectionHandle peerHandle) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+mrsPeerConnectionCreateAnswer(mrsPeerConnectionHandle peer_handle) noexcept {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     return (peer->CreateAnswer() ? Result::kSuccess : Result::kUnknownError);
   }
   return Result::kInvalidNativeHandle;
@@ -940,12 +918,12 @@ mrsPeerConnectionSetBitrate(mrsPeerConnectionHandle peer_handle,
 }
 
 mrsResult MRS_CALL
-mrsPeerConnectionSetRemoteDescriptionAsync(mrsPeerConnectionHandle peerHandle,
+mrsPeerConnectionSetRemoteDescriptionAsync(mrsPeerConnectionHandle peer_handle,
                                            const char* type,
                                            const char* sdp,
                                            ActionCallback callback,
                                            void* user_data) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     return (peer->SetRemoteDescriptionAsync(type, sdp,
                                             Callback<>{callback, user_data})
                 ? Result::kSuccess
@@ -955,8 +933,8 @@ mrsPeerConnectionSetRemoteDescriptionAsync(mrsPeerConnectionHandle peerHandle,
 }
 
 mrsResult MRS_CALL
-mrsPeerConnectionClose(mrsPeerConnectionHandle peerHandle) noexcept {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+mrsPeerConnectionClose(mrsPeerConnectionHandle peer_handle) noexcept {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->Close();
     return Result::kSuccess;
   }
@@ -1056,10 +1034,10 @@ T& FindOrInsert(std::vector<std::pair<std::string, T>>& vec,
 }  // namespace
 
 mrsResult MRS_CALL mrsPeerConnectionGetSimpleStats(
-    mrsPeerConnectionHandle peerHandle,
+    mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionGetSimpleStatsCallback callback,
     void* user_data) {
-  if (auto peer = static_cast<PeerConnection*>(peerHandle)) {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     struct Collector : webrtc::RTCStatsCollectorCallback {
       Collector(mrsPeerConnectionGetSimpleStatsCallback callback,
                 void* user_data)

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/interop_api.cpp
@@ -627,8 +627,7 @@ void MRS_CALL mrsPeerConnectionRegisterAudioTrackAddedCallback(
     void* user_data) noexcept {
   if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterAudioTrackAddedCallback(
-        Callback<mrsRemoteAudioTrackHandle, mrsTransceiverHandle>{callback,
-                                                                  user_data});
+        Callback<const mrsRemoteAudioTrackAddedInfo*>{callback, user_data});
   }
 }
 
@@ -649,8 +648,7 @@ void MRS_CALL mrsPeerConnectionRegisterVideoTrackAddedCallback(
     void* user_data) noexcept {
   if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
     peer->RegisterVideoTrackAddedCallback(
-        Callback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>{callback,
-                                                                  user_data});
+        Callback<const mrsRemoteVideoTrackAddedInfo*>{callback, user_data});
   }
 }
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/local_video_track_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/local_video_track_interop.cpp
@@ -36,24 +36,22 @@ mrsLocalVideoTrackRemoveRef(mrsLocalVideoTrackHandle handle) noexcept {
 // mrsLocalVideoTrackCreateFromDevice -> interop_api.cpp
 
 mrsResult MRS_CALL mrsLocalVideoTrackCreateFromExternalSource(
-    mrsExternalVideoTrackSourceHandle source_handle,
     const mrsLocalVideoTrackFromExternalSourceInitConfig* config,
-    const char* track_name,
     mrsLocalVideoTrackHandle* track_handle_out) noexcept {
-  if (!track_handle_out) {
+  if (!config || !track_handle_out || !config->source_handle) {
     return Result::kInvalidParameter;
   }
   *track_handle_out = nullptr;
 
   auto track_source =
-      static_cast<detail::ExternalVideoTrackSourceImpl*>(source_handle);
+      static_cast<detail::ExternalVideoTrackSourceImpl*>(config->source_handle);
   if (!track_source) {
     return Result::kInvalidNativeHandle;
   }
 
   std::string track_name_str;
-  if (!IsStringNullOrEmpty(track_name)) {
-    track_name_str = track_name;
+  if (!IsStringNullOrEmpty(config->track_name)) {
+    track_name_str = config->track_name;
   } else {
     track_name_str = "external_track";
   }
@@ -75,8 +73,7 @@ mrsResult MRS_CALL mrsLocalVideoTrackCreateFromExternalSource(
 
   // Create the video track wrapper
   RefPtr<LocalVideoTrack> track =
-      new LocalVideoTrack(std::move(global_factory), std::move(video_track),
-                          config->track_interop_handle);
+      new LocalVideoTrack(std::move(global_factory), std::move(video_track));
   *track_handle_out = track.release();
   return Result::kSuccess;
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/peer_connection_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/peer_connection_interop.cpp
@@ -50,10 +50,9 @@ mrsPeerConnectionAddTransceiver(mrsPeerConnectionHandle peer_handle,
   }
   *handle = nullptr;
   if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
-    ErrorOr<RefPtr<Transceiver>> result = peer->AddTransceiver(*config);
+    ErrorOr<Transceiver*> result = peer->AddTransceiver(*config);
     if (result.ok()) {
-      auto transceiver = result.MoveValue();
-      *handle = transceiver->asHandle();
+      *handle = result.value()->GetHandle();
       return Result::kSuccess;
     }
     return result.error().result();

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/peer_connection_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/peer_connection_interop.cpp
@@ -31,6 +31,16 @@ mrsPeerConnectionRemoveRef(mrsPeerConnectionHandle handle) noexcept {
   }
 }
 
+void MRS_CALL mrsPeerConnectionRegisterTransceiverAddedCallback(
+    mrsPeerConnectionHandle peer_handle,
+    mrsPeerConnectionTransceiverAddedCallback callback,
+    void* user_data) noexcept {
+  if (auto peer = static_cast<PeerConnection*>(peer_handle)) {
+    peer->RegisterTransceiverAddedCallback(
+        Callback<const mrsTransceiverAddedInfo*>{callback, user_data});
+  }
+}
+
 void MRS_CALL mrsPeerConnectionRegisterIceGatheringStateChangedCallback(
     mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionIceGatheringStateChangedCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/peer_connection_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/peer_connection_interop.cpp
@@ -54,7 +54,6 @@ mrsPeerConnectionAddTransceiver(mrsPeerConnectionHandle peer_handle,
     if (result.ok()) {
       auto transceiver = result.MoveValue();
       *handle = transceiver->asHandle();
-      transceiver.release();  // handles now implicitly owns a reference
       return Result::kSuccess;
     }
     return result.error().result();

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/remote_audio_track_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/remote_audio_track_interop.cpp
@@ -10,6 +10,22 @@
 
 using namespace Microsoft::MixedReality::WebRTC;
 
+MRS_API void MRS_CALL
+mrsRemoteAudioTrackSetUserData(mrsRemoteAudioTrackHandle handle,
+                               void* user_data) noexcept {
+  if (auto track = static_cast<RemoteAudioTrack*>(handle)) {
+    track->SetUserData(user_data);
+  }
+}
+
+MRS_API void* MRS_CALL
+mrsRemoteAudioTrackGetUserData(mrsRemoteAudioTrackHandle handle) noexcept {
+  if (auto track = static_cast<RemoteAudioTrack*>(handle)) {
+    return track->GetUserData();
+  }
+  return nullptr;
+}
+
 void MRS_CALL
 mrsRemoteAudioTrackRegisterFrameCallback(mrsRemoteAudioTrackHandle trackHandle,
                                          mrsAudioFrameCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/remote_audio_track_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/remote_audio_track_interop.cpp
@@ -11,26 +11,6 @@
 using namespace Microsoft::MixedReality::WebRTC;
 
 void MRS_CALL
-mrsRemoteAudioTrackAddRef(mrsRemoteAudioTrackHandle handle) noexcept {
-  if (auto track = static_cast<RemoteAudioTrack*>(handle)) {
-    track->AddRef();
-  } else {
-    RTC_LOG(LS_WARNING)
-        << "Trying to add reference to NULL RemoteAudioTrack object.";
-  }
-}
-
-void MRS_CALL
-mrsRemoteAudioTrackRemoveRef(mrsRemoteAudioTrackHandle handle) noexcept {
-  if (auto track = static_cast<RemoteAudioTrack*>(handle)) {
-    track->RemoveRef();
-  } else {
-    RTC_LOG(LS_WARNING) << "Trying to remove reference from NULL "
-                           "RemoteAudioTrack object.";
-  }
-}
-
-void MRS_CALL
 mrsRemoteAudioTrackRegisterFrameCallback(mrsRemoteAudioTrackHandle trackHandle,
                                          mrsAudioFrameCallback callback,
                                          void* user_data) noexcept {

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/remote_video_track_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/remote_video_track_interop.cpp
@@ -10,26 +10,6 @@
 
 using namespace Microsoft::MixedReality::WebRTC;
 
-void MRS_CALL
-mrsRemoteVideoTrackAddRef(mrsRemoteVideoTrackHandle handle) noexcept {
-  if (auto track = static_cast<RemoteVideoTrack*>(handle)) {
-    track->AddRef();
-  } else {
-    RTC_LOG(LS_WARNING)
-        << "Trying to add reference to NULL RemoteVideoTrack object.";
-  }
-}
-
-void MRS_CALL
-mrsRemoteVideoTrackRemoveRef(mrsRemoteVideoTrackHandle handle) noexcept {
-  if (auto track = static_cast<RemoteVideoTrack*>(handle)) {
-    track->RemoveRef();
-  } else {
-    RTC_LOG(LS_WARNING) << "Trying to remove reference from NULL "
-                           "RemoteVideoTrack object.";
-  }
-}
-
 void MRS_CALL mrsRemoteVideoTrackRegisterI420AFrameCallback(
     mrsRemoteVideoTrackHandle trackHandle,
     mrsI420AVideoFrameCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/remote_video_track_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/remote_video_track_interop.cpp
@@ -10,6 +10,22 @@
 
 using namespace Microsoft::MixedReality::WebRTC;
 
+MRS_API void MRS_CALL
+mrsRemoteVideoTrackSetUserData(mrsRemoteVideoTrackHandle handle,
+                               void* user_data) noexcept {
+  if (auto track = static_cast<RemoteVideoTrack*>(handle)) {
+    track->SetUserData(user_data);
+  }
+}
+
+MRS_API void* MRS_CALL
+mrsRemoteVideoTrackGetUserData(mrsRemoteVideoTrackHandle handle) noexcept {
+  if (auto track = static_cast<RemoteVideoTrack*>(handle)) {
+    return track->GetUserData();
+  }
+  return nullptr;
+}
+
 void MRS_CALL mrsRemoteVideoTrackRegisterI420AFrameCallback(
     mrsRemoteVideoTrackHandle trackHandle,
     mrsI420AVideoFrameCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/transceiver_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/transceiver_interop.cpp
@@ -14,24 +14,6 @@
 
 using namespace Microsoft::MixedReality::WebRTC;
 
-void MRS_CALL mrsTransceiverAddRef(mrsTransceiverHandle handle) noexcept {
-  if (auto transceiver = static_cast<Transceiver*>(handle)) {
-    transceiver->AddRef();
-  } else {
-    RTC_LOG(LS_WARNING)
-        << "Trying to add reference to NULL Transceiver object.";
-  }
-}
-
-void MRS_CALL mrsTransceiverRemoveRef(mrsTransceiverHandle handle) noexcept {
-  if (auto transceiver = static_cast<Transceiver*>(handle)) {
-    transceiver->RemoveRef();
-  } else {
-    RTC_LOG(LS_WARNING)
-        << "Trying to remove reference from NULL Transceiver object.";
-  }
-}
-
 void MRS_CALL mrsTransceiverRegisterStateUpdatedCallback(
     mrsTransceiverHandle handle,
     mrsTransceiverStateUpdatedCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/transceiver_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/transceiver_interop.cpp
@@ -14,6 +14,21 @@
 
 using namespace Microsoft::MixedReality::WebRTC;
 
+MRS_API void MRS_CALL mrsTransceiverSetUserData(mrsTransceiverHandle handle,
+                                                void* user_data) noexcept {
+  if (auto transceiver = static_cast<Transceiver*>(handle)) {
+    transceiver->SetUserData(user_data);
+  }
+}
+
+MRS_API void* MRS_CALL
+mrsTransceiverGetUserData(mrsTransceiverHandle handle) noexcept {
+  if (auto transceiver = static_cast<Transceiver*>(handle)) {
+    return transceiver->GetUserData();
+  }
+  return nullptr;
+}
+
 void MRS_CALL mrsTransceiverRegisterStateUpdatedCallback(
     mrsTransceiverHandle handle,
     mrsTransceiverStateUpdatedCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_audio_track.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_audio_track.cpp
@@ -11,11 +11,9 @@ namespace Microsoft::MixedReality::WebRTC {
 
 LocalAudioTrack::LocalAudioTrack(
     RefPtr<GlobalFactory> global_factory,
-    rtc::scoped_refptr<webrtc::AudioTrackInterface> track,
-    mrsLocalAudioTrackInteropHandle interop_handle) noexcept
+    rtc::scoped_refptr<webrtc::AudioTrackInterface> track) noexcept
     : MediaTrack(std::move(global_factory), ObjectType::kLocalAudioTrack),
       track_(std::move(track)),
-      interop_handle_(interop_handle),
       track_name_(track_->id()) {
   RTC_CHECK(track_);
   kind_ = mrsTrackKind::kAudioTrack;
@@ -27,15 +25,13 @@ LocalAudioTrack::LocalAudioTrack(
     PeerConnection& owner,
     Transceiver* transceiver,
     rtc::scoped_refptr<webrtc::AudioTrackInterface> track,
-    rtc::scoped_refptr<webrtc::RtpSenderInterface> sender,
-    mrsLocalAudioTrackInteropHandle interop_handle) noexcept
+    rtc::scoped_refptr<webrtc::RtpSenderInterface> sender) noexcept
     : MediaTrack(std::move(global_factory),
                  ObjectType::kLocalAudioTrack,
                  owner),
       track_(std::move(track)),
       sender_(std::move(sender)),
       transceiver_(transceiver),
-      interop_handle_(interop_handle),
       track_name_(track_->id()) {
   RTC_CHECK(owner_);
   RTC_CHECK(transceiver_);

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_audio_track.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_audio_track.h
@@ -40,17 +40,17 @@ class Transceiver;
 class LocalAudioTrack : public AudioFrameObserver, public MediaTrack {
  public:
   /// Constructor for a track not added to any peer connection.
-  LocalAudioTrack(RefPtr<GlobalFactory> global_factory,
-                  rtc::scoped_refptr<webrtc::AudioTrackInterface> track,
-                  mrsLocalAudioTrackInteropHandle interop_handle) noexcept;
+  LocalAudioTrack(
+      RefPtr<GlobalFactory> global_factory,
+      rtc::scoped_refptr<webrtc::AudioTrackInterface> track) noexcept;
 
   /// Constructor for a track added to a peer connection.
-  LocalAudioTrack(RefPtr<GlobalFactory> global_factory,
-                  PeerConnection& owner,
-                  Transceiver* transceiver,
-                  rtc::scoped_refptr<webrtc::AudioTrackInterface> track,
-                  rtc::scoped_refptr<webrtc::RtpSenderInterface> sender,
-                  mrsLocalAudioTrackInteropHandle interop_handle) noexcept;
+  LocalAudioTrack(
+      RefPtr<GlobalFactory> global_factory,
+      PeerConnection& owner,
+      Transceiver* transceiver,
+      rtc::scoped_refptr<webrtc::AudioTrackInterface> track,
+      rtc::scoped_refptr<webrtc::RtpSenderInterface> sender) noexcept;
 
   ~LocalAudioTrack() override;
 
@@ -82,11 +82,6 @@ class LocalAudioTrack : public AudioFrameObserver, public MediaTrack {
     return impl();
   }
 
-  [[nodiscard]] mrsLocalAudioTrackInteropHandle GetInteropHandle() const
-      noexcept {
-    return interop_handle_;
-  }
-
   /// Internal callback on added to a peer connection to update the internal
   /// state of the object.
   void OnAddedToPeerConnection(
@@ -113,9 +108,6 @@ class LocalAudioTrack : public AudioFrameObserver, public MediaTrack {
   /// Weak back-pointer to the Transceiver this track is associated with, if
   /// any. This avoids a circular reference with the transceiver itself.
   Transceiver* transceiver_{nullptr};
-
-  /// Optional interop handle, if associated with an interop wrapper.
-  mrsLocalAudioTrackInteropHandle interop_handle_{};
 
   /// Cached track name, to avoid dispatching on signaling thread.
   const std::string track_name_;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_video_track.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_video_track.cpp
@@ -11,11 +11,9 @@ namespace Microsoft::MixedReality::WebRTC {
 
 LocalVideoTrack::LocalVideoTrack(
     RefPtr<GlobalFactory> global_factory,
-    rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
-    mrsLocalVideoTrackInteropHandle interop_handle) noexcept
+    rtc::scoped_refptr<webrtc::VideoTrackInterface> track) noexcept
     : MediaTrack(std::move(global_factory), ObjectType::kLocalVideoTrack),
       track_(std::move(track)),
-      interop_handle_(interop_handle),
       track_name_(track_->id()) {
   RTC_CHECK(track_);
   kind_ = mrsTrackKind::kVideoTrack;
@@ -29,15 +27,13 @@ LocalVideoTrack::LocalVideoTrack(
     PeerConnection& owner,
     Transceiver* transceiver,
     rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
-    rtc::scoped_refptr<webrtc::RtpSenderInterface> sender,
-    mrsLocalVideoTrackInteropHandle interop_handle) noexcept
+    rtc::scoped_refptr<webrtc::RtpSenderInterface> sender) noexcept
     : MediaTrack(std::move(global_factory),
                  ObjectType::kLocalVideoTrack,
                  owner),
       track_(std::move(track)),
       sender_(std::move(sender)),
       transceiver_(transceiver),
-      interop_handle_(interop_handle),
       track_name_(track_->id()) {
   RTC_CHECK(owner_);
   RTC_CHECK(transceiver_);

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_video_track.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/local_video_track.h
@@ -41,16 +41,14 @@ class LocalVideoTrack : public VideoFrameObserver, public MediaTrack {
  public:
   /// Constructor for a track not added to any peer connection.
   LocalVideoTrack(RefPtr<GlobalFactory> global_factory,
-                  rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
-                  mrsLocalVideoTrackInteropHandle interop_handle) noexcept;
+                  rtc::scoped_refptr<webrtc::VideoTrackInterface> track) noexcept;
 
   /// Constructor for a track added to a peer connection.
   LocalVideoTrack(RefPtr<GlobalFactory> global_factory,
                   PeerConnection& owner,
                   Transceiver* transceiver,
                   rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
-                  rtc::scoped_refptr<webrtc::RtpSenderInterface> sender,
-                  mrsLocalVideoTrackInteropHandle interop_handle) noexcept;
+                  rtc::scoped_refptr<webrtc::RtpSenderInterface> sender) noexcept;
 
   ~LocalVideoTrack() override;
 
@@ -82,11 +80,6 @@ class LocalVideoTrack : public VideoFrameObserver, public MediaTrack {
     return impl();
   }
 
-  [[nodiscard]] mrsLocalVideoTrackInteropHandle GetInteropHandle() const
-      noexcept {
-    return interop_handle_;
-  }
-
   /// Internal callback on added to a peer connection to update the internal
   /// state of the object.
   void OnAddedToPeerConnection(
@@ -113,9 +106,6 @@ class LocalVideoTrack : public VideoFrameObserver, public MediaTrack {
   /// Weak back-pointer to the Transceiver this track is associated with, if
   /// any. This avoids a circular reference with the transceiver itself.
   Transceiver* transceiver_{nullptr};
-
-  /// Optional interop handle, if associated with an interop wrapper.
-  mrsLocalVideoTrackInteropHandle interop_handle_{};
 
   /// Cached track name, to avoid dispatching on signaling thread.
   const std::string track_name_;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_audio_track.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_audio_track.cpp
@@ -14,15 +14,13 @@ RemoteAudioTrack::RemoteAudioTrack(
     PeerConnection& owner,
     Transceiver* transceiver,
     rtc::scoped_refptr<webrtc::AudioTrackInterface> track,
-    rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
-    mrsRemoteAudioTrackInteropHandle interop_handle) noexcept
+    rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) noexcept
     : MediaTrack(std::move(global_factory),
                  ObjectType::kRemoteAudioTrack,
                  owner),
       track_(std::move(track)),
       receiver_(std::move(receiver)),
       transceiver_(transceiver),
-      interop_handle_(interop_handle),
       track_name_(track_->id()) {
   RTC_CHECK(owner_);
   RTC_CHECK(track_);

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_audio_track.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_audio_track.h
@@ -57,6 +57,13 @@ class RemoteAudioTrack : public AudioFrameObserver, public MediaTrack {
   // Advanced use
   //
 
+  /// Get a handle to the remote audio track. This handle is valid until the
+  /// remote track is removed from the peer connection and destroyed, which is
+  /// signaled by the |TrackRemoved| event on the peer connection.
+  [[nodiscard]] constexpr mrsRemoteAudioTrackHandle GetHandle() const noexcept {
+    return (mrsRemoteAudioTrackHandle)this;
+  }
+
   [[nodiscard]] webrtc::AudioTrackInterface* impl() const;
   [[nodiscard]] webrtc::RtpReceiverInterface* receiver() const;
 
@@ -68,7 +75,6 @@ class RemoteAudioTrack : public AudioFrameObserver, public MediaTrack {
       const override {
     return impl();
   }
-
 
   // Automatically called - do not use.
   void OnTrackRemoved(PeerConnection& owner);

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_audio_track.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_audio_track.h
@@ -33,12 +33,12 @@ class Transceiver;
 /// connection. The local peer only has limited control over the track.
 class RemoteAudioTrack : public AudioFrameObserver, public MediaTrack {
  public:
-  RemoteAudioTrack(RefPtr<GlobalFactory> global_factory,
-                   PeerConnection& owner,
-                   Transceiver* transceiver,
-                   rtc::scoped_refptr<webrtc::AudioTrackInterface> track,
-                   rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
-                   mrsRemoteAudioTrackInteropHandle interop_handle) noexcept;
+  RemoteAudioTrack(
+      RefPtr<GlobalFactory> global_factory,
+      PeerConnection& owner,
+      Transceiver* transceiver,
+      rtc::scoped_refptr<webrtc::AudioTrackInterface> track,
+      rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) noexcept;
   ~RemoteAudioTrack() override;
 
   /// Get the name of the remote audio track.
@@ -69,10 +69,6 @@ class RemoteAudioTrack : public AudioFrameObserver, public MediaTrack {
     return impl();
   }
 
-  [[nodiscard]] mrsRemoteAudioTrackInteropHandle GetInteropHandle() const
-      noexcept {
-    return interop_handle_;
-  }
 
   // Automatically called - do not use.
   void OnTrackRemoved(PeerConnection& owner);
@@ -89,9 +85,6 @@ class RemoteAudioTrack : public AudioFrameObserver, public MediaTrack {
   /// Note that unlike local tracks, this is never NULL since the remote track
   /// gets destroyed when detached from the transceiver.
   Transceiver* transceiver_{nullptr};
-
-  /// Optional interop handle, if associated with an interop wrapper.
-  mrsRemoteAudioTrackInteropHandle interop_handle_{};
 
   /// Cached track name, to avoid dispatching on signaling thread.
   const std::string track_name_;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_video_track.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_video_track.cpp
@@ -14,15 +14,13 @@ RemoteVideoTrack::RemoteVideoTrack(
     PeerConnection& owner,
     Transceiver* transceiver,
     rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
-    rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
-    mrsRemoteVideoTrackInteropHandle interop_handle) noexcept
+    rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) noexcept
     : MediaTrack(std::move(global_factory),
                  ObjectType::kRemoteVideoTrack,
                  owner),
       track_(std::move(track)),
       receiver_(std::move(receiver)),
       transceiver_(transceiver),
-      interop_handle_(interop_handle),
       track_name_(track_->id()) {
   RTC_CHECK(owner_);
   RTC_CHECK(track_);

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_video_track.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_video_track.h
@@ -57,6 +57,13 @@ class RemoteVideoTrack : public VideoFrameObserver, public MediaTrack {
   // Advanced use
   //
 
+  /// Get a handle to the remote video track. This handle is valid until the
+  /// remote track is removed from the peer connection and destroyed, which is
+  /// signaled by the |TrackRemoved| event on the peer connection.
+  [[nodiscard]] constexpr mrsRemoteVideoTrackHandle GetHandle() const noexcept {
+    return (mrsRemoteVideoTrackHandle)this;
+  }
+
   [[nodiscard]] webrtc::VideoTrackInterface* impl() const;
   [[nodiscard]] webrtc::RtpReceiverInterface* receiver() const;
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_video_track.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/remote_video_track.h
@@ -33,12 +33,12 @@ class Transceiver;
 /// connection. The local peer only has limited control over the track.
 class RemoteVideoTrack : public VideoFrameObserver, public MediaTrack {
  public:
-  RemoteVideoTrack(RefPtr<GlobalFactory> global_factory,
-                   PeerConnection& owner,
-                   Transceiver* transceiver,
-                   rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
-                   rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
-                   mrsRemoteVideoTrackInteropHandle interop_handle) noexcept;
+  RemoteVideoTrack(
+      RefPtr<GlobalFactory> global_factory,
+      PeerConnection& owner,
+      Transceiver* transceiver,
+      rtc::scoped_refptr<webrtc::VideoTrackInterface> track,
+      rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) noexcept;
   ~RemoteVideoTrack() override;
 
   /// Get the name of the remote video track.
@@ -69,11 +69,6 @@ class RemoteVideoTrack : public VideoFrameObserver, public MediaTrack {
     return impl();
   }
 
-  [[nodiscard]] mrsRemoteVideoTrackInteropHandle GetInteropHandle() const
-      noexcept {
-    return interop_handle_;
-  }
-
   // Automatically called - do not use.
   void OnTrackRemoved(PeerConnection& owner);
 
@@ -89,9 +84,6 @@ class RemoteVideoTrack : public VideoFrameObserver, public MediaTrack {
   /// Note that unlike local tracks, this is never NULL since the remote track
   /// gets destroyed when detached from the transceiver.
   Transceiver* transceiver_{nullptr};
-
-  /// Optional interop handle, if associated with an interop wrapper.
-  mrsRemoteVideoTrackInteropHandle interop_handle_{};
 
   /// Cached track name, to avoid dispatching on signaling thread.
   const std::string track_name_;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/transceiver.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/transceiver.cpp
@@ -33,10 +33,9 @@ RefPtr<Transceiver> Transceiver::CreateForPlanB(
     PeerConnection& owner,
     int mline_index,
     std::string name,
-    Direction desired_direction,
-    mrsTransceiverHandle interop_handle) noexcept {
+    Direction desired_direction) noexcept {
   return new Transceiver(std::move(global_factory), kind, owner, mline_index,
-                         std::move(name), desired_direction, interop_handle);
+                         std::move(name), desired_direction);
 }
 
 RefPtr<Transceiver> Transceiver::CreateForUnifiedPlan(
@@ -46,11 +45,10 @@ RefPtr<Transceiver> Transceiver::CreateForUnifiedPlan(
     int mline_index,
     std::string name,
     rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver,
-    Direction desired_direction,
-    mrsTransceiverHandle interop_handle) noexcept {
+    Direction desired_direction) noexcept {
   return new Transceiver(std::move(global_factory), kind, owner, mline_index,
                          std::move(name), std::move(transceiver),
-                         desired_direction, interop_handle);
+                         desired_direction);
 }
 
 Transceiver::Transceiver(RefPtr<GlobalFactory> global_factory,
@@ -58,8 +56,7 @@ Transceiver::Transceiver(RefPtr<GlobalFactory> global_factory,
                          PeerConnection& owner,
                          int mline_index,
                          std::string name,
-                         Direction desired_direction,
-                         mrsTransceiverHandle interop_handle) noexcept
+                         Direction desired_direction) noexcept
     : TrackedObject(std::move(global_factory),
                     kind == MediaKind::kAudio ? ObjectType::kAudioTransceiver
                                               : ObjectType::kVideoTransceiver),
@@ -68,8 +65,7 @@ Transceiver::Transceiver(RefPtr<GlobalFactory> global_factory,
       mline_index_(mline_index),
       name_(std::move(name)),
       desired_direction_(desired_direction),
-      plan_b_(new PlanBEmulation),
-      interop_handle_(interop_handle) {
+      plan_b_(new PlanBEmulation) {
   RTC_CHECK(owner_);
   //< TODO
   // RTC_CHECK(owner.sdp_semantic == webrtc::SdpSemantics::kPlanB);
@@ -82,8 +78,7 @@ Transceiver::Transceiver(
     int mline_index,
     std::string name,
     rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver,
-    Direction desired_direction,
-    mrsTransceiverHandle interop_handle) noexcept
+    Direction desired_direction) noexcept
     : TrackedObject(std::move(global_factory),
                     kind == MediaKind::kAudio ? ObjectType::kAudioTransceiver
                                               : ObjectType::kVideoTransceiver),
@@ -92,8 +87,7 @@ Transceiver::Transceiver(
       mline_index_(mline_index),
       name_(std::move(name)),
       desired_direction_(desired_direction),
-      transceiver_(std::move(transceiver)),
-      interop_handle_(interop_handle) {
+      transceiver_(std::move(transceiver)) {
   RTC_CHECK(owner_);
   RTC_DCHECK(transceiver_);
   RTC_DCHECK(

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/transceiver.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/transceiver.h
@@ -40,8 +40,7 @@ class Transceiver : public TrackedObject {
       PeerConnection& owner,
       int mline_index,
       std::string name,
-      Direction desired_direction,
-      mrsTransceiverHandle interop_handle) noexcept;
+      Direction desired_direction) noexcept;
 
   /// Construct a Unified Plan transceiver wrapper referencing an actual WebRTC
   /// transceiver implementation object as defined in Unified Plan.
@@ -52,8 +51,7 @@ class Transceiver : public TrackedObject {
       int mline_index,
       std::string name,
       rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver,
-      Direction desired_direction,
-      mrsTransceiverHandle interop_handle) noexcept;
+      Direction desired_direction) noexcept;
 
   ~Transceiver() override;
 
@@ -168,11 +166,6 @@ class Transceiver : public TrackedObject {
   [[nodiscard]] rtc::scoped_refptr<webrtc::RtpTransceiverInterface> impl()
       const;
 
-  [[nodiscard]] constexpr mrsTransceiverInteropHandle GetInteropHandle() const
-      noexcept {
-    return interop_handle_;
-  }
-
   /// Synchronize the RTP sender with the desired direction when using Plan B.
   /// |needed| indicate whether an RTP sender is needed or not. |peer| is passed
   /// as argument for convenience, as |owner_| cannot access it. |media_kind| is
@@ -227,8 +220,7 @@ class Transceiver : public TrackedObject {
               PeerConnection& owner,
               int mline_index,
               std::string name,
-              Direction desired_direction,
-              mrsTransceiverHandle interop_handle) noexcept;
+              Direction desired_direction) noexcept;
 
   /// Construct a Unified Plan transceiver wrapper referencing an actual WebRTC
   /// transceiver implementation object as defined in Unified Plan.
@@ -238,8 +230,7 @@ class Transceiver : public TrackedObject {
               int mline_index,
               std::string name,
               rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver,
-              Direction desired_direction,
-              mrsTransceiverHandle interop_handle) noexcept;
+              Direction desired_direction) noexcept;
 
   Result SetLocalTrackImpl(RefPtr<MediaTrack> local_track) noexcept;
   Result SetRemoteTrackImpl(RefPtr<MediaTrack> remote_track) noexcept;
@@ -297,9 +288,6 @@ class Transceiver : public TrackedObject {
   StateUpdatedCallback state_updated_callback_ RTC_GUARDED_BY(cb_mutex_);
 
   std::mutex cb_mutex_;
-
-  /// Optional interop handle, if associated with an interop wrapper.
-  mrsTransceiverInteropHandle interop_handle_{};
 };
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/transceiver.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/transceiver.h
@@ -160,8 +160,12 @@ class Transceiver : public TrackedObject {
 
   /// Get a handle to the tranceiver. This is not virtual on purpose, as the API
   /// doesn't differentiate between audio and video transceivers, so any handle
-  /// would be cast back to a base class |Transceiver| pointer.
-  mrsTransceiverHandle asHandle() const { return (mrsTransceiverHandle)this; }
+  /// would be cast back to a base class |Transceiver| pointer. This handle is
+  /// valid until the transceiver is removed from the peer connection and
+  /// destroyed, which happens during |PeerConnection::Close()|.
+  [[nodiscard]] constexpr mrsTransceiverHandle GetHandle() const noexcept {
+    return (mrsTransceiverHandle)this;
+  }
 
   [[nodiscard]] rtc::scoped_refptr<webrtc::RtpTransceiverInterface> impl()
       const;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
@@ -1874,6 +1874,10 @@ void PeerConnection::GetStats(webrtc::RTCStatsCollectorCallback* callback) {
   ((PeerConnectionImpl*)this)->peer_->GetStats(callback);
 }
 
+void PeerConnection::InvokeRenegotiationNeeded() {
+  ((PeerConnectionImpl*)this)->OnRenegotiationNeeded();
+}
+
 PeerConnection::PeerConnection(RefPtr<GlobalFactory> global_factory)
     : TrackedObject(std::move(global_factory), ObjectType::kPeerConnection) {}
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -212,7 +212,7 @@ class PeerConnection : public TrackedObject {
   //
 
   /// Callback invoked when a transceiver is added to the peer connection.
-  using TransceiverAddedCallback = Callback<mrsTransceiverHandle>;
+  using TransceiverAddedCallback = Callback<const mrsTransceiverAddedInfo*>;
 
   /// Register a custom TransceiverAddedCallback invoked when a transceiver is
   /// is added to the peer connection. Only one callback can be registered at a

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -350,8 +350,9 @@ class PeerConnection : public TrackedObject {
   /// automatically by non-negotiated data channels; do not call manually.
   virtual void OnDataChannelAdded(const DataChannel& data_channel) noexcept = 0;
 
-  /// Internal use.
+  // Internal use.
   void GetStats(webrtc::RTCStatsCollectorCallback* callback);
+  void InvokeRenegotiationNeeded();
 
  protected:
   PeerConnection(RefPtr<GlobalFactory> global_factory);

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -71,8 +71,7 @@ class PeerConnection : public TrackedObject {
   /// Create a new PeerConnection based on the given |config|.
   /// This serves as the constructor for PeerConnection.
   static ErrorOr<RefPtr<PeerConnection>> create(
-      const mrsPeerConnectionConfiguration& config,
-      mrsPeerConnectionInteropHandle interop_handle);
+      const mrsPeerConnectionConfiguration& config);
 
   /// Set the name of the peer connection. This is a friendly name opaque to the
   /// implementation, used mainly for debugging and logging.
@@ -212,6 +211,15 @@ class PeerConnection : public TrackedObject {
   // Transceivers
   //
 
+  /// Callback invoked when a transceiver is added to the peer connection.
+  using TransceiverAddedCallback = Callback<mrsTransceiverHandle>;
+
+  /// Register a custom TransceiverAddedCallback invoked when a transceiver is
+  /// is added to the peer connection. Only one callback can be registered at a
+  /// time.
+  virtual void RegisterTransceiverAddedCallback(
+      TransceiverAddedCallback&& callback) noexcept = 0;
+
   /// Add a new audio or video transceiver to the peer connection.
   virtual ErrorOr<RefPtr<Transceiver>> AddTransceiver(
       const mrsTransceiverInitConfig& config) noexcept = 0;
@@ -222,10 +230,8 @@ class PeerConnection : public TrackedObject {
 
   /// Callback invoked when a remote video track is added to the peer
   /// connection.
-  using VideoTrackAddedCallback = Callback<mrsRemoteVideoTrackInteropHandle,
-                                           mrsRemoteVideoTrackHandle,
-                                           mrsTransceiverInteropHandle,
-                                           mrsTransceiverHandle>;
+  using VideoTrackAddedCallback =
+      Callback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>;
 
   /// Register a custom |VideoTrackAddedCallback| invoked when a remote video
   /// track is added to the peer connection. Only one callback can be registered
@@ -235,10 +241,8 @@ class PeerConnection : public TrackedObject {
 
   /// Callback invoked when a remote video track is removed from the peer
   /// connection.
-  using VideoTrackRemovedCallback = Callback<mrsRemoteVideoTrackInteropHandle,
-                                             mrsRemoteVideoTrackHandle,
-                                             mrsTransceiverInteropHandle,
-                                             mrsTransceiverHandle>;
+  using VideoTrackRemovedCallback =
+      Callback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>;
 
   /// Register a custom |VideoTrackRemovedCallback| invoked when a remote video
   /// track is removed from the peer connection. Only one callback can be
@@ -280,10 +284,8 @@ class PeerConnection : public TrackedObject {
 
   /// Callback invoked when a remote audio track is added to the peer
   /// connection.
-  using AudioTrackAddedCallback = Callback<mrsRemoteAudioTrackInteropHandle,
-                                           mrsRemoteAudioTrackHandle,
-                                           mrsTransceiverInteropHandle,
-                                           mrsTransceiverHandle>;
+  using AudioTrackAddedCallback =
+      Callback<mrsRemoteAudioTrackHandle, mrsTransceiverHandle>;
 
   /// Register a custom AudioTrackAddedCallback invoked when a remote audio
   /// track is is added to the peer connection. Only one callback can be
@@ -293,10 +295,8 @@ class PeerConnection : public TrackedObject {
 
   /// Callback invoked when a remote audio track is removed from the peer
   /// connection.
-  using AudioTrackRemovedCallback = Callback<mrsRemoteAudioTrackInteropHandle,
-                                             mrsRemoteAudioTrackHandle,
-                                             mrsTransceiverInteropHandle,
-                                             mrsTransceiverHandle>;
+  using AudioTrackRemovedCallback =
+      Callback<mrsRemoteAudioTrackHandle, mrsTransceiverHandle>;
 
   /// Register a custom AudioTrackRemovedCallback invoked when a remote audio
   /// track is removed from the peer connection. Only one callback can be
@@ -310,13 +310,11 @@ class PeerConnection : public TrackedObject {
 
   /// Callback invoked when a new data channel is received from the remote peer
   /// and added locally.
-  using DataChannelAddedCallback =
-      Callback<mrsDataChannelInteropHandle, mrsDataChannelHandle>;
+  using DataChannelAddedCallback = Callback<mrsDataChannelHandle>;
 
   /// Callback invoked when a data channel is removed from the remote peer and
   /// removed locally.
-  using DataChannelRemovedCallback =
-      Callback<mrsDataChannelInteropHandle, mrsDataChannelHandle>;
+  using DataChannelRemovedCallback = Callback<mrsDataChannelHandle>;
 
   /// Register a custom callback invoked when a new data channel is received
   /// from the remote peer and added locally. Only one callback can be
@@ -336,8 +334,7 @@ class PeerConnection : public TrackedObject {
       int id,
       std::string_view label,
       bool ordered,
-      bool reliable,
-      mrsDataChannelInteropHandle dataChannelInteropHandle) noexcept = 0;
+      bool reliable) noexcept = 0;
 
   /// Close a given data channel and remove it from the peer connection.
   /// This invokes the DataChannelRemoved callback.
@@ -354,16 +351,6 @@ class PeerConnection : public TrackedObject {
 
   /// Internal use.
   void GetStats(webrtc::RTCStatsCollectorCallback* callback);
-
-  //
-  // Advanced use
-  //
-
-  /// Register some interop callbacks to allow the native implementation to
-  /// interact with the interop layer. This is called automatically; do not call
-  /// manually.
-  virtual mrsResult RegisterInteropCallbacks(
-      const mrsPeerConnectionInteropCallbacks& callbacks) noexcept = 0;
 
  protected:
   PeerConnection(RefPtr<GlobalFactory> global_factory);

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -221,7 +221,9 @@ class PeerConnection : public TrackedObject {
       TransceiverAddedCallback&& callback) noexcept = 0;
 
   /// Add a new audio or video transceiver to the peer connection.
-  virtual ErrorOr<RefPtr<Transceiver>> AddTransceiver(
+  /// The transceiver is owned by the peer connection until it is closed with
+  /// |Close()|, and the pointer is valid until that time.
+  virtual ErrorOr<Transceiver*> AddTransceiver(
       const mrsTransceiverInitConfig& config) noexcept = 0;
 
   //

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -232,8 +232,7 @@ class PeerConnection : public TrackedObject {
 
   /// Callback invoked when a remote video track is added to the peer
   /// connection.
-  using VideoTrackAddedCallback =
-      Callback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>;
+  using VideoTrackAddedCallback = Callback<const mrsRemoteVideoTrackAddedInfo*>;
 
   /// Register a custom |VideoTrackAddedCallback| invoked when a remote video
   /// track is added to the peer connection. Only one callback can be registered
@@ -286,8 +285,7 @@ class PeerConnection : public TrackedObject {
 
   /// Callback invoked when a remote audio track is added to the peer
   /// connection.
-  using AudioTrackAddedCallback =
-      Callback<mrsRemoteAudioTrackHandle, mrsTransceiverHandle>;
+  using AudioTrackAddedCallback = Callback<const mrsRemoteAudioTrackAddedInfo*>;
 
   /// Register a custom AudioTrackAddedCallback invoked when a remote audio
   /// track is is added to the peer connection. Only one callback can be

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.h
@@ -8,6 +8,7 @@
 #include "data_channel.h"
 #include "media/transceiver.h"
 #include "mrs_errors.h"
+#include "peer_connection_interop.h"
 #include "refptr.h"
 #include "tracked_object.h"
 #include "video_frame_observer.h"
@@ -310,7 +311,7 @@ class PeerConnection : public TrackedObject {
 
   /// Callback invoked when a new data channel is received from the remote peer
   /// and added locally.
-  using DataChannelAddedCallback = Callback<mrsDataChannelHandle>;
+  using DataChannelAddedCallback = Callback<const mrsDataChannelAddedInfo*>;
 
   /// Callback invoked when a data channel is removed from the remote peer and
   /// removed locally.

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/tracked_object.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/tracked_object.h
@@ -48,9 +48,18 @@ class TrackedObject : public RefCountedBase {
   /// limitation.
   virtual std::string GetName() const = 0;
 
+  [[nodiscard]] constexpr void* GetUserData() const noexcept {
+    return user_data_;
+  }
+
+  constexpr void SetUserData(void* user_data) noexcept {
+    user_data_ = user_data;
+  }
+
  protected:
   RefPtr<GlobalFactory> global_factory_;
   const ObjectType object_type_;
+  void* user_data_{nullptr};
 };
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj
@@ -118,6 +118,7 @@
   <ItemGroup>
     <ClInclude Include="../pch.h" />
     <ClInclude Include="..\..\include\audio_frame.h" />
+    <ClInclude Include="..\..\include\data_channel_interop.h" />
     <ClInclude Include="..\..\include\export.h" />
     <ClInclude Include="..\..\include\external_video_track_source_interop.h" />
     <ClInclude Include="..\..\include\interop_api.h" />

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj.filters
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/uwp/Microsoft.MixedReality.WebRTC.Native.UWP.vcxproj.filters
@@ -183,6 +183,9 @@
     <ClInclude Include="..\utils.h">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\data_channel_interop.h">
+      <Filter>include</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="../../docs/design.md" />

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj
@@ -124,6 +124,7 @@
   <ItemGroup>
     <ClInclude Include="../pch.h" />
     <ClInclude Include="..\..\include\audio_frame.h" />
+    <ClInclude Include="..\..\include\data_channel_interop.h" />
     <ClInclude Include="..\..\include\export.h" />
     <ClInclude Include="..\..\include\external_video_track_source_interop.h" />
     <ClInclude Include="..\..\include\interop_api.h" />
@@ -165,6 +166,7 @@
     </ClCompile>
     <ClCompile Include="..\audio_frame_observer.cpp" />
     <ClCompile Include="..\data_channel.cpp" />
+    <ClCompile Include="..\interop\data_channel_interop.cpp" />
     <ClCompile Include="..\interop\external_video_track_source_interop.cpp" />
     <ClCompile Include="..\interop\global_factory.cpp" />
     <ClCompile Include="..\interop\interop_api.cpp" />

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj.filters
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/win32/Microsoft.MixedReality.WebRTC.Native.Win32.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="..\audio_frame_observer.cpp">
       <Filter>src\media</Filter>
     </ClCompile>
+    <ClCompile Include="..\interop\data_channel_interop.cpp">
+      <Filter>src\interop</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\media\external_video_track_source.h">
@@ -181,6 +184,9 @@
       <Filter>include</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\export.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\data_channel_interop.h">
       <Filter>include</Filter>
     </ClInclude>
   </ItemGroup>

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/audio_track_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/audio_track_tests.cpp
@@ -235,7 +235,6 @@ TEST_P(AudioTrackTests, Simple) {
 
   // Clean-up
   mrsRemoteAudioTrackRegisterFrameCallback(audio_track2, nullptr, nullptr);
-  mrsRemoteAudioTrackRemoveRef(audio_track2);
   mrsLocalAudioTrackRemoveRef(audio_track1);
 }
 
@@ -372,7 +371,6 @@ TEST_P(AudioTrackTests, Muted) {
 
   // Clean-up
   mrsRemoteAudioTrackRegisterFrameCallback(audio_track2, nullptr, nullptr);
-  mrsRemoteAudioTrackRemoveRef(audio_track2);
   mrsLocalAudioTrackRemoveRef(audio_track1);
 }
 

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/audio_track_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/audio_track_tests.cpp
@@ -106,6 +106,13 @@ TEST_P(AudioTrackTests, Simple) {
           mrsTransceiverHandle transceiver_handle) {
         audio_track2 = track_handle;
         audio_transceiver2 = transceiver_handle;
+        // Test user data here
+        {
+          ASSERT_EQ(nullptr, mrsRemoteAudioTrackGetUserData(audio_track2));
+          mrsRemoteAudioTrackSetUserData(audio_track2, audio_transceiver2);
+          ASSERT_EQ(audio_transceiver2,
+                    mrsRemoteAudioTrackGetUserData(audio_track2));
+        }
         track_added2_ev.Set();
       };
   mrsPeerConnectionRegisterAudioTrackAddedCallback(pair.pc2(),

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/audio_track_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/audio_track_tests.cpp
@@ -24,7 +24,7 @@ namespace {
 
 // PeerConnectionAudioTrackAddedCallback
 using AudioTrackAddedCallback =
-    InteropCallback<mrsRemoteAudioTrackHandle, mrsTransceiverHandle>;
+    InteropCallback<const mrsRemoteAudioTrackAddedInfo*>;
 
 // PeerConnectionAudioFrameCallback
 using AudioFrameCallback = InteropCallback<const AudioFrame&>;
@@ -101,11 +101,10 @@ TEST_P(AudioTrackTests, Simple) {
   mrsRemoteAudioTrackHandle audio_track2{};
   Event track_added2_ev;
   AudioTrackAddedCallback track_added2_cb =
-      [&audio_track2, &audio_transceiver2, &track_added2_ev](
-          mrsRemoteAudioTrackHandle track_handle,
-          mrsTransceiverHandle transceiver_handle) {
-        audio_track2 = track_handle;
-        audio_transceiver2 = transceiver_handle;
+      [&audio_track2, &audio_transceiver2,
+       &track_added2_ev](const mrsRemoteAudioTrackAddedInfo* info) {
+        audio_track2 = info->track_handle;
+        audio_transceiver2 = info->audio_transceiver_handle;
         // Test user data here
         {
           ASSERT_EQ(nullptr, mrsRemoteAudioTrackGetUserData(audio_track2));
@@ -256,11 +255,10 @@ TEST_P(AudioTrackTests, Muted) {
   mrsRemoteAudioTrackHandle audio_track2{};
   Event track_added2_ev;
   AudioTrackAddedCallback track_added2_cb =
-      [&audio_track2, &audio_transceiver2, &track_added2_ev](
-          mrsRemoteAudioTrackHandle track_handle,
-          mrsTransceiverHandle transceiver_handle) {
-        audio_track2 = track_handle;
-        audio_transceiver2 = transceiver_handle;
+      [&audio_track2, &audio_transceiver2,
+       &track_added2_ev](const mrsRemoteAudioTrackAddedInfo* info) {
+        audio_track2 = info->track_handle;
+        audio_transceiver2 = info->audio_transceiver_handle;
         track_added2_ev.Set();
       };
   mrsPeerConnectionRegisterAudioTrackAddedCallback(pair.pc2(),

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/data_channel_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/data_channel_tests.cpp
@@ -18,13 +18,15 @@ using DataAddedCallback = InteropCallback<const mrsDataChannelAddedInfo*>;
 
 void MRS_CALL StaticMessageCallback(void* user_data,
                                     const void* data,
-                                    const uint64_t size) {
+                                    const uint64_t size) noexcept {
   auto func = *static_cast<std::function<void(const void*, const uint64_t)>*>(
       user_data);
   func(data, size);
 }
 
-void MRS_CALL StaticStateCallback(void* user_data, int32_t state, int32_t id) {
+void MRS_CALL StaticStateCallback(void* user_data,
+                                  int32_t state,
+                                  int32_t id) noexcept {
   auto func = *static_cast<std::function<void(int32_t, int32_t)>*>(user_data);
   func(state, id);
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/external_video_track_source_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/external_video_track_source_tests.cpp
@@ -118,7 +118,7 @@ void ValidateQuadTestFrame(const void* data,
 
 // PeerConnectionVideoTrackAddedCallback
 using VideoTrackAddedCallback =
-    InteropCallback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>;
+    InteropCallback<const mrsRemoteVideoTrackAddedInfo*>;
 
 // mrsArgb32VideoFrameCallback
 using Argb32VideoFrameCallback = InteropCallback<const mrsArgb32VideoFrame&>;
@@ -141,11 +141,10 @@ TEST_P(ExternalVideoTrackSourceTests, Simple) {
   mrsTransceiverHandle transceiver_handle2{};
   Event track_added2_ev;
   VideoTrackAddedCallback track_added2_cb =
-      [&track_handle2, &transceiver_handle2, &track_added2_ev](
-          mrsRemoteVideoTrackHandle track_handle,
-          mrsTransceiverHandle transceiver_handle) {
-        track_handle2 = track_handle;
-        transceiver_handle2 = transceiver_handle;
+      [&track_handle2, &transceiver_handle2,
+       &track_added2_ev](const mrsRemoteVideoTrackAddedInfo* info) {
+        track_handle2 = info->track_handle;
+        transceiver_handle2 = info->audio_transceiver_handle;
         track_added2_ev.Set();
       };
   mrsPeerConnectionRegisterVideoTrackAddedCallback(pair.pc2(),

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/external_video_track_source_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/external_video_track_source_tests.cpp
@@ -118,10 +118,7 @@ void ValidateQuadTestFrame(const void* data,
 
 // PeerConnectionVideoTrackAddedCallback
 using VideoTrackAddedCallback =
-    InteropCallback<mrsRemoteVideoTrackInteropHandle,
-                    mrsRemoteVideoTrackHandle,
-                    mrsTransceiverInteropHandle,
-                    mrsTransceiverHandle>;
+    InteropCallback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>;
 
 // mrsArgb32VideoFrameCallback
 using Argb32VideoFrameCallback = InteropCallback<const mrsArgb32VideoFrame&>;
@@ -145,9 +142,7 @@ TEST_P(ExternalVideoTrackSourceTests, Simple) {
   Event track_added2_ev;
   VideoTrackAddedCallback track_added2_cb =
       [&track_handle2, &transceiver_handle2, &track_added2_ev](
-          mrsRemoteVideoTrackInteropHandle /*interop_handle*/,
           mrsRemoteVideoTrackHandle track_handle,
-          mrsTransceiverInteropHandle /*interop_handle*/,
           mrsTransceiverHandle transceiver_handle) {
         track_handle2 = track_handle;
         transceiver_handle2 = transceiver_handle;
@@ -168,9 +163,10 @@ TEST_P(ExternalVideoTrackSourceTests, Simple) {
   mrsLocalVideoTrackHandle track_handle1{};
   {
     mrsLocalVideoTrackFromExternalSourceInitConfig source_config{};
-    ASSERT_EQ(mrsResult::kSuccess,
-              mrsLocalVideoTrackCreateFromExternalSource(
-                  source_handle1, &source_config, "gen_track", &track_handle1));
+    source_config.source_handle = source_handle1;
+    source_config.track_name = "gen_track";
+    ASSERT_EQ(mrsResult::kSuccess, mrsLocalVideoTrackCreateFromExternalSource(
+                                       &source_config, &track_handle1));
     ASSERT_NE(nullptr, track_handle1);
     ASSERT_NE(mrsBool::kFalse, mrsLocalVideoTrackIsEnabled(track_handle1));
   }
@@ -221,9 +217,7 @@ TEST_P(ExternalVideoTrackSourceTests, Simple) {
   mrsRemoteVideoTrackRegisterArgb32FrameCallback(track_handle2, nullptr,
                                                  nullptr);
   mrsRemoteVideoTrackRemoveRef(track_handle2);
-  mrsTransceiverRemoveRef(transceiver_handle2);
   mrsLocalVideoTrackRemoveRef(track_handle1);
-  mrsTransceiverRemoveRef(transceiver_handle1);
   mrsExternalVideoTrackSourceShutdown(source_handle1);
   mrsExternalVideoTrackSourceRemoveRef(source_handle1);
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/external_video_track_source_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/external_video_track_source_tests.cpp
@@ -216,7 +216,6 @@ TEST_P(ExternalVideoTrackSourceTests, Simple) {
   // Clean-up
   mrsRemoteVideoTrackRegisterArgb32FrameCallback(track_handle2, nullptr,
                                                  nullptr);
-  mrsRemoteVideoTrackRemoveRef(track_handle2);
   mrsLocalVideoTrackRemoveRef(track_handle1);
   mrsExternalVideoTrackSourceShutdown(source_handle1);
   mrsExternalVideoTrackSourceRemoveRef(source_handle1);

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_test_helpers.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/peer_connection_test_helpers.h
@@ -146,23 +146,17 @@ class PCRaii {
   /// connection from being established.
   PCRaii() {
     mrsPeerConnectionConfiguration config{};
-    mrsPeerConnectionInteropHandle interop_handle = (void*)0x1;
-    create(config, interop_handle);
+    create(config);
   }
   /// Create a peer connection with a specific configuration.
-  PCRaii(const mrsPeerConnectionConfiguration& config,
-         mrsPeerConnectionInteropHandle interop_handle = (void*)0x1) {
-    create(config, interop_handle);
-  }
+  PCRaii(const mrsPeerConnectionConfiguration& config) { create(config); }
   ~PCRaii() { mrsPeerConnectionRemoveRef(handle_); }
   mrsPeerConnectionHandle handle() const { return handle_; }
 
  protected:
   mrsPeerConnectionHandle handle_{};
-  void create(const mrsPeerConnectionConfiguration& config,
-              mrsPeerConnectionInteropHandle interop_handle) {
-    ASSERT_EQ(mrsResult::kSuccess,
-              mrsPeerConnectionCreate(&config, interop_handle, &handle_));
+  void create(const mrsPeerConnectionConfiguration& config) {
+    ASSERT_EQ(mrsResult::kSuccess, mrsPeerConnectionCreate(&config, &handle_));
     ASSERT_NE(nullptr, handle_);
   }
 };
@@ -237,17 +231,6 @@ class LocalPeerPairRaii {
   LocalPeerPairRaii(const mrsPeerConnectionConfiguration& config)
       : pc1_(config),
         pc2_(config),
-        sdp1_cb_(pc1()),
-        sdp2_cb_(pc2()),
-        ice1_cb_(pc1()),
-        ice2_cb_(pc2()) {
-    setup();
-  }
-  LocalPeerPairRaii(const mrsPeerConnectionConfiguration& config,
-                    mrsPeerConnectionInteropHandle h1,
-                    mrsPeerConnectionInteropHandle h2)
-      : pc1_(config, h1),
-        pc2_(config, h2),
         sdp1_cb_(pc1()),
         sdp2_cb_(pc2()),
         ice1_cb_(pc1()),

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/simple_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/simple_interop.cpp
@@ -13,21 +13,6 @@ void ForceTestFailure() {
 
 }  // namespace
 
-void SimpleInterop::Register(mrsPeerConnectionHandle pc) noexcept {
-  mrsPeerConnectionInteropCallbacks interop{};
-  interop.remote_audio_track_create_object = &RemoteAudioTrackCreateStatic;
-  interop.remote_video_track_create_object = &RemoteVideoTrackCreateStatic;
-  interop.data_channel_create_object = &DataChannelCreateStatic;
-  ASSERT_EQ(Result::kSuccess,
-            mrsPeerConnectionRegisterInteropCallbacks(pc, &interop));
-}
-
-void SimpleInterop::Unregister(mrsPeerConnectionHandle pc) noexcept {
-  mrsPeerConnectionInteropCallbacks interop{};
-  ASSERT_EQ(Result::kSuccess,
-            mrsPeerConnectionRegisterInteropCallbacks(pc, &interop));
-}
-
 void* SimpleInterop::CreateObject(ObjectType type) noexcept {
   const uint32_t id = free_id_.fetch_add(1);
   try {
@@ -73,54 +58,4 @@ bool SimpleInterop::ObjectExists(ObjectType type, void* obj) noexcept {
     ForceTestFailure();
   }
   return false;
-}
-
-mrsRemoteAudioTrackInteropHandle SimpleInterop::RemoteAudioTrackCreate(
-    mrsPeerConnectionInteropHandle parent,
-    const mrsRemoteAudioTrackConfig& /*config*/) noexcept {
-  EXPECT_TRUE(ObjectExists(ObjectType::kPeerConnection, parent));
-  return CreateObject(ObjectType::kRemoteAudioTrack);
-}
-
-mrsRemoteVideoTrackInteropHandle SimpleInterop::RemoteVideoTrackCreate(
-    mrsPeerConnectionInteropHandle parent,
-    const mrsRemoteVideoTrackConfig& /*config*/) noexcept {
-  EXPECT_TRUE(ObjectExists(ObjectType::kPeerConnection, parent));
-  return CreateObject(ObjectType::kRemoteVideoTrack);
-}
-
-mrsDataChannelInteropHandle SimpleInterop::DataChannelCreate(
-    mrsPeerConnectionInteropHandle parent,
-    const mrsDataChannelConfig& /*config*/,
-    mrsDataChannelCallbacks* /*callbacks*/) noexcept {
-  EXPECT_TRUE(ObjectExists(ObjectType::kPeerConnection, parent));
-  return CreateObject(ObjectType::kDataChannel);
-}
-
-mrsRemoteAudioTrackInteropHandle MRS_CALL
-SimpleInterop::RemoteAudioTrackCreateStatic(
-    mrsPeerConnectionInteropHandle parent,
-    const mrsRemoteAudioTrackConfig& config) noexcept {
-  auto parent_handle = (Handle*)parent;
-  EXPECT_NE(nullptr, parent_handle);
-  return parent_handle->interop_->RemoteAudioTrackCreate(parent, config);
-}
-
-mrsRemoteVideoTrackInteropHandle MRS_CALL
-SimpleInterop::RemoteVideoTrackCreateStatic(
-    mrsPeerConnectionInteropHandle parent,
-    const mrsRemoteVideoTrackConfig& config) noexcept {
-  auto parent_handle = (Handle*)parent;
-  EXPECT_NE(nullptr, parent_handle);
-  return parent_handle->interop_->RemoteVideoTrackCreate(parent, config);
-}
-
-mrsDataChannelInteropHandle MRS_CALL SimpleInterop::DataChannelCreateStatic(
-    mrsPeerConnectionInteropHandle parent,
-    const mrsDataChannelConfig& config,
-    mrsDataChannelCallbacks* callbacks) noexcept {
-  auto parent_handle = (Handle*)parent;
-  EXPECT_NE(nullptr, parent_handle);
-  EXPECT_NE(nullptr, callbacks);
-  return parent_handle->interop_->DataChannelCreate(parent, config, callbacks);
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/simple_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/simple_interop.h
@@ -23,34 +23,9 @@ class SimpleInterop {
     uint32_t id_;
   };
 
-  void Register(mrsPeerConnectionHandle pc) noexcept;
-  void Unregister(mrsPeerConnectionHandle pc) noexcept;
-
   void* CreateObject(ObjectType type) noexcept;
   void DestroyObject(void* obj) noexcept;
   bool ObjectExists(ObjectType type, void* obj) noexcept;
-
-  mrsRemoteAudioTrackInteropHandle RemoteAudioTrackCreate(
-      mrsPeerConnectionInteropHandle parent,
-      const mrsRemoteAudioTrackConfig& config) noexcept;
-  mrsRemoteVideoTrackInteropHandle RemoteVideoTrackCreate(
-      mrsPeerConnectionInteropHandle parent,
-      const mrsRemoteVideoTrackConfig& config) noexcept;
-  mrsDataChannelInteropHandle DataChannelCreate(
-      mrsPeerConnectionInteropHandle parent,
-      const mrsDataChannelConfig& config,
-      mrsDataChannelCallbacks* callbacks) noexcept;
-
-  static mrsRemoteAudioTrackInteropHandle MRS_CALL RemoteAudioTrackCreateStatic(
-      mrsPeerConnectionInteropHandle parent,
-      const mrsRemoteAudioTrackConfig& config) noexcept;
-  static mrsRemoteVideoTrackInteropHandle MRS_CALL RemoteVideoTrackCreateStatic(
-      mrsPeerConnectionInteropHandle parent,
-      const mrsRemoteVideoTrackConfig& config) noexcept;
-  static mrsDataChannelInteropHandle MRS_CALL
-  DataChannelCreateStatic(mrsPeerConnectionInteropHandle parent,
-                          const mrsDataChannelConfig& config,
-                          mrsDataChannelCallbacks* callbacks) noexcept;
 
   std::mutex objects_map_mutex_;
   std::unordered_map<void*, std::unique_ptr<Handle>> objects_map_;

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/transceiver_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/transceiver_tests.cpp
@@ -474,6 +474,23 @@ TYPED_TEST_P(TransceiverTests, SetLocalTrack_InvalidHandle) {
   MediaTrait<TypeParam::MediaType>::Test_SetLocalTrack_InvalidHandle();
 }
 
+TYPED_TEST_P(TransceiverTests, UserData) {
+  using Media = MediaTrait<TypeParam::MediaType>;
+  mrsPeerConnectionConfiguration pc_config{};
+  pc_config.sdp_semantic = TypeParam::kSdpSemantic;
+  LocalPeerPairRaii pair(pc_config);
+  mrsTransceiverHandle transceiver_handle1{};
+  mrsTransceiverInitConfig transceiver_config{};
+  transceiver_config.media_kind = TypeParam::kMediaKind;
+  ASSERT_EQ(Result::kSuccess,
+            mrsPeerConnectionAddTransceiver(pair.pc1(), &transceiver_config,
+                                            &transceiver_handle1));
+  ASSERT_NE(nullptr, transceiver_handle1);
+  ASSERT_EQ(nullptr, mrsTransceiverGetUserData(transceiver_handle1));
+  mrsTransceiverSetUserData(transceiver_handle1, this);
+  ASSERT_EQ(this, mrsTransceiverGetUserData(transceiver_handle1));
+}
+
 // Note: All tests must be listed in this macro
 REGISTER_TYPED_TEST_CASE_P(TransceiverTests,
                            InvalidName,
@@ -481,7 +498,8 @@ REGISTER_TYPED_TEST_CASE_P(TransceiverTests,
                            SetDirection_InvalidHandle,
                            SetLocalTrack_InvalidHandle,
                            SetLocalTrackSendRecv,
-                           SetLocalTrackRecvOnly);
+                           SetLocalTrackRecvOnly,
+                           UserData);
 
 using TestTypes = ::testing::Types<TestParams<AudioTest, SdpPlanB>,
                                    TestParams<AudioTest, SdpUnifiedPlan>,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/video_track_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/video_track_tests.cpp
@@ -174,7 +174,6 @@ TEST_P(VideoTrackTests, Simple) {
   // Clean-up
   mrsRemoteVideoTrackRegisterI420AFrameCallback(track_handle2, nullptr,
                                                 nullptr);
-  mrsRemoteVideoTrackRemoveRef(track_handle2);
   mrsLocalVideoTrackRemoveRef(track_handle1);
 }
 
@@ -271,7 +270,6 @@ TEST_P(VideoTrackTests, Muted) {
   // Clean-up
   mrsRemoteVideoTrackRegisterI420AFrameCallback(track_handle2, nullptr,
                                                 nullptr);
-  mrsRemoteVideoTrackRemoveRef(track_handle2);
   mrsLocalVideoTrackRemoveRef(track_handle1);
 }
 
@@ -445,7 +443,6 @@ TEST_P(VideoTrackTests, Multi) {
   for (auto&& track : tracks) {
     mrsRemoteVideoTrackRegisterI420AFrameCallback(track.remote_handle, nullptr,
                                                   nullptr);
-    mrsRemoteVideoTrackRemoveRef(track.remote_handle);
     mrsLocalVideoTrackRemoveRef(track.local_handle);
   }
   mrsExternalVideoTrackSourceRemoveRef(source_handle1);
@@ -548,7 +545,6 @@ TEST_P(VideoTrackTests, ExternalI420) {
   mrsRemoteVideoTrackRegisterI420AFrameCallback(track_handle2, nullptr,
                                                 nullptr);
   mrsLocalVideoTrackRemoveRef(track_handle1);
-  mrsRemoteVideoTrackRemoveRef(track_handle2);
   mrsExternalVideoTrackSourceShutdown(source_handle1);
   mrsExternalVideoTrackSourceRemoveRef(source_handle1);
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/video_track_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/video_track_tests.cpp
@@ -312,6 +312,8 @@ TEST_F(VideoTrackTests, DeviceIdInvalid) {
   ASSERT_EQ(nullptr, track_handle);
 }
 
+#endif  // MRSW_EXCLUDE_DEVICE_TESTS
+
 TEST_P(VideoTrackTests, Multi) {
   SimpleInterop simple_interop1;
   SimpleInterop simple_interop2;
@@ -464,6 +466,13 @@ TEST_P(VideoTrackTests, ExternalI420) {
           mrsTransceiverHandle transceiver_handle) {
         track_handle2 = track_handle;
         transceiver_handle2 = transceiver_handle;
+        // Test user data here
+        {
+          ASSERT_EQ(nullptr, mrsRemoteVideoTrackGetUserData(track_handle2));
+          mrsRemoteVideoTrackSetUserData(track_handle2, transceiver_handle2);
+          ASSERT_EQ(transceiver_handle2,
+                    mrsRemoteVideoTrackGetUserData(track_handle2));
+        }
         track_added2_ev.Set();
       };
   mrsPeerConnectionRegisterVideoTrackAddedCallback(pair.pc2(),
@@ -548,5 +557,3 @@ TEST_P(VideoTrackTests, ExternalI420) {
   mrsExternalVideoTrackSourceShutdown(source_handle1);
   mrsExternalVideoTrackSourceRemoveRef(source_handle1);
 }
-
-#endif  // MRSW_EXCLUDE_DEVICE_TESTS

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/video_track_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/video_track_tests.cpp
@@ -22,7 +22,7 @@ class VideoTrackTests : public TestUtils::TestBase,
 
 // PeerConnectionVideoTrackAddedCallback
 using VideoTrackAddedCallback =
-    InteropCallback<mrsRemoteVideoTrackHandle, mrsTransceiverHandle>;
+    InteropCallback<const mrsRemoteVideoTrackAddedInfo*>;
 
 // PeerConnectionI420VideoFrameCallback
 using I420VideoFrameCallback = InteropCallback<const I420AVideoFrame&>;
@@ -53,11 +53,10 @@ TEST_P(VideoTrackTests, Simple) {
   mrsTransceiverHandle transceiver_handle2{};
   Event track_added2_ev;
   VideoTrackAddedCallback track_added2_cb =
-      [&track_handle2, &transceiver_handle2, &track_added2_ev](
-          mrsRemoteVideoTrackHandle track_handle,
-          mrsTransceiverHandle transceiver_handle) {
-        track_handle2 = track_handle;
-        transceiver_handle2 = transceiver_handle;
+      [&track_handle2, &transceiver_handle2,
+       &track_added2_ev](const mrsRemoteVideoTrackAddedInfo* info) {
+        track_handle2 = info->track_handle;
+        transceiver_handle2 = info->audio_transceiver_handle;
         track_added2_ev.Set();
       };
   mrsPeerConnectionRegisterVideoTrackAddedCallback(pair.pc2(),
@@ -188,11 +187,10 @@ TEST_P(VideoTrackTests, Muted) {
   mrsTransceiverHandle transceiver_handle2{};
   Event track_added2_ev;
   VideoTrackAddedCallback track_added2_cb =
-      [&track_handle2, &transceiver_handle2, &track_added2_ev](
-          mrsRemoteVideoTrackHandle track_handle,
-          mrsTransceiverHandle transceiver_handle) {
-        track_handle2 = track_handle;
-        transceiver_handle2 = transceiver_handle;
+      [&track_handle2, &transceiver_handle2,
+       &track_added2_ev](const mrsRemoteVideoTrackAddedInfo* info) {
+        track_handle2 = info->track_handle;
+        transceiver_handle2 = info->audio_transceiver_handle;
         track_added2_ev.Set();
       };
   mrsPeerConnectionRegisterVideoTrackAddedCallback(pair.pc2(),
@@ -344,13 +342,12 @@ TEST_P(VideoTrackTests, Multi) {
   Semaphore track_added2_sem;
   std::atomic_int32_t track_id{0};
   VideoTrackAddedCallback track_added2_cb =
-      [&track_added2_sem, &track_id, &tracks, kNumTracks](
-          mrsRemoteVideoTrackHandle track_handle,
-          mrsTransceiverHandle transceiver_handle) {
+      [&track_added2_sem, &track_id, &tracks,
+       kNumTracks](const mrsRemoteVideoTrackAddedInfo* info) {
         int id = track_id.fetch_add(1);
         ASSERT_LT(id, kNumTracks);
-        tracks[id].remote_handle = track_handle;
-        tracks[id].remote_transceiver_handle = transceiver_handle;
+        tracks[id].remote_handle = info->track_handle;
+        tracks[id].remote_transceiver_handle = info->audio_transceiver_handle;
         track_added2_sem.Release();
       };
   mrsPeerConnectionRegisterVideoTrackAddedCallback(pair.pc2(),
@@ -461,11 +458,10 @@ TEST_P(VideoTrackTests, ExternalI420) {
   mrsTransceiverHandle transceiver_handle2{};
   Event track_added2_ev;
   VideoTrackAddedCallback track_added2_cb =
-      [&track_handle2, &transceiver_handle2, &track_added2_ev](
-          mrsRemoteVideoTrackHandle track_handle,
-          mrsTransceiverHandle transceiver_handle) {
-        track_handle2 = track_handle;
-        transceiver_handle2 = transceiver_handle;
+      [&track_handle2, &transceiver_handle2,
+       &track_added2_ev](const mrsRemoteVideoTrackAddedInfo* info) {
+        track_handle2 = info->track_handle;
+        transceiver_handle2 = info->audio_transceiver_handle;
         // Test user data here
         {
           ASSERT_EQ(nullptr, mrsRemoteVideoTrackGetUserData(track_handle2));


### PR DESCRIPTION
Refactor the "interop handle" concept into a opaque "user data" storage on each implementation object, to disambiguate from native handles to those implementation objects.

This changes the creation steps of objects owned by the peer connection (transceivers, remote tracks, data channels), which are now created internally then notify the user of their existence via "added" callbacks. At this point any interop wrapper layer (like the C# library) can create wrapper objects associated with those native implementation ones, and optionally store any data in them via the "user data" storage, for example storing a raw pointer to the wrapper object.

This change also simplify as a result the lifecycle of those objects by making their handles pure C-style handles with a definite start/end lifetime, removing any reference count manipulation via handles and the risk to leak references.

Bug: #207