### PR TITLE
Fix marshaling of data channel create config

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/interop_api.h
@@ -83,9 +83,15 @@ using mrsLocalVideoTrackInteropHandle = void*;
 using mrsDataChannelInteropHandle = void*;
 
 /// Callback to create an interop wrapper for a data channel.
+///
+/// The |config| parameter is passed by value to facilitate interop with C#, as
+/// the struct contains a string which would otherwise not be marshaled
+/// correctly.
+///
+/// The |callbacks| struct is filled by the callee with callbacks to register.
 using mrsDataChannelCreateObjectCallback = mrsDataChannelInteropHandle(
     MRS_CALL*)(mrsPeerConnectionInteropHandle parent,
-               const mrsDataChannelConfig& config,
+               mrsDataChannelConfig config,
                mrsDataChannelCallbacks* callbacks);
 
 //
@@ -585,9 +591,9 @@ inline uint32_t operator&(mrsDataChannelConfigFlags a,
 }
 
 struct mrsDataChannelConfig {
-  int32_t id = -1;      // -1 for auto; >=0 for negotiated
-  const char* label{};  // optional; can be null or empty string
+  int32_t id = -1;  // -1 for auto; >=0 for negotiated
   mrsDataChannelConfigFlags flags{};
+  const char* label{};  // optional; can be null or empty string
 };
 
 struct mrsDataChannelCallbacks {

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/peer_connection.cpp
@@ -1081,7 +1081,7 @@ void PeerConnectionImpl::OnDataChannel(
 
   // Read the data channel config
   std::string label = impl->label();
-  mrsDataChannelConfig config;
+  mrsDataChannelConfig config{};
   config.id = impl->id();
   config.label = label.c_str();
   if (impl->ordered()) {

--- a/libs/Microsoft.MixedReality.WebRTC.Native/test/data_channel_tests.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/test/data_channel_tests.cpp
@@ -17,7 +17,7 @@ const mrsDataChannelInteropHandle kFakeInteropDataChannelHandle = (void*)0x2;
 
 mrsDataChannelInteropHandle MRS_CALL
 FakeIterop_DataChannelCreate(mrsPeerConnectionInteropHandle /*parent*/,
-                             const mrsDataChannelConfig& /*config*/,
+                             mrsDataChannelConfig /*config*/,
                              mrsDataChannelCallbacks* /*callbacks*/) noexcept {
   return kFakeInteropDataChannelHandle;
 }


### PR DESCRIPTION
Ensure that reverse P/Invoke struct containing a string type is passed
by value and not by reference, to ensure proper marshaling.

This essentially reverts f1b3328e and 43272b8d5, and actually fix the
C++ callsites instead to pass by value again.

Validated on:
- Desktop x64 Debug & Release (native tests)
- UWP x64 Debug & Release (TestAppUWP)
- UWP ARM Debug & Release (Unity deploy to HL2 via IL2CPP)

Note that this will go away with the multi-track refactor (#152).
