### PR TITLE
Fix DataChannelCreateObjectCallback signature

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/Interop/DataChannelInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/DataChannelInterop.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         #region Native callbacks
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
-        public delegate IntPtr CreateObjectDelegate(IntPtr peer, CreateConfig config,
+        public delegate IntPtr CreateObjectDelegate(IntPtr peer, ref CreateConfig config,
             out Callbacks callbacks);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         }
 
         [MonoPInvokeCallback(typeof(CreateObjectDelegate))]
-        public static IntPtr DataChannelCreateObjectCallback(IntPtr peer, CreateConfig config,
+        public static IntPtr DataChannelCreateObjectCallback(IntPtr peer, ref CreateConfig config,
             out Callbacks callbacks)
         {
             var peerWrapper = Utils.ToWrapper<PeerConnection>(peer);


### PR DESCRIPTION
ref structs are not implicitly passed by ref, at least not in IL2CPP.