### PR TITLE
Remove Signaler use from PeerConnection

### DIFF
--- a/examples/TestAppUwp/MainPage.xaml.cs
+++ b/examples/TestAppUwp/MainPage.xaml.cs
@@ -891,9 +891,9 @@ namespace TestAppUwp
 
                     case NodeDssSignaler.Message.WireMessageType.Ice:
                         // TODO - This is NodeDSS-specific
-                        // this "parts" protocol is defined above, in OnIceCandiateReadyToSend listener
+                        // this "parts" protocol is defined above, in OnIceCandidateReadyToSend listener
                         var parts = message.Data.Split(new string[] { message.IceDataSeparator }, StringSplitOptions.RemoveEmptyEntries);
-                        // Note the inverted arguments; candidate is last here, but first in OnIceCandiateReadyToSend
+                        // Note the inverted arguments; candidate is last here, but first in OnIceCandidateReadyToSend
                         _peerConnection.AddIceCandidate(parts[2], int.Parse(parts[1]), parts[0]);
                         break;
 

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Examples/VideoChatDemo/VideoChatDemo.prefab
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Examples/VideoChatDemo/VideoChatDemo.prefab
@@ -410,7 +410,6 @@ MonoBehaviour:
   AutoInitializeOnStart: 1
   AutoCreateOfferOnRenegotiationNeeded: 1
   AutoLogErrorsToUnityConsole: 1
-  Signaler: {fileID: 8734329137356271696}
   IceServers:
   - Type: 1
     Uri: stun.l.google.com:19302
@@ -438,6 +437,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6f59b5937dc35994c87e058b9edfe08a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  PeerConnection: {fileID: 114452439610826054}
   AutoLogErrors: 1
   LocalPeerId: 
   RemotePeerId: 
@@ -877,6 +877,9 @@ MonoBehaviour:
   VideoStreamStopped:
     m_PersistentCalls:
       m_Calls: []
+  WebcamDevice:
+    id: 
+    name: 
   EnableMixedRealityCapture: 1
   EnableMRCRecordingIndicator: 1
   FormatMode: 0

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/NodeDssSignaler.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/NodeDssSignaler.cs
@@ -286,9 +286,9 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                         break;
 
                     case NodeDssMessage.Type.Ice:
-                        // this "parts" protocol is defined above, in OnIceCandiateReadyToSend listener
+                        // this "parts" protocol is defined above, in OnIceCandidateReadyToSend listener
                         var parts = msg.Data.Split(new string[] { msg.IceDataSeparator }, StringSplitOptions.RemoveEmptyEntries);
-                        // Note the inverted arguments; candidate is last here, but first in OnIceCandiateReadyToSend
+                        // Note the inverted arguments; candidate is last here, but first in OnIceCandidateReadyToSend
                         _nativePeer.AddIceCandidate(parts[2], int.Parse(parts[1]), parts[0]);
                         break;
 

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/Signaler.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/Signaler.cs
@@ -152,7 +152,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             _nativePeer = PeerConnection.Peer;
 
             // Register handlers for the SDP events
-            _nativePeer.IceCandidateReadytoSend += OnIceCandiateReadyToSend_Listener;
+            _nativePeer.IceCandidateReadytoSend += OnIceCandidateReadyToSend_Listener;
             _nativePeer.LocalSdpReadytoSend += OnLocalSdpReadyToSend_Listener;
         }
 
@@ -164,13 +164,13 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         public void OnPeerUninitializing()
         {
             // Unregister handlers for the SDP events
-            //_nativePeer.IceCandidateReadytoSend -= OnIceCandiateReadyToSend_Listener;
+            //_nativePeer.IceCandidateReadytoSend -= OnIceCandidateReadyToSend_Listener;
             //_nativePeer.LocalSdpReadytoSend -= OnLocalSdpReadyToSend_Listener;
         }
 
-        private void OnIceCandiateReadyToSend_Listener(string candidate, int sdpMlineIndex, string sdpMid)
+        private void OnIceCandidateReadyToSend_Listener(string candidate, int sdpMlineIndex, string sdpMid)
         {
-            _mainThreadWorkQueue.Enqueue(() => OnIceCandiateReadyToSend(candidate, sdpMlineIndex, sdpMid));
+            _mainThreadWorkQueue.Enqueue(() => OnIceCandidateReadyToSend(candidate, sdpMlineIndex, sdpMid));
         }
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// <param name="candidate"></param>
         /// <param name="sdpMlineIndex"></param>
         /// <param name="sdpMid"></param>
-        protected virtual void OnIceCandiateReadyToSend(string candidate, int sdpMlineIndex, string sdpMid)
+        protected virtual void OnIceCandidateReadyToSend(string candidate, int sdpMlineIndex, string sdpMid)
         {
             var message = new IceMessage(sdpMid, sdpMlineIndex, candidate);
             SendMessageAsync(message);


### PR DESCRIPTION
- Remove any mention of Signaler in PeerConnection.
- Remove the node-dss specific message type from the Signaler abstract
  base class, and move it to the specific NodeDssSignaler
  implementation.

Note that currently Signaler encapsulates messages into a Message type,
which is then re-encapsulated into a different NodeDssMessage type by
the NodeDssSignaler. This looks redundant, but there are 2 reasons for
this:
- NodeDssSignaler needs a specific message type that serializes to JSON
  with specific field names, to be compatible with the node-dss
  protocol.
- The Signaler.Message type will eventually move into the C# library API
  and be transparent to the user (#188).

Bug: #172