### PR TITLE
Fix duplicate media line index by exposing real mid

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Native/include/transceiver_interop.h
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/include/transceiver_interop.h
@@ -21,6 +21,14 @@ MRS_API void MRS_CALL mrsTransceiverSetUserData(mrsTransceiverHandle handle,
 MRS_API void* MRS_CALL
 mrsTransceiverGetUserData(mrsTransceiverHandle handle) noexcept;
 
+using mrsTransceiverAssociatedCallback = void(MRS_CALL*)(void* user_data,
+                                                         int mlineIndex);
+
+MRS_API void MRS_CALL mrsTransceiverRegisterAssociatedCallback(
+    mrsTransceiverHandle handle,
+    mrsTransceiverAssociatedCallback callback,
+    void* user_data) noexcept;
+
 using mrsTransceiverStateUpdatedCallback =
     void(MRS_CALL*)(void* user_data,
                     mrsTransceiverStateUpdatedReason reason,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/transceiver_interop.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/interop/transceiver_interop.cpp
@@ -29,6 +29,16 @@ mrsTransceiverGetUserData(mrsTransceiverHandle handle) noexcept {
   return nullptr;
 }
 
+void MRS_CALL mrsTransceiverRegisterAssociatedCallback(
+    mrsTransceiverHandle handle,
+    mrsTransceiverAssociatedCallback callback,
+    void* user_data) noexcept {
+  if (auto transceiver = static_cast<Transceiver*>(handle)) {
+    transceiver->RegisterAssociatedCallback(
+        Transceiver::AssociatedCallback{callback, user_data});
+  }
+}
+
 void MRS_CALL mrsTransceiverRegisterStateUpdatedCallback(
     mrsTransceiverHandle handle,
     mrsTransceiverStateUpdatedCallback callback,

--- a/libs/Microsoft.MixedReality.WebRTC.Native/src/media/transceiver.cpp
+++ b/libs/Microsoft.MixedReality.WebRTC.Native/src/media/transceiver.cpp
@@ -459,6 +459,18 @@ void Transceiver::SetTrackPlanB(webrtc::MediaStreamTrackInterface* new_track) {
   }
 }
 
+void Transceiver::OnAssociated(int mline_index) {
+  assert(mline_index >= 0);
+  // Transceiver recycling is not used, to transceivers can only be associated
+  // once, from their initial non-associated state.
+  assert(mline_index_ < 0);
+  mline_index_ = mline_index;
+  auto lock = std::scoped_lock{cb_mutex_};
+  if (auto cb = associated_callback_) {
+    cb(mline_index);
+  }
+}
+
 void Transceiver::OnSessionDescUpdated(bool remote, bool forced) {
   // Parse state to check for changes
   bool changed = false;

--- a/libs/Microsoft.MixedReality.WebRTC/Microsoft.MixedReality.WebRTC.csproj
+++ b/libs/Microsoft.MixedReality.WebRTC/Microsoft.MixedReality.WebRTC.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <!-- This needs to go first, before Microsoft.Common.props is imported  -->
   <PropertyGroup>

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -2118,29 +2118,6 @@ namespace Microsoft.MixedReality.WebRTC
         }
 
         /// <summary>
-        /// Insert the given transceiver into the <see cref="Transceivers"/> list at the index
-        /// corresponding to its <see cref="Transceiver.MlineIndex"/>.
-        /// </summary>
-        /// <param name="transceiver">Transceiver object to insert.</param>
-        internal void InsertTransceiverNoLock(Transceiver transceiver)
-        {
-            int mlineIndex = transceiver.MlineIndex;
-            if (mlineIndex >= Transceivers.Count)
-            {
-                while (mlineIndex >= Transceivers.Count + 1)
-                {
-                    Transceivers.Add(null);
-                }
-                Transceivers.Add(transceiver);
-            }
-            else
-            {
-                Debug.Assert(Transceivers[mlineIndex] == null);
-                Transceivers[mlineIndex] = transceiver;
-            }
-        }
-
-        /// <summary>
         /// Callback on transceiver created for the peer connection, irrelevant of whether
         /// it has tracks or not. This is called both when created from the managed side or
         /// from the native side.
@@ -2150,7 +2127,7 @@ namespace Microsoft.MixedReality.WebRTC
         {
             lock (_tracksLock)
             {
-                InsertTransceiverNoLock(tr);
+                Transceivers.Add(tr);
             }
             TransceiverAdded?.Invoke(tr);
         }

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -666,13 +666,32 @@ namespace Microsoft.MixedReality.WebRTC
         public bool IsConnected { get; private set; } = false;
 
         /// <summary>
-        /// Collection of transceivers for the peer conneciton.
-        /// Transceivers are present in the list in order of their media line index
-        /// (<see cref="Transceiver.MlineIndex"/>). Once a transceiver is added to the
-        /// peer connection, it cannot be removed, but its tracks can be changed.
-        /// This requires some renegotiation.
+        /// Collection of transceivers for the peer connection. Once a transceiver is added
+        /// to the peer connection, it cannot be removed, but its tracks can be changed.
+        /// Adding a transceiver or changing its direction require some new session negotiation.
         /// </summary>
         public List<Transceiver> Transceivers { get; } = new List<Transceiver>();
+
+        /// <summary>
+        /// Collection of transceivers which have already been associated with a media line.
+        ///
+        /// A transceiver is associated with a media line when a local or remote offer is applied
+        /// to the peer connection, respectively during <see cref="CreateOffer"/> and
+        /// <see cref="SetRemoteDescriptionAsync(string, string)"/>.
+        /// </summary>
+        public IEnumerable<Transceiver> AssociatedTransceivers
+        {
+            get
+            {
+                foreach (var tr in Transceivers)
+                {
+                    if (tr.MlineIndex >= 0)
+                    {
+                        yield return tr;
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Collection of local audio tracks attached to the peer connection.


### PR DESCRIPTION
Fix duplicate media line index occurring when both peers create a transceiver before an offer by exposing the real `mid` attribute of the JSEP session as it appears in the SDP message. This allows better insight into the actual state of the transceivers.

Practically this changes a few things:
- The `Transceiver.MlineIndex` property may be invalid (negative) when the transceiver is not yet associated with a media line. Once an offer associates it, a new `Transceiver.Associated` event is raised and the property takes the actual value of the `mid` SDP attribute.
- Corollary of the above, the media line index of the transceivers of the `PeerConnection.Transceivers` array do not form anymore a contiguous sequence of indices [0..N], since data channels also consume a media line, and non-associated transceivers have a negative media line index.
- Corollary of the above, the `Transceiver.MlineIndex` property is not anymore the index into the `PeerConnection.Transceivers` array.

This change also fix an issue where "holes" appeared in the transceivers numbering due to data channels also consuming media lines yet not having any transceiver.