### PR TITLE
Add IAudioTrack and IVideoTrack interfaces

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/IAudioTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/IAudioTrack.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.MixedReality.WebRTC
+{
+    /// <summary>
+    /// Interface for audio tracks, whether local or remote.
+    /// </summary>
+    public interface IAudioTrack
+    {
+        /// <summary>
+        /// Event that occurs when a new audio frame is available from the track, either
+        /// because the track produced it locally (<see cref="LocalAudioTrack"/>) or because
+        /// it received it from the remote peer (<see cref="RemoteAudioTrack"/>).
+        /// </summary>
+        /// <seealso cref="LocalAudioTrack"/>
+        /// <seealso cref="RemoteAudioTrack"/>
+        event AudioFrameDelegate AudioFrameReady;
+
+        /// <summary>
+        /// Enabled status of the track. If enabled, produces audio frames as expected. If
+        /// disabled, produces silence instead.
+        /// </summary>
+        bool Enabled { get; }
+    }
+}

--- a/libs/Microsoft.MixedReality.WebRTC/IVideoTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/IVideoTrack.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.MixedReality.WebRTC
+{
+    /// <summary>
+    /// Interface for video tracks, whether local or remote.
+    /// </summary>
+    public interface IVideoTrack
+    {
+        /// <summary>
+        /// Event that occurs when a new video frame is available from the track, either
+        /// because the track produced it locally (<see cref="LocalVideoTrack"/>) or because
+        /// it received it from the remote peer (<see cref="RemoteVideoTrack"/>).
+        /// 
+        /// The frame is delivered as an I420A-encoded video frame.
+        /// </summary>
+        /// <seealso cref="LocalVideoTrack"/>
+        /// <seealso cref="RemoteVideoTrack"/>
+        event I420AVideoFrameDelegate I420AVideoFrameReady;
+
+        /// <summary>
+        /// Event that occurs when a new video frame is available from the track, either
+        /// because the track produced it locally (<see cref="LocalVideoTrack"/>) or because
+        /// it received it from the remote peer (<see cref="RemoteVideoTrack"/>).
+        /// 
+        /// The frame is delivered as an ARGB32-encoded video frame.
+        /// </summary>
+        /// <seealso cref="LocalVideoTrack"/>
+        /// <seealso cref="RemoteVideoTrack"/>
+        event Argb32VideoFrameDelegate Argb32VideoFrameReady;
+
+        /// <summary>
+        /// Enabled status of the track. If enabled, produces video frames as expected. If
+        /// disabled, produces black frames instead.
+        /// </summary>
+        bool Enabled { get; }
+    }
+}

--- a/libs/Microsoft.MixedReality.WebRTC/LocalAudioTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/LocalAudioTrack.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// Audio track sending to the remote peer audio frames originating from
     /// a local track source (local microphone or other audio recording device).
     /// </summary>
-    public class LocalAudioTrack : MediaTrack, IDisposable
+    public class LocalAudioTrack : MediaTrack, IAudioTrack, IDisposable
     {
         /// <summary>
         /// Enabled status of the track. If enabled, send local audio frames to the remote peer as

--- a/libs/Microsoft.MixedReality.WebRTC/LocalVideoTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/LocalVideoTrack.cs
@@ -159,7 +159,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// Video track sending to the remote peer video frames originating from
     /// a local track source.
     /// </summary>
-    public class LocalVideoTrack : MediaTrack, IDisposable
+    public class LocalVideoTrack : MediaTrack, IVideoTrack, IDisposable
     {
         /// <summary>
         /// External source for this video track, or <c>null</c> if the source is some

--- a/libs/Microsoft.MixedReality.WebRTC/RemoteAudioTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/RemoteAudioTrack.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// <summary>
     /// Audio track receiving audio frames from the remote peer.
     /// </summary>
-    public class RemoteAudioTrack : MediaTrack
+    public class RemoteAudioTrack : MediaTrack, IAudioTrack
     {
         /// <summary>
         /// Enabled status of the track. If enabled, receives audio frames from the remote peer as

--- a/libs/Microsoft.MixedReality.WebRTC/RemoteVideoTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/RemoteVideoTrack.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// <summary>
     /// Video track receiving video frames from the remote peer.
     /// </summary>
-    public class RemoteVideoTrack : MediaTrack
+    public class RemoteVideoTrack : MediaTrack, IVideoTrack
     {
         /// <summary>
         /// Enabled status of the track. If enabled, receives video frames from the remote peer as


### PR DESCRIPTION
Add some interfaces for audio and video tracks to allow manipulating
them generically, irrelevant of whether the track is local or remote.
This allows applications to register some frame callback and check the
enabled status of the track, which are common properties to all audio
and video tracks.