### PR TITLE
Fix license of TestReceiveAV/Program.cs

### DIFF
--- a/examples/TestReceiveAV/Program.cs
+++ b/examples/TestReceiveAV/Program.cs
@@ -1,5 +1,19 @@
-// Copyright (c) Microsoft Corporation.
+//-----------------------------------------------------------------------------
+// Filename: Program.cs
+//
+// Description: Demonstration of receiving and rendering video from a WebRTC
+// enabled browser using https://github.com/microsoft/MixedReality-WebRTC 
+// dotnet library.
+//
+// Author(s):
+// Aaron Clauson (aaron@sipsorcery.com)
+// 
+// History:
+// 07 Feb 2020	Aaron Clauson	Created, Dublin, Ireland.
+//
+// License: 
 // Licensed under the MIT License.
+//-----------------------------------------------------------------------------
 
 using System;
 using System.Drawing;


### PR DESCRIPTION
Restore the original author's license header and remove the Microsoft
license header to reflect the fact that this file was contributed by a
third-party author and not written by a Microsoft employee, in
accordance with the official Microsoft copyright headers policy for
open-source projects.