### PR TITLE
Add support for multi-track to TestAppUWP

### DIFF
--- a/examples/TestAppUwp/AddAudioTrackPage.xaml
+++ b/examples/TestAppUwp/AddAudioTrackPage.xaml
@@ -1,0 +1,34 @@
+<Page
+    x:Class="TestAppUwp.AddAudioTrackPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <Grid Margin="8,0,8,8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Vertical" Grid.Row="0">
+            <TextBlock Text="Add audio track" Margin="0,12,0,0" Style="{StaticResource SubtitleTextBlockStyle}"/>
+            <TextBlock Text="Track" Margin="0,12,0,0" Style="{StaticResource BaseTextBlockStyle}"/>
+            <TextBox x:Name="trackName" PlaceholderText="track_name" Margin="0,8,0,0"/>
+            <TextBlock FontStyle="Italic" Margin="0,8,0,0" TextWrapping="Wrap">
+                MixedReality-WebRTC currently uses the built-in audio from libwebrtc, which does not support any capture option
+                and instead always capture from the default input audio device.
+            </TextBlock>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Grid.Row="2">
+            <Button Content="Close" Click="CloseClicked" Margin="0,0,8,0"/>
+            <Button Content="Create Track" Click="CreateTrackClicked"
+                    IsEnabled="{x:Bind AudioCaptureViewModel.CanCreateTrack, Mode=OneWay}"/>
+            <ProgressRing x:Name="progressRing" IsActive="False" Margin="0,8,0,0"/>
+            <TextBlock x:Name="createTrackStatusText" Margin="0,8,0,0"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/examples/TestAppUwp/AddAudioTrackPage.xaml.cs
+++ b/examples/TestAppUwp/AddAudioTrackPage.xaml.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    public sealed partial class AddAudioTrackPage : Page
+    {
+        public AudioCaptureViewModel AudioCaptureViewModel { get; } = new AudioCaptureViewModel();
+
+        public AddAudioTrackPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void CloseClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            Frame.GoBack();
+        }
+
+        private async void CreateTrackClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            var button = (Button)sender;
+            button.IsEnabled = false;
+            progressRing.IsActive = true;
+            createTrackStatusText.Text = "Creating track...";
+            bool wasCreated = true;
+            try
+            {
+                await AudioCaptureViewModel.AddAudioTrackFromDeviceAsync(trackName.Text);
+                createTrackStatusText.Text = "Track created.";
+            }
+            catch (Exception ex)
+            {
+                createTrackStatusText.Text = "Failed: " + ex.Message;
+                wasCreated = false;
+            }
+            progressRing.IsActive = false;
+            button.IsEnabled = true;
+            if (wasCreated)
+            {
+                Frame.GoBack();
+            }
+        }
+    }
+}

--- a/examples/TestAppUwp/AddVideoTrackPage.xaml
+++ b/examples/TestAppUwp/AddVideoTrackPage.xaml
@@ -1,0 +1,117 @@
+<Page
+    x:Class="TestAppUwp.AddVideoTrackPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:winmc="using:Windows.Media.Capture"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <Page.Resources>
+        <DataTemplate x:Key="VideoCaptureDeviceTemplate" x:DataType="local:VideoCaptureDeviceInfo">
+            <StackPanel Orientation="Horizontal">
+                <SymbolIcon Symbol="{x:Bind Symbol}" Margin="0,0,12,0" />
+                <StackPanel Orientation="Vertical" AutomationProperties.Name="{x:Bind DisplayName}">
+                    <TextBlock Text="{x:Bind DisplayName}" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Bind Id}" VerticalAlignment="Center" FontSize="9px" />
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate x:Key="VideoProfileTemplate" x:DataType="winmc:MediaCaptureVideoProfile">
+            <TextBlock Text="{x:Bind Id}" VerticalAlignment="Center"/>
+        </DataTemplate>
+        <DataTemplate x:Key="RecordMediaDescTemplate" x:DataType="winmc:MediaCaptureVideoProfileMediaDescription">
+            <StackPanel Orientation="Horizontal">
+                <SymbolIcon Symbol="WebCam" Margin="0,0,12,0" />
+                <TextBlock VerticalAlignment="Center" >
+                    <Run Text="{x:Bind Width}" />
+                    <Run> x </Run>
+                    <Run Text="{x:Bind Height}" />
+                    <Run> @ </Run>
+                    <Run Text="{x:Bind FrameRate}" />
+                    <Run> FPS (</Run>
+                    <Run Text="{x:Bind Subtype}" />
+                    <Run>)</Run>
+                </TextBlock>
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate x:Key="VideoCaptureFormatTemplate" x:DataType="local:VideoCaptureFormatViewModel">
+            <StackPanel Orientation="Horizontal">
+                <SymbolIcon Symbol="Video" Margin="0,0,12,0" />
+                <TextBlock VerticalAlignment="Center" >
+                    <Run Text="{x:Bind Format.width}" />
+                    <Run> x </Run>
+                    <Run Text="{x:Bind Format.height}" />
+                    <Run> @ </Run>
+                    <Run Text="{x:Bind Format.framerate}" />
+                    <Run> FPS (</Run>
+                    <Run Text="{x:Bind Format.fourcc}" />
+                    <Run>)</Run>
+                </TextBlock>
+            </StackPanel>
+        </DataTemplate>
+    </Page.Resources>
+    <Grid Margin="8,0,8,8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Vertical" Grid.Row="0">
+            <TextBlock Text="Add video track" Margin="0,12,0,0" Style="{StaticResource SubtitleTextBlockStyle}"/>
+            <TextBlock Text="Track" Margin="0,12,0,0" Style="{StaticResource BaseTextBlockStyle}"/>
+            <TextBox x:Name="trackName" PlaceholderText="track_name" Margin="0,8,0,0"/>
+            <TextBlock Text="Track Source" Margin="0,12,0,0" Style="{StaticResource BaseTextBlockStyle}"/>
+            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                <RadioButton x:Name="captureDeviceRadioButton" Content="Video Capture Device" IsChecked="True"/>
+                <RadioButton x:Name="uniformColorRadioButton" Content="Uniform Color (not implemented yet)" IsEnabled="False" Margin="16,0,0,0"/>
+            </StackPanel>
+            <TextBlock Text="{x:Bind VideoCaptureViewModel.ErrorMessage, Mode=OneWay}" Foreground="Red" TextWrapping="Wrap"
+                       Visibility="{x:Bind VideoCaptureViewModel.ErrorMessage, Mode=OneWay, Converter={StaticResource VisibleIfNotEmptyConverter}}"/>
+            <Border BorderBrush="#66000000" BorderThickness="2,2,2,2" Background="#AAFFFFFF" Padding="8,8,8,8">
+                <ListView x:Name="videoCaptureDeviceList" HorizontalAlignment="Stretch" MinHeight="96"
+                          ItemsSource="{x:Bind VideoCaptureViewModel.VideoCaptureDevices, Mode=OneWay}"
+                          SelectedItem="{x:Bind VideoCaptureViewModel.VideoCaptureDevices.SelectedItem, Mode=TwoWay}"
+                          ItemTemplate="{StaticResource VideoCaptureDeviceTemplate}"/>
+            </Border>
+            <TextBlock Text="Video profile" Margin="0,12,0,0" Style="{StaticResource BaseTextBlockStyle}"/>
+            <TextBlock Text="Video profiles are not supported by this device"
+                       Visibility="{x:Bind VideoCaptureViewModel.VideoCaptureDevices.SelectedItem.SupportsVideoProfiles,
+                           Mode=OneWay, Converter={StaticResource BooleanToVisibilityInvertedConverter}}"/>
+            <Grid Visibility="{x:Bind VideoCaptureViewModel.VideoCaptureDevices.SelectedItem.SupportsVideoProfiles, Mode=OneWay}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="20px"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Vertical" Grid.Column="2">
+                    <ComboBox x:Name="KnownVideoProfileKindComboBox" Margin="0,10,0,0" MaxWidth="400" MinWidth="200" />
+                    <ComboBox x:Name="VideoProfileComboBox" ItemsSource="{x:Bind VideoCaptureViewModel.VideoProfiles}"
+                              ItemTemplate="{StaticResource VideoProfileTemplate}" Margin="0,10,0,10" MaxWidth="400" MinWidth="200"/>
+                    <ListView x:Name="RecordMediaDescList" ItemsSource="{x:Bind VideoCaptureViewModel.RecordMediaDescs}"
+                              ItemTemplate="{StaticResource RecordMediaDescTemplate}" MinHeight="120" MinWidth="120" />
+                </StackPanel>
+            </Grid>
+            <TextBlock Text="Capture resolution" Margin="0,12,0,0" Style="{StaticResource BaseTextBlockStyle}"/>
+        </StackPanel>
+        <ScrollViewer Grid.Row="1" Margin="0,8,0,8">
+            <ListView x:Name="VideoCaptureFormatList" HorizontalAlignment="Stretch" MinHeight="120"
+                      ItemsSource="{x:Bind VideoCaptureViewModel.VideoCaptureFormats, Mode=OneWay}"
+                      SelectedItem="{x:Bind VideoCaptureViewModel.VideoCaptureFormats.SelectedItem, Mode=TwoWay}"
+                      ItemTemplate="{StaticResource VideoCaptureFormatTemplate}"
+                      ScrollViewer.VerticalScrollMode="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+        </ScrollViewer>
+        <StackPanel Orientation="Horizontal" Grid.Row="2">
+            <Button Content="Close" Click="CloseClicked" Margin="0,0,8,0"/>
+            <Button Content="Create Track" Click="CreateTrackClicked"
+                    IsEnabled="{x:Bind VideoCaptureViewModel.CanCreateTrack, Mode=OneWay}"/>
+            <ProgressRing x:Name="progressRing" IsActive="False" Margin="0,8,0,0"/>
+            <TextBlock x:Name="createTrackStatusText" Margin="0,8,0,0"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/examples/TestAppUwp/AddVideoTrackPage.xaml.cs
+++ b/examples/TestAppUwp/AddVideoTrackPage.xaml.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// Page to create a new video track and add it to the collection of existing tracks.
+    /// </summary>
+    public sealed partial class AddVideoTrackPage : Page
+    {
+        public VideoCaptureViewModel VideoCaptureViewModel { get; } = new VideoCaptureViewModel();
+
+        public AddVideoTrackPage()
+        {
+            this.InitializeComponent();
+            _ = VideoCaptureViewModel.RefreshVideoCaptureDevicesAsync();
+        }
+
+        private void CloseClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            Frame.GoBack();
+        }
+
+        private async void CreateTrackClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            var button = (Button)sender;
+            button.IsEnabled = false;
+            progressRing.IsActive = true;
+            createTrackStatusText.Text = "Creating track...";
+            bool wasCreated = true;
+            try
+            {
+                await VideoCaptureViewModel.AddVideoTrackFromDeviceAsync(trackName.Text);
+                createTrackStatusText.Text = "Track created.";
+            }
+            catch (Exception ex)
+            {
+                createTrackStatusText.Text = "Failed: " + ex.Message;
+                wasCreated = false;
+            }
+            progressRing.IsActive = false;
+            button.IsEnabled = true;
+            if (wasCreated)
+            {
+                Frame.GoBack();
+            }
+        }
+    }
+}

--- a/examples/TestAppUwp/App.xaml
+++ b/examples/TestAppUwp/App.xaml
@@ -1,7 +1,16 @@
-﻿<Application
+<Application
     x:Class="TestAppUwp.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:TestAppUwp">
-
+    <Application.Resources>
+        <local:BooleanToVisibilityInvertedConverter x:Key="BooleanToVisibilityInvertedConverter"/>
+        <local:MediaKindToSymbolConverter x:Key="MediaKindToSymbolConverter"/>
+        <local:TransceiverDirectionToSymbolConverter x:Key="TransceiverDirectionToSymbolConverter"/>
+        <local:NullToBoolConverter x:Key="NullToBoolConverter"/>
+        <local:CountToBoolNotEmptyConvert x:Key="CountToBoolNotEmptyConvert"/>
+        <local:BooleanInverter x:Key="BooleanInverter"/>
+        <local:VisibleIfNotEmptyConverter x:Key="VisibleIfNotEmptyConverter"/>
+        <local:StringFormatConverter x:Key="StringFormatConverter"/>
+    </Application.Resources>
 </Application>

--- a/examples/TestAppUwp/App.xaml.cs
+++ b/examples/TestAppUwp/App.xaml.cs
@@ -26,7 +26,7 @@ namespace TestAppUwp
         }
 
         /// <summary>
-        /// Invoked when the application is launched normally by the end user.  Other entry points
+        /// Invoked when the application is launched normally by the end user. Other entry points
         /// will be used such as when the application is launched to open a specific file.
         /// </summary>
         /// <param name="e">Details about the launch request and process.</param>
@@ -85,9 +85,9 @@ namespace TestAppUwp
         /// <param name="e">Details about the suspend request.</param>
         private void OnSuspending(object sender, SuspendingEventArgs e)
         {
-            var deferral = e.SuspendingOperation.GetDeferral();
-            //TODO: Save application state and stop any background activity
-            deferral.Complete();
+            //var deferral = e.SuspendingOperation.GetDeferral();
+            ////TODO: Save application state and stop any background activity
+            //deferral.Complete();
         }
     }
 }

--- a/examples/TestAppUwp/DebugConsolePage.xaml
+++ b/examples/TestAppUwp/DebugConsolePage.xaml
@@ -1,0 +1,23 @@
+<Page
+    x:Class="TestAppUwp.DebugConsolePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <Grid Margin="8,8,8,8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <TextBlock Text="Debug console" Style="{StaticResource TitleTextBlockStyle}"/>
+        <ScrollViewer Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <TextBox Name="debugMessages" Text="{x:Bind local:Logger.Instance.FullText}" TextWrapping="Wrap"
+                     IsReadOnly="True" Background="#AAFFFFFF" AllowDrop="False"
+                     ScrollViewer.VerticalScrollBarVisibility="Visible"/>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/examples/TestAppUwp/DebugConsolePage.xaml.cs
+++ b/examples/TestAppUwp/DebugConsolePage.xaml.cs
@@ -33,7 +33,9 @@ namespace TestAppUwp
     }
 
     /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// Page displaying the so-called "debug console", a raw text dump of all messages
+    /// output through the <see cref="Logger"/> singleton instance by the various part
+    /// of the application, and mainly used for debugging.
     /// </summary>
     public sealed partial class DebugConsolePage : Page
     {

--- a/examples/TestAppUwp/DebugConsolePage.xaml.cs
+++ b/examples/TestAppUwp/DebugConsolePage.xaml.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    public class Logger : NotifierBase
+    {
+        public static void Log(string message)
+        {
+            Instance.LogMessage(message);
+        }
+
+        private string _fullText;
+
+        public static Logger Instance { get; } = new Logger();
+
+        public string FullText
+        {
+            get { return _fullText; }
+            set { SetProperty(ref _fullText, value); }
+        }
+
+        public void LogMessage(string message)
+        {
+            Debugger.Log(4, "TestAppUWP", message);
+            message += "\n";
+            _fullText += message;
+            RaisePropertyChanged("FullText");
+        }
+    }
+
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class DebugConsolePage : Page
+    {
+        public DebugConsolePage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/examples/TestAppUwp/MainPage.xaml
+++ b/examples/TestAppUwp/MainPage.xaml
@@ -10,309 +10,60 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Page.Resources>
-        <DataTemplate x:Key="NavLinkItemTemplate" x:DataType="local:NavLink">
-            <StackPanel Orientation="Horizontal" Margin="2,0,0,0" AutomationProperties.Name="{x:Bind Label}">
-                <SymbolIcon Symbol="{x:Bind Symbol}" />
-                <TextBlock Text="{x:Bind Label}" Margin="24,0,0,0" VerticalAlignment="Center" />
-            </StackPanel>
+        <local:MenuItemTemplateSelector x:Key="CategoryTemplate">
+            <local:MenuItemTemplateSelector.ItemTemplate>
+                <DataTemplate x:DataType="local:Category" >
+                    <NavigationViewItem Content="{x:Bind Name}">
+                        <NavigationViewItem.Icon>
+                            <SymbolIcon Symbol="{x:Bind Glyph}"/>
+                        </NavigationViewItem.Icon>
+                    </NavigationViewItem>
+                </DataTemplate>
+            </local:MenuItemTemplateSelector.ItemTemplate >
+        </local:MenuItemTemplateSelector>
+        <!--<DataTemplate x:Key="AudioTrackItemTemplate" x:DataType="local:AudioTrackViewModel">
+            <TextBlock Text="{x:Bind DisplayName}" Margin="0,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Left" />
         </DataTemplate>
-        <DataTemplate x:Key="VideoCaptureDeviceTemplate" x:DataType="local:VideoCaptureDeviceInfo">
-            <StackPanel Orientation="Horizontal">
-                <SymbolIcon Symbol="{x:Bind Symbol}" Margin="0,0,12,0" />
-                <StackPanel Orientation="Vertical" AutomationProperties.Name="{x:Bind DisplayName}">
-                    <TextBlock Text="{x:Bind DisplayName}" VerticalAlignment="Center" />
-                    <TextBlock Text="{x:Bind Id}" VerticalAlignment="Center" FontSize="9px" />
-                </StackPanel>
-            </StackPanel>
-        </DataTemplate>
-        <DataTemplate x:Key="VideoProfileTemplate" x:DataType="winmc:MediaCaptureVideoProfile">
-            <TextBlock Text="{x:Bind Id}" VerticalAlignment="Center"/>
-        </DataTemplate>
-        <DataTemplate x:Key="RecordMediaDescTemplate" x:DataType="winmc:MediaCaptureVideoProfileMediaDescription">
-            <StackPanel Orientation="Horizontal">
-                <SymbolIcon Symbol="WebCam" Margin="0,0,12,0" />
-                <TextBlock VerticalAlignment="Center" >
-                    <Run Text="{x:Bind Width}" />
-                    <Run> x </Run>
-                    <Run Text="{x:Bind Height}" />
-                    <Run> @ </Run>
-                    <Run Text="{x:Bind FrameRate}" />
-                    <Run> FPS (</Run>
-                    <Run Text="{x:Bind Subtype}" />
-                    <Run>)</Run>
-                </TextBlock>
-            </StackPanel>
-        </DataTemplate>
-        <DataTemplate x:Key="VideoCaptureFormatTemplate" x:DataType="webrtc:VideoCaptureFormat">
-            <StackPanel Orientation="Horizontal">
-                <SymbolIcon Symbol="Video" Margin="0,0,12,0" />
-                <TextBlock VerticalAlignment="Center" >
-                    <Run Text="{x:Bind width}" />
-                    <Run> x </Run>
-                    <Run Text="{x:Bind height}" />
-                    <Run> @ </Run>
-                    <Run Text="{x:Bind framerate}" />
-                    <Run> FPS (</Run>
-                    <Run Text="{x:Bind fourcc}" />
-                    <Run>)</Run>
-                </TextBlock>
-            </StackPanel>
-        </DataTemplate>
-        <DataTemplate x:Key="ChatChannelItemTemplate" x:DataType="local:ChatChannel">
-            <StackPanel Orientation="Horizontal" Margin="2,0,0,0" AutomationProperties.Name="{x:Bind Label}">
-                <TextBlock Text="{x:Bind Label}" Margin="24,0,0,0" VerticalAlignment="Center" />
-            </StackPanel>
-        </DataTemplate>
-    </Page.Resources>
-    <Grid x:Name="LayoutRoot" Margin="0,0,0,12">
-        <Pivot SelectedIndex="0">
-            <PivotItem Header="Signaling" Margin="12,12,12,0">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="Signaling server" VerticalAlignment="Center" Style="{StaticResource BaseTextBlockStyle}" Margin="0,0,0,6" Grid.ColumnSpan="2"/>
-                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" FontStyle="Italic" Grid.Row="1" Grid.ColumnSpan="2">
-                    The signaling server is used to discover a peer to connect to. This app uses <Hyperlink NavigateUri="https://github.com/bengreenier/node-dss">node-dss</Hyperlink>.
-                    </TextBlock>
-                    <TextBlock Text="Server address" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,12,0" Grid.Row="2"/>
-                    <TextBox Name="dssServer" HorizontalAlignment="Left" PlaceholderText="http://server:port/" Text="http://localhost:3000/" VerticalAlignment="Center" Width="285" Grid.Row="2" Grid.Column="1" Margin="0,6,0,6"/>
-                    <TextBlock Text="Poll delay" VerticalAlignment="Center" Grid.Row="3" HorizontalAlignment="Right" Margin="0,0,12,0"/>
-                    <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Margin="0,6,0,6">
-                        <TextBox x:Name="dssPollTimeMs" MinWidth="100" Text="500" TextAlignment="Right"/>
-                        <TextBlock Text="ms" VerticalAlignment="Center" Margin="4,0,0,0" />
-                    </StackPanel>
-                    <TextBlock Text="Local peer UID" VerticalAlignment="Center" Grid.Row="4" HorizontalAlignment="Right" Margin="0,0,12,0" Height="20"  />
-                    <TextBox x:Name="localPeerUidTextBox" MinWidth="250" Grid.Row="4" Grid.Column="1" Margin="0,6,0,6" />
-                    <TextBlock Text="Remote peer UID" VerticalAlignment="Center" Margin="0,0,12,0" Grid.Row="5" HorizontalAlignment="Right"  />
-                    <TextBox x:Name="remotePeerUidTextBox" MinWidth="250" Grid.Row="5" Grid.Column="1" Margin="0,6,0,6" />
-                    <!--<SymbolIcon Symbol="Setting" />-->
-                    <Button x:Name="pollDssButton" Content="Start polling" HorizontalAlignment="Left" Margin="0,12,0,0" VerticalAlignment="Center" Width="125" Click="PollDssButtonClicked" Grid.Row="6" Grid.ColumnSpan="2"/>
-                    <!--<ListView x:Name="NavLinksList" Margin="0,12,0,0" SelectionMode="None" Grid.Row="1" VerticalAlignment="Stretch"
-                    ItemClick="NavLinksList_ItemClick" IsItemClickEnabled="True"
-                    ItemsSource="{x:Bind NavLinks}" ItemTemplate="{StaticResource NavLinkItemTemplate}"/>-->
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Connection">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="STUN server" FontWeight="Bold" />
-                    <TextBlock Text="The STUN server is used to establish a peer connection through NATs." FontStyle="Italic" Grid.Row="1" Margin="12,6,0,0" />
-                    <TextBox Name="stunServer" Width="400" HorizontalAlignment="Left" PlaceholderText="address:port (without prefix)" Text="stun.l.google.com:19302" Grid.Row="2" Margin="12,6,0,6"/>
-                    <!--<TextBlock Text="Discovered peers" FontWeight="Bold" Grid.ColumnSpan="2" Grid.Row="3" Margin="0,12,0,0" FontFamily="Segoe UI" />
-                    <ListView Grid.Row="4" Margin="12,0,0,0" ItemsSource="{x:Bind NavLinks}" ItemTemplate="{StaticResource NavLinkItemTemplate}" />-->
-                    <TextBlock Text="SDP semantic" FontWeight="Bold" />
-                    <TextBlock FontStyle="Italic" Margin="12,6,0,0">
-                        Specifies the <Hyperlink NavigateUri="https://webrtc.org/web-apis/chrome/unified-plan/">SDP dialect</Hyperlink> used to negotiate a peer connection.<LineBreak/>Do not use Plan B unless there is an issue with the Unified Plan.
-                    </TextBlock>
-                    <StackPanel Orientation="Horizontal" Margin="12,0,0,0">
-                        <RadioButton x:Name="sdpSemanticUnifiedPlan" Content="Unified Plan" IsChecked="True" GroupName="SdpSemanticGroup" Margin="0,0,20,0" />
-                        <RadioButton x:Name="sdpSemanticPlanB" Content="Plan B (deprecated)" GroupName="SdpSemanticGroup" />
-                    </StackPanel>
-                    <TextBlock Text="Preferred codecs" FontWeight="Bold" Margin="0,12,0,0" FontFamily="Segoe UI" />
-                    <TextBlock FontStyle="Italic" Margin="0,6,0,0">
-                            This option allows filtering the SDP offer to retain only one preferred audio and/or video codec amongst the supported ones, thereby forcing their use.<LineBreak/>This must be set before sending an offer to the remote peer. This has no effect on the receiver side.<LineBreak/>If the selected codec is not supported by the local peer implemention, this does nothing, and the default codec is used.
-                    </TextBlock>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Audio :</TextBlock>
-                        <RadioButton x:Name="PreferredAudioCodec_Default" GroupName="PreferredAudioCodecGroup" Checked="PreferredAudioCodecChecked" Content="(default)" IsChecked="True" />
-                        <RadioButton x:Name="PreferredAudioCodec_OPUS" GroupName="PreferredAudioCodecGroup" Checked="PreferredAudioCodecChecked" Content="OPUS" />
-                        <RadioButton x:Name="PreferredAudioCodec_Custom" GroupName="PreferredAudioCodecGroup" Checked="PreferredAudioCodecChecked" Content="Custom value" />
-                    </StackPanel>
-                    <TextBlock x:Name="CustomPreferredAudioCodecHelpText" FontStyle="Italic" Margin="48,6,0,0">
-                            Leave blank to use the default video codec. A partial list is <Hyperlink NavigateUri="https://en.wikipedia.org/wiki/RTP_payload_formats">available from Wikipedia</Hyperlink>.<LineBreak />Common values include "opus" or "ISAC". Names are case sensitive.
-                    </TextBlock>
-                    <TextBox x:Name="CustomPreferredAudioCodec" Text="" PlaceholderText="(use default)" Margin="48,6,0,6" Width="400" HorizontalAlignment="Left" />
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Local params:</TextBlock>
-                        <TextBox x:Name="PreferredAudioCodecExtraParamsLocalTextBox" Margin="16,0,0,0" Width="250"></TextBox>
-                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Remote params:</TextBlock>
-                        <TextBox x:Name="PreferredAudioCodecExtraParamsRemoteTextBox" Margin="16,0,0,0" Width="250"></TextBox>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Video :</TextBlock>
-                        <RadioButton x:Name="PreferredVideoCodec_Default" GroupName="PreferredVideoCodecGroup" Checked="PreferredVideoCodecChecked" Content="(default)" />
-                        <RadioButton x:Name="PreferredVideoCodec_H264" GroupName="PreferredVideoCodecGroup" Checked="PreferredVideoCodecChecked" Content="H.264" IsChecked="True" />
-                        <RadioButton x:Name="PreferredVideoCodec_VP8" GroupName="PreferredVideoCodecGroup" Checked="PreferredVideoCodecChecked" Content="VP8" />
-                        <RadioButton x:Name="PreferredVideoCodec_Custom" GroupName="PreferredVideoCodecGroup" Checked="PreferredVideoCodecChecked" Content="Custom value" />
-                    </StackPanel>
-                    <TextBlock x:Name="CustomPreferredVideoCodecHelpText" FontStyle="Italic" Margin="48,6,0,0">
-                            Leave blank to use the default video codec. A partial list is <Hyperlink NavigateUri="https://en.wikipedia.org/wiki/RTP_payload_formats">available from Wikipedia</Hyperlink>.<LineBreak />Common values include "H264" or "VP8". Names are case sensitive.
-                    </TextBlock>
-                    <TextBox x:Name="CustomPreferredVideoCodec" PlaceholderText="(use default)" Margin="48,6,0,6" Width="400" HorizontalAlignment="Left" />
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Local params:</TextBlock>
-                        <TextBox x:Name="PreferredVideoCodecExtraParamsLocalTextBox" Margin="16,0,0,0" Width="250"></TextBox>
-                        <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Remote params:</TextBlock>
-                        <TextBox x:Name="PreferredVideoCodecExtraParamsRemoteTextBox" Margin="16,0,0,0" Width="250"></TextBox>
-                    </StackPanel>
-                    <TextBlock Text="SDP connection offer" FontWeight="Bold" Margin="0,12,0,0" FontFamily="Segoe UI" />
-                    <Button Name="createOfferButton" IsEnabled="False" Content="Create offer" HorizontalAlignment="Left" VerticalAlignment="Top" RenderTransformOrigin="0.511,0.634" Click="CreateOfferButtonClicked" Width="125" Margin="0,12,0,0"/>
-                    <Button Name="addExtraDataChannelButton" Content="Add extra data channel" HorizontalAlignment="Left" VerticalAlignment="Top" RenderTransformOrigin="0.511,0.634" Click="AddExtraDataChannelButtonClicked" Width="250" Margin="0,12,0,0"/>
-                </StackPanel>
-            </PivotItem>
-            <PivotItem Header="Webcam">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="20px"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Text="Video capture device" FontWeight="Bold" Margin="0,12,0,0" FontFamily="Segoe UI" />
-                        <ListView x:Name="VideoCaptureDeviceList" ItemsSource="{x:Bind VideoCaptureDevices}" ItemTemplate="{StaticResource VideoCaptureDeviceTemplate}" MinHeight="120" MinWidth="120" />
+        <DataTemplate x:Key="VideoTrackItemTemplate" x:DataType="local:VideoTrackViewModel">
+            <TextBlock Text="{x:Bind DisplayName}" Margin="0,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Left" />
+        </DataTemplate>-->
 
-                    </StackPanel>
-                    <StackPanel Orientation="Vertical" Grid.Column="2">
-                        <TextBlock Text="Video profile" FontWeight="Bold" Margin="0,12,0,0" FontFamily="Segoe UI" />
-                        <ComboBox x:Name="KnownVideoProfileKindComboBox" Margin="0,10,0,0" MaxWidth="400" MinWidth="200" />
-                        <ComboBox x:Name="VideoProfileComboBox" ItemsSource="{x:Bind VideoProfiles}" ItemTemplate="{StaticResource VideoProfileTemplate}" Margin="0,10,0,10" MaxWidth="400" MinWidth="200"/>
-                        <ListView x:Name="RecordMediaDescList" ItemsSource="{x:Bind RecordMediaDescs}" ItemTemplate="{StaticResource RecordMediaDescTemplate}" MinHeight="120" MinWidth="120" />
-                        <ListView x:Name="VideoCaptureFormatList" ItemsSource="{x:Bind VideoCaptureFormats}" ItemTemplate="{StaticResource VideoCaptureFormatTemplate}" MinHeight="120" MinWidth="120" />
-                    </StackPanel>
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Tracks">
-                <Grid HorizontalAlignment="Stretch" Margin="0,0,0,0" VerticalAlignment="Stretch">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="20"/>
-                        <RowDefinition Height="2*"/>
-                        <RowDefinition Height="20"/>
-                        <RowDefinition Height="45"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="12px"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="150px"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="Local video channel" FontWeight="Bold" />
-                        <TextBlock x:Name="localVideoSourceName" Grid.Column="1" Margin="12,0,0,0" />
-                        <TextBlock x:Name="localVideoStateText" Text="State:" Grid.Column="2" />
-                    </Grid>
-                    <Grid Grid.Column="2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="150px"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="Remote video channel" FontWeight="Bold"/>
-                        <TextBlock x:Name="remoteVideoStateText" Text="State:" Grid.Column="1" />
-                    </Grid>
-                    <Border Grid.Row="1" BorderBrush="#66000000" BorderThickness="2,2,2,2" Background="#AAFFFFFF">
-                        <MediaPlayerElement x:Name="localVideo" Height="480" Width="640" />
-                    </Border>
-                    <StackPanel Grid.Row="1" Orientation="Horizontal" Height="68" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="0,0,0,20" Background="#CCB2D0FF" Padding="10,10,10,10" >
-                        <Button  Name="startLocalMedia" IsEnabled="False" VerticalAlignment="Center" Click="StartLocalMediaClicked" Width="48" HorizontalAlignment="Center" Height="48">
-                            <SymbolIcon x:Name="startLocalMediaIcon" Symbol="Play" />
-                        </Button>
-                        <Button Name="muteLocalVideo" IsEnabled="False" VerticalAlignment="Center" Click="MuteLocalVideoClicked" Width="48" HorizontalAlignment="Center" Height="48" Margin="10,0,0,0" Padding="0,0,0,0">
-                            <Grid Width="32" Height="32" VerticalAlignment="Center">
-                                <SymbolIcon Symbol="Video" />
-                                <Path x:Name="muteLocalVideoStroke" Stroke="Black" Data="M 32,0 L 0,32" Width="32" Height="32" />
+        <!--<DataTemplate x:Key="ChatChannelItemTemplate" x:DataType="local:ChatChannel">
+            <StackPanel Orientation="Horizontal" Margin="2,0,0,0" AutomationProperties.Name="{x:Bind Label}">
+                <TextBlock Text="{x:Bind Label}" Margin="24,0,0,0" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>-->
+    </Page.Resources>
+    <Grid x:Name="LayoutRoot">
+        <NavigationView x:Name="navigationView"
+                        MenuItemsSource="{x:Bind Categories, Mode=OneTime}"
+                        MenuItemTemplateSelector="{StaticResource CategoryTemplate}"
+                        ItemInvoked="OnNavigationViewItemInvoked"
+                        OpenPaneLength="170" IsBackButtonVisible="Collapsed">
+            <Frame x:Name="rootFrame" CacheSize="2" />
+            
+            <!--<Grid Grid.Row="5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="200"/>
+                                    <ColumnDefinition Width="12"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <ListView x:Name="chatList" Width="200" ItemClick="ChatList_ItemClick" IsItemClickEnabled="True"
+                                ItemsSource="{x:Bind ChatChannels}" ItemTemplate="{StaticResource ChatChannelItemTemplate}"/>
+                                <ScrollViewer x:Name="chatScrollViewer" Grid.Column="2" >
+                                    <TextBox x:Name="chatTextBox" IsEnabled="False" IsReadOnly="True" AcceptsReturn="True" />
+                                </ScrollViewer>
                             </Grid>
-                        </Button>
-                        <Button Name="muteLocalAudio" IsEnabled="False" VerticalAlignment="Center" Click="MuteLocalAudioClicked" Width="48" HorizontalAlignment="Center" Height="48" Margin="10,0,0,0" Padding="0,0,0,0">
-                            <Grid Width="32" Height="32" VerticalAlignment="Center">
-                                <SymbolIcon Symbol="Microphone" />
-                                <Path x:Name="muteLocalAudioStroke" Stroke="Black" Data="M 32,0 L 0,32" Width="32" Height="32" />
-                            </Grid>
-                        </Button>
-                    </StackPanel>
-                    <Border Grid.Row="1" BorderBrush="#66000000" BorderThickness="2,2,2,2" Grid.Column="2" Background="#AAFFFFFF">
-                        <MediaPlayerElement x:Name="remoteVideo" Height="480" Width="640" />
-                    </Border>
-                    <Grid Grid.Row="2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock x:Name="localLoadText" Text="Produce:" HorizontalAlignment="Stretch"  VerticalAlignment="Stretch" />
-                        <TextBlock x:Name="localPresentText" Text="Render:"  Grid.Column="1" HorizontalAlignment="Stretch"  VerticalAlignment="Stretch" />
-                        <TextBlock x:Name="localSkipText" Text="Skip:" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
-                        <TextBlock x:Name="localLateText" Text="Late:" Grid.Column="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
-                    </Grid>
-                    <Grid Grid.Row="2" Grid.Column="2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock x:Name="remoteLoadText" Text="Receive:"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
-                        <TextBlock x:Name="remotePresentText" Text="Render:"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Column="1" />
-                        <TextBlock x:Name="remoteSkipText" Text="Skip:" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Column="2" />
-                        <TextBlock x:Name="remoteLateText" Text="Late:" Grid.Column="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
-                    </Grid>
-                    <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="2">
-                        <TextBlock Text="ICE state : " VerticalAlignment="Top" />
-                        <TextBlock x:Name="iceStateText" Text="-" VerticalAlignment="Top" Margin="6,0,0,0" />
-                        <TextBlock Text="ICE gathering : " VerticalAlignment="Top" Margin="20,0,0,0" />
-                        <TextBlock x:Name="iceGatheringStateText" Text="-" VerticalAlignment="Top" Margin="6,0,0,0" />
-                        <TextBlock Text="Remote Audio Channels : " VerticalAlignment="Top" Margin="20,0,0,0" />
-                        <TextBlock x:Name="remoteAudioChannelCount" Text="-" VerticalAlignment="Top" Margin="6,0,0,0" />
-                        <TextBlock Text="Sample rate : " VerticalAlignment="Top" Margin="20,0,0,0" />
-                        <TextBlock x:Name="remoteAudioSampleRate" Text="-" VerticalAlignment="Top" Margin="6,0,0,0" />
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Grid.Row="3">
-                        <TextBlock Text="Data channel" VerticalAlignment="Bottom" FontWeight="Bold" />
-                        <TextBlock x:Name="sessionStatusText" Text="(not connected)" VerticalAlignment="Bottom" Margin="6,0,0,0" />
-                    </StackPanel>
-                    <Grid Grid.Row="4" Grid.ColumnSpan="3">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200"/>
-                            <ColumnDefinition Width="12"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <ListView x:Name="chatList" Width="200" ItemClick="ChatList_ItemClick" IsItemClickEnabled="True"
-                    ItemsSource="{x:Bind ChatChannels}" ItemTemplate="{StaticResource ChatChannelItemTemplate}"/>
-                        <ScrollViewer x:Name="chatScrollViewer" Grid.Column="2" >
-                            <TextBox x:Name="chatTextBox" IsEnabled="False" IsReadOnly="True" AcceptsReturn="True" />
-                        </ScrollViewer>
-                    </Grid>
-                    <Grid Grid.Row="5" Grid.ColumnSpan="3">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Button x:Name="chatSendButton" IsEnabled="False" Margin="0,6,6,0" Click="ChatSendButton_Click">
-                            <SymbolIcon Symbol="Send" />
-                        </Button>
-                        <TextBox x:Name="chatInputBox" IsEnabled="False" Margin="0,6,0,0" PlaceholderText="Type some text to send..." Grid.Column="2" KeyDown="OnChatKeyDown" />
-                    </Grid>
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Debug">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <TextBlock Text="Debug console" FontWeight="Bold"/>
-                    <TextBox Name="debugMessages" Text="" TextWrapping="Wrap"  Grid.Row="1" IsReadOnly="True" Background="#AAFFFFFF"/>
-                </Grid>
-            </PivotItem>
-        </Pivot>
+                            <Grid Grid.Row="6">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Button x:Name="chatSendButton" IsEnabled="False" Margin="0,6,6,0" Click="ChatSendButton_Click">
+                                    <SymbolIcon Symbol="Send" />
+                                </Button>
+                                <TextBox x:Name="chatInputBox" IsEnabled="False" Margin="0,6,0,0" PlaceholderText="Type some text to send..." Grid.Column="2" KeyDown="OnChatKeyDown" />
+                            </Grid>-->
+        </NavigationView>
     </Grid>
 </Page>

--- a/examples/TestAppUwp/MainPage.xaml.cs
+++ b/examples/TestAppUwp/MainPage.xaml.cs
@@ -2,258 +2,71 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.MixedReality.WebRTC;
-using TestAppUwp.Video;
 using Windows.ApplicationModel;
-using Windows.Media.Capture;
-using Windows.Media.Core;
-using Windows.Media.MediaProperties;
-using Windows.Media.Playback;
 using Windows.Storage;
-using Windows.System.Profile;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
 
 namespace TestAppUwp
 {
-    public class NavLink
+    public class CategoryBase { }
+
+    public class Category : CategoryBase
     {
-        public string Id { get; set; }
-        public string Label { get; set; }
-        public Symbol Symbol { get; set; }
+        public string Name { get; set; }
+        public string Tooltip { get; set; }
+        public Symbol Glyph { get; set; }
+        public Type PageType { get; set; }
     }
 
-    public class VideoCaptureDeviceInfo
-    {
-        public string Id;
-        public string DisplayName;
-        public Symbol Symbol;
+    public class Separator : CategoryBase { }
 
-        public bool SupportsVideoProfiles
+    public class Header : CategoryBase
+    {
+        public string Name { get; set; }
+    }
+
+    [ContentProperty(Name = "ItemTemplate")]
+    class MenuItemTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate ItemTemplate { get; set; }
+
+        internal DataTemplate HeaderTemplate = (DataTemplate)XamlReader.Load(
+            @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                   <NavigationViewItemHeader Content='{Binding Name}' />
+                  </DataTemplate>");
+
+        internal DataTemplate SeparatorTemplate = (DataTemplate)XamlReader.Load(
+            @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                    <NavigationViewItemSeparator />
+                  </DataTemplate>");
+
+        protected override DataTemplate SelectTemplateCore(object item)
         {
-            get
-            {
-                if (Id != null)
-                {
-                    return MediaCapture.IsVideoProfileSupported(Id);
-                }
-                return false;
-            }
+            return item is Separator ? SeparatorTemplate : item is Header ? HeaderTemplate : ItemTemplate;
         }
     }
 
-    public class ChatChannel
-    {
-        public DataChannel DataChannel;
-        public string Text = "";
-        public string Label { get { return DataChannel?.Label; } }
-    }
-
     /// <summary>
-    /// The main application page.
+    /// Main application page with the navigation menu.
     /// </summary>
     public sealed partial class MainPage : Page
     {
         /// <summary>
-        /// Indicates whether the native plugin has been successfully initialized,
-        /// and the <see cref="_peerConnection"/> object can be used.
+        /// Collection of categories for the main navigation menu.
         /// </summary>
-        public bool PluginInitialized { get; private set; } = false;
-
-        private Transceiver _audioTransceiver = null;
-        private Transceiver _videoTransceiver = null;
-
-        private MediaStreamSource localVideoSource = null;
-        private MediaSource localMediaSource = null;
-        private MediaPlayer localVideoPlayer = new MediaPlayer();
-        private bool _isLocalVideoPlaying = false;
-        private object _isLocalMediaPlayingLock = new object();
-        private LocalAudioTrack _localAudioTrack = null;
-        private LocalVideoTrack _localVideoTrack = null;
-
-        private MediaStreamSource remoteVideoSource = null;
-        private MediaSource remoteMediaSource = null;
-        private MediaPlayer remoteVideoPlayer = new MediaPlayer();
-        private bool _isRemoteVideoPlaying = false;
-        private bool _isRemoteAudioPlaying = false;
-        private uint _remoteVideoWidth = 0;
-        private uint _remoteVideoHeight = 0;
-        private uint _remoteAudioChannelCount = 0;
-        private uint _remoteAudioSampleRate = 0;
-        private object _isRemoteMediaPlayingLock = new object();
-        private RemoteAudioTrack _remoteAudioTrack = null;
-        private RemoteVideoTrack _remoteVideoTrack = null;
-
-        /// <summary>
-        /// The underlying <see cref="PeerConnection"/> object.
-        /// </summary>
-        private PeerConnection _peerConnection;
-
-        /// <summary>
-        /// Enable automatically creating a new SDP offer when the renegotiation event is fired.
-        /// This can be disabled when adding multiple tracks, to bundle all changes together and
-        /// avoid multiple round trips to the signaler and remote peer.
-        /// </summary>
-        private bool _renegotiationOfferEnabled = true;
-
-        /// <summary>
-        /// Predetermined chat data channel ID, negotiated out of band.
-        /// </summary>
-        private const int ChatChannelID = 42;
-
-        private bool isDssPolling = false;
-        private NodeDssSignaler dssSignaler = new NodeDssSignaler();
-
-        private DispatcherTimer localVideoStatsTimer = new DispatcherTimer();
-        private DispatcherTimer remoteVideoStatsTimer = new DispatcherTimer();
-
-        /// <summary>
-        /// Get the string representing the preferred audio codec the user selected.
-        /// </summary>
-        public string PreferredAudioCodec
+        public ObservableCollection<CategoryBase> Categories { get; } = new ObservableCollection<CategoryBase>()
         {
-            get
-            {
-                if (PreferredAudioCodec_Custom.IsChecked.GetValueOrDefault(false))
-                {
-                    return CustomPreferredAudioCodec.Text;
-                }
-                else if (PreferredAudioCodec_OPUS.IsChecked.GetValueOrDefault(false))
-                {
-                    return "opus";
-                }
-                return string.Empty;
-            }
-        }
-
-        /// <summary>
-        /// Get the string representing the preferred video codec the user selected.
-        /// </summary>
-        public string PreferredVideoCodec
-        {
-            get
-            {
-                if (PreferredVideoCodec_Custom.IsChecked.GetValueOrDefault(false))
-                {
-                    return CustomPreferredVideoCodec.Text;
-                }
-                else if (PreferredVideoCodec_H264.IsChecked.GetValueOrDefault(false))
-                {
-                    return "H264";
-                }
-                else if (PreferredVideoCodec_VP8.IsChecked.GetValueOrDefault(false))
-                {
-                    return "VP8";
-                }
-                return string.Empty;
-            }
-        }
-
-        public ObservableCollection<VideoCaptureDeviceInfo> VideoCaptureDevices { get; private set; }
-            = new ObservableCollection<VideoCaptureDeviceInfo>();
-
-        public VideoCaptureDeviceInfo SelectedVideoCaptureDevice
-        {
-            get
-            {
-                var deviceIndex = VideoCaptureDeviceList.SelectedIndex;
-                if ((deviceIndex < 0) || (deviceIndex >= VideoCaptureDevices.Count))
-                {
-                    return null;
-                }
-                return VideoCaptureDevices[deviceIndex];
-            }
-        }
-
-        public VideoProfileKind SelectedVideoProfileKind
-        {
-            get
-            {
-                var videoProfileKindIndex = KnownVideoProfileKindComboBox.SelectedIndex;
-                if (videoProfileKindIndex < 0)
-                {
-                    return VideoProfileKind.Unspecified;
-                }
-                return (VideoProfileKind)Enum.GetValues(typeof(VideoProfileKind)).GetValue(videoProfileKindIndex);
-            }
-        }
-
-        public ObservableCollection<MediaCaptureVideoProfile> VideoProfiles { get; private set; }
-            = new ObservableCollection<MediaCaptureVideoProfile>();
-
-        public MediaCaptureVideoProfile SelectedVideoProfile
-        {
-            get
-            {
-                var profileIndex = VideoProfileComboBox.SelectedIndex;
-                if ((profileIndex < 0) || (profileIndex >= VideoProfiles.Count))
-                {
-                    return null;
-                }
-                return VideoProfiles[profileIndex];
-            }
-        }
-
-        public ObservableCollection<MediaCaptureVideoProfileMediaDescription> RecordMediaDescs { get; private set; }
-            = new ObservableCollection<MediaCaptureVideoProfileMediaDescription>();
-
-        public MediaCaptureVideoProfileMediaDescription SelectedRecordMediaDesc
-        {
-            get
-            {
-                var descIndex = RecordMediaDescList.SelectedIndex;
-                if ((descIndex < 0) || (descIndex >= RecordMediaDescs.Count))
-                {
-                    return null;
-                }
-                return RecordMediaDescs[descIndex];
-
-            }
-        }
-
-        public ObservableCollection<VideoCaptureFormat> VideoCaptureFormats { get; private set; }
-            = new ObservableCollection<VideoCaptureFormat>();
-
-        public VideoCaptureFormat? SelectedVideoCaptureFormat
-        {
-            get
-            {
-                var profileIndex = VideoCaptureFormatList.SelectedIndex;
-                if ((profileIndex < 0) || (profileIndex >= VideoCaptureFormats.Count))
-                {
-                    return null;
-                }
-                return VideoCaptureFormats[profileIndex];
-            }
-        }
-
-        public ObservableCollection<NavLink> NavLinks { get; }
-            = new ObservableCollection<NavLink>();
-
-        public ObservableCollection<ChatChannel> ChatChannels { get; private set; }
-            = new ObservableCollection<ChatChannel>();
-
-        public ChatChannel SelectedChatChannel
-        {
-            get
-            {
-                var chatIndex = chatList.SelectedIndex;
-                if ((chatIndex < 0) || (chatIndex >= ChatChannels.Count))
-                {
-                    return null;
-                }
-                return ChatChannels[chatIndex];
-            }
-        }
-
-        private VideoBridge localVideoBridge = new VideoBridge(3);
-        private VideoBridge remoteVideoBridge = new VideoBridge(5);
+            new Category { Name = "Signaling", Glyph = Symbol.Map, PageType = typeof(SignalingPage) },
+            new Category { Name = "Local Tracks", Glyph = Symbol.Library, PageType = typeof(TracksPage) },
+            new Category { Name = "Session", Glyph = Symbol.VideoChat, PageType = typeof(SessionPage) },
+            new Category { Name = "Media Player", Glyph = Symbol.Play, PageType = typeof(MediaPlayerPage) },
+            new Category { Name = "Debug Logs", Glyph = Symbol.Memo, PageType = typeof(DebugConsolePage) },
+        };
 
         public static string GetDeviceName()
         {
@@ -262,46 +75,53 @@ namespace TestAppUwp
 
         public MainPage()
         {
+            RestoreSettings();
+
             this.InitializeComponent();
 
-            muteLocalVideoStroke.Visibility = Visibility.Collapsed;
-            muteLocalAudioStroke.Visibility = Visibility.Collapsed;
+            // Insert items manually into navigation menu. It doesn't seem that there is a way
+            // to force selecting a menu item when using data binding, so selecting the first
+            // page below would crash (empty MenuItems list if assigning MenuItemsSource).
+            //foreach (var catBase in Categories)
+            //{
+            //    if (catBase is Category cat)
+            //    {
+            //        var item = new NavigationViewItem()
+            //        {
+            //            Content = cat.Name,
+            //            Icon = new SymbolIcon() { Symbol = cat.Glyph },
+            //            DataContext = catBase
+            //        };
+            //        AutomationProperties.SetName(item, cat.Name);
+            //        navigationView.MenuItems.Add(item);
+            //    }
+            //    else if (catBase is Header headerCat)
+            //    {
+            //        var item = new NavigationViewItemHeader()
+            //        {
+            //            Name = headerCat.Name,
+            //            DataContext = catBase
+            //        };
+            //        AutomationProperties.SetName(item, headerCat.Name);
+            //        navigationView.MenuItems.Add(item);
+            //    }
+            //    else if (catBase is Separator sepCat)
+            //    {
+            //        navigationView.MenuItems.Add(new NavigationViewItemSeparator());
+            //    }
+            //}
 
-            // This will be enabled once the signaling is initialized and ready to send data
-            createOfferButton.IsEnabled = false;
+            // Open the "Signaling" page by default
+            //navigationView.MenuItemsSource = Categories;
+            rootFrame.Navigate((Categories[0] as Category).PageType);
+            //((NavigationViewItem)(navigationView.MenuItems[0])).IsSelected = true; // doesn't work...
 
             // Those are called during InitializeComponent() but before the controls are initialized (!).
             // Force-call again to actually initialize the panels correctly.
-            PreferredAudioCodecChecked(null, null);
-            PreferredVideoCodecChecked(null, null);
-
-            RestoreParams();
-
-            dssSignaler.OnMessage += DssSignaler_OnMessage;
-            dssSignaler.OnFailure += DssSignaler_OnFailure;
-            dssSignaler.OnPollingDone += DssSignaler_OnPollingDone;
-
-            localVideoStatsTimer.Tick += OnLocalVideoStatsTimerTicked;
-            remoteVideoStatsTimer.Tick += OnRemoteVideoStatsTimerTicked;
-
-            _peerConnection = new PeerConnection();
-            _peerConnection.Connected += OnPeerConnected;
-            _peerConnection.DataChannelAdded += OnDataChannelAdded;
-            _peerConnection.DataChannelRemoved += OnDataChannelRemoved;
-            _peerConnection.LocalSdpReadytoSend += OnLocalSdpReadyToSend;
-            _peerConnection.IceCandidateReadytoSend += OnIceCandidateReadyToSend;
-            _peerConnection.IceStateChanged += OnIceStateChanged;
-            _peerConnection.IceGatheringStateChanged += OnIceGatheringStateChanged;
-            _peerConnection.RenegotiationNeeded += OnPeerRenegotiationNeeded;
-            _peerConnection.AudioTrackAdded += Peer_RemoteAudioTrackAdded;
-            _peerConnection.AudioTrackRemoved += Peer_RemoteAudioTrackRemoved;
-            _peerConnection.VideoTrackAdded += Peer_RemoteVideoTrackAdded;
-            _peerConnection.VideoTrackRemoved += Peer_RemoteVideoTrackRemoved;
+            //PreferredAudioCodecChecked(null, null);
+            //PreferredVideoCodecChecked(null, null);
 
             //Window.Current.Closed += Shutdown; // doesn't work
-
-            // Start polling automatically.
-            PollDssButtonClicked(this, null);
 
             this.Loaded += OnLoaded;
             Application.Current.Suspending += App_Suspending;
@@ -312,1450 +132,324 @@ namespace TestAppUwp
         {
             // Save local and remote peer IDs for next launch for convenience
             ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
-            localSettings.Values["DssServerAddress"] = dssServer.Text;
-            localSettings.Values["LocalPeerID"] = localPeerUidTextBox.Text;
-            localSettings.Values["RemotePeerID"] = remotePeerUidTextBox.Text;
-            localSettings.Values["PreferredAudioCodec"] = PreferredAudioCodec;
-            localSettings.Values["PreferredAudioCodecExtraParamsLocal"] = PreferredAudioCodecExtraParamsLocalTextBox.Text;
-            localSettings.Values["PreferredAudioCodecExtraParamsRemote"] = PreferredAudioCodecExtraParamsRemoteTextBox.Text;
-            localSettings.Values["PreferredAudioCodec_Custom"] = PreferredAudioCodec_Custom.IsChecked.GetValueOrDefault() ? CustomPreferredAudioCodec.Text : "";
-            localSettings.Values["PreferredVideoCodec"] = PreferredVideoCodec;
-            localSettings.Values["PreferredVideoCodecExtraParamsLocal"] = PreferredVideoCodecExtraParamsLocalTextBox.Text;
-            localSettings.Values["PreferredVideoCodecExtraParamsRemote"] = PreferredVideoCodecExtraParamsRemoteTextBox.Text;
-            localSettings.Values["PreferredVideoCodec_Custom"] = PreferredVideoCodec_Custom.IsChecked.GetValueOrDefault() ? CustomPreferredVideoCodec.Text : "";
+            SessionModel sessionModel = SessionModel.Current;
+            localSettings.Values["DssServerAddress"] = sessionModel.NodeDssSignaler.HttpServerAddress;
+            localSettings.Values["LocalPeerID"] = sessionModel.NodeDssSignaler.LocalPeerId;
+            localSettings.Values["RemotePeerID"] = sessionModel.NodeDssSignaler.RemotePeerId;
+            localSettings.Values["PollTimeMs"] = sessionModel.NodeDssSignaler.PollTimeMs;
+            //localSettings.Values["PreferredAudioCodec"] = PreferredAudioCodec;
+            //localSettings.Values["PreferredAudioCodecExtraParamsLocal"] = PreferredAudioCodecExtraParamsLocalTextBox.Text;
+            //localSettings.Values["PreferredAudioCodecExtraParamsRemote"] = PreferredAudioCodecExtraParamsRemoteTextBox.Text;
+            //localSettings.Values["PreferredAudioCodec_Custom"] = PreferredAudioCodec_Custom.IsChecked.GetValueOrDefault() ? CustomPreferredAudioCodec.Text : "";
+            //localSettings.Values["PreferredVideoCodec"] = PreferredVideoCodec;
+            //localSettings.Values["PreferredVideoCodecExtraParamsLocal"] = PreferredVideoCodecExtraParamsLocalTextBox.Text;
+            //localSettings.Values["PreferredVideoCodecExtraParamsRemote"] = PreferredVideoCodecExtraParamsRemoteTextBox.Text;
+            //localSettings.Values["PreferredVideoCodec_Custom"] = PreferredVideoCodec_Custom.IsChecked.GetValueOrDefault() ? CustomPreferredVideoCodec.Text : "";
         }
 
         private void App_Resuming(object sender, object e)
         {
-            RestoreParams();
+            RestoreSettings();
         }
 
+        /// <summary>
+        /// Check if this application instance is the first one launched on the host device.
+        /// </summary>
+        /// <returns><c>true</c> if the current application instance is the first and therefore only instance.</returns>
         private static bool IsFirstInstance()
         {
             var firstInstance = AppInstance.FindOrRegisterInstanceForKey("{44CD414E-B604-482E-8CFD-A9E09076CABD}");
             return firstInstance.IsCurrentInstance;
         }
 
-        private void RestoreParams()
+        private void RestoreSettings()
         {
+            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+            SessionModel sessionModel = SessionModel.Current;
+
             // Uncomment these lines if you want to connect a HoloLens (or any non-x64 device) to a
             // x64 PC.
             //var arch = System.Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
             //if (arch == "AMD64")
             //{
-            //    localPeerUidTextBox.Text = "Pc";
-            //    remotePeerUidTextBox.Text = "Device";
+            //    sessionModel.NodeDssSignaler.LocalPeerId = "Pc";
+            //    sessionModel.NodeDssSignaler.RemotePeerId = "Device";
             //}
             //else
             //{
-            //    localPeerUidTextBox.Text = "Device";
-            //    remotePeerUidTextBox.Text = "Pc";
+            //    sessionModel.NodeDssSignaler.LocalPeerId = "Device";
+            //    sessionModel.NodeDssSignaler.RemotePeerId = "Pc";
             //}
 
             // Get server address and peer ID from local settings if available.
-            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
             if (localSettings.Values.TryGetValue("DssServerAddress", out object dssServerAddress))
             {
                 if (dssServerAddress is string str)
                 {
-                    dssServer.Text = str;
+                    sessionModel.NodeDssSignaler.HttpServerAddress = str;
                 }
+            }
+            if (string.IsNullOrWhiteSpace(sessionModel.NodeDssSignaler.HttpServerAddress))
+            {
+                sessionModel.NodeDssSignaler.HttpServerAddress = "http://localhost:3000/";
             }
 
             if (localSettings.Values.TryGetValue("LocalPeerID", out object localObj))
             {
                 if (localObj is string str)
                 {
-                    localPeerUidTextBox.Text = str;
+                    sessionModel.NodeDssSignaler.LocalPeerId = str;
                 }
             }
-            if (localPeerUidTextBox.Text.Length == 0)
+            if (sessionModel.NodeDssSignaler.LocalPeerId.Length == 0)
             {
-                localPeerUidTextBox.Text = GetDeviceName();
+                sessionModel.NodeDssSignaler.LocalPeerId = GetDeviceName();
             }
             if (localSettings.Values.TryGetValue("RemotePeerID", out object remoteObj))
             {
                 if (remoteObj is string str)
                 {
-                    remotePeerUidTextBox.Text = str;
+                    sessionModel.NodeDssSignaler.RemotePeerId = str;
+                }
+            }
+            if (localSettings.Values.TryGetValue("PollTimeMs", out object pollTimeObject))
+            {
+                if (pollTimeObject is int pollTimeMs)
+                {
+                    sessionModel.NodeDssSignaler.PollTimeMs = pollTimeMs;
                 }
             }
 
             if (!IsFirstInstance())
             {
                 // Swap the peer IDs. This way two instances launched on the same machine connect
-                // to each other by default.
-                var tmp = localPeerUidTextBox.Text;
-                localPeerUidTextBox.Text = remotePeerUidTextBox.Text;
-                remotePeerUidTextBox.Text = tmp;
+                // to each other by default
+                var tmp = sessionModel.NodeDssSignaler.LocalPeerId;
+                sessionModel.NodeDssSignaler.LocalPeerId = sessionModel.NodeDssSignaler.RemotePeerId;
+                sessionModel.NodeDssSignaler.RemotePeerId = tmp;
             }
 
-            if (localSettings.Values.TryGetValue("PreferredAudioCodec", out object preferredAudioObj))
-            {
-                if (preferredAudioObj is string str)
-                {
-                    switch(str)
-                    {
-                        case "":
-                        {
-                            PreferredAudioCodec_Default.IsChecked = true;
-                            break;
-                        }
-                        case "opus":
-                        {
-                            PreferredAudioCodec_OPUS.IsChecked = true;
-                            break;
-                        }
-                        default:
-                        {
-                            PreferredAudioCodec_Custom.IsChecked = true;
-                            CustomPreferredAudioCodec.Text = str;
-                            break;
-                        }
-                    }
-                }
-            }
-            if (localSettings.Values.TryGetValue("PreferredAudioCodecExtraParamsLocal", out object preferredAudioParamsLocalObj))
-            {
-                if (preferredAudioParamsLocalObj is string str)
-                {
-                    PreferredAudioCodecExtraParamsLocalTextBox.Text = str;
-                }
-            }
-            if (localSettings.Values.TryGetValue("PreferredAudioCodecExtraParamsRemote", out object preferredAudioParamsRemoteObj))
-            {
-                if (preferredAudioParamsRemoteObj is string str)
-                {
-                    PreferredAudioCodecExtraParamsRemoteTextBox.Text = str;
-                }
-            }
+            //if (localSettings.Values.TryGetValue("PreferredAudioCodec", out object preferredAudioObj))
+            //{
+            //    if (preferredAudioObj is string str)
+            //    {
+            //        switch (str)
+            //        {
+            //        case "":
+            //        {
+            //            PreferredAudioCodec_Default.IsChecked = true;
+            //            break;
+            //        }
+            //        case "opus":
+            //        {
+            //            PreferredAudioCodec_OPUS.IsChecked = true;
+            //            break;
+            //        }
+            //        default:
+            //        {
+            //            PreferredAudioCodec_Custom.IsChecked = true;
+            //            CustomPreferredAudioCodec.Text = str;
+            //            break;
+            //        }
+            //        }
+            //    }
+            //}
+            //if (localSettings.Values.TryGetValue("PreferredAudioCodecExtraParamsLocal", out object preferredAudioParamsLocalObj))
+            //{
+            //    if (preferredAudioParamsLocalObj is string str)
+            //    {
+            //        PreferredAudioCodecExtraParamsLocalTextBox.Text = str;
+            //    }
+            //}
+            //if (localSettings.Values.TryGetValue("PreferredAudioCodecExtraParamsRemote", out object preferredAudioParamsRemoteObj))
+            //{
+            //    if (preferredAudioParamsRemoteObj is string str)
+            //    {
+            //        PreferredAudioCodecExtraParamsRemoteTextBox.Text = str;
+            //    }
+            //}
 
-            if (localSettings.Values.TryGetValue("PreferredVideoCodec", out object preferredVideoObj))
-            {
-                if (preferredVideoObj is string str)
-                {
-                    switch (str)
-                    {
-                        case "":
-                        {
-                            PreferredVideoCodec_Default.IsChecked = true;
-                            break;
-                        }
-                        case "H264":
-                        {
-                            PreferredVideoCodec_H264.IsChecked = true;
-                            break;
-                        }
-                        case "VP8":
-                        {
-                            PreferredVideoCodec_VP8.IsChecked = true;
-                            break;
-                        }
-                        default:
-                        {
-                            PreferredVideoCodec_Custom.IsChecked = true;
-                            CustomPreferredVideoCodec.Text = str;
-                            break;
-                        }
-                    }
-                }
-            }
-            if (localSettings.Values.TryGetValue("PreferredVideoCodecExtraParamsLocal", out object preferredVideoParamsLocalObj))
-            {
-                if (preferredVideoParamsLocalObj is string str)
-                {
-                    PreferredVideoCodecExtraParamsLocalTextBox.Text = str;
-                }
-            }
-            if (localSettings.Values.TryGetValue("PreferredVideoCodecExtraParamsRemote", out object preferredVideoParamsRemoteObj))
-            {
-                if (preferredVideoParamsRemoteObj is string str)
-                {
-                    PreferredVideoCodecExtraParamsRemoteTextBox.Text = str;
-                }
-            }
+            //if (localSettings.Values.TryGetValue("PreferredVideoCodec", out object preferredVideoObj))
+            //{
+            //    if (preferredVideoObj is string str)
+            //    {
+            //        switch (str)
+            //        {
+            //        case "":
+            //        {
+            //            PreferredVideoCodec_Default.IsChecked = true;
+            //            break;
+            //        }
+            //        case "H264":
+            //        {
+            //            PreferredVideoCodec_H264.IsChecked = true;
+            //            break;
+            //        }
+            //        case "VP8":
+            //        {
+            //            PreferredVideoCodec_VP8.IsChecked = true;
+            //            break;
+            //        }
+            //        default:
+            //        {
+            //            PreferredVideoCodec_Custom.IsChecked = true;
+            //            CustomPreferredVideoCodec.Text = str;
+            //            break;
+            //        }
+            //        }
+            //    }
+            //}
+            //if (localSettings.Values.TryGetValue("PreferredVideoCodecExtraParamsLocal", out object preferredVideoParamsLocalObj))
+            //{
+            //    if (preferredVideoParamsLocalObj is string str)
+            //    {
+            //        PreferredVideoCodecExtraParamsLocalTextBox.Text = str;
+            //    }
+            //}
+            //if (localSettings.Values.TryGetValue("PreferredVideoCodecExtraParamsRemote", out object preferredVideoParamsRemoteObj))
+            //{
+            //    if (preferredVideoParamsRemoteObj is string str)
+            //    {
+            //        PreferredVideoCodecExtraParamsRemoteTextBox.Text = str;
+            //    }
+            //}
         }
 
-        private void OnDataChannelAdded(DataChannel channel)
-        {
-            LogMessage($"Added data channel '{channel.Label}' (#{channel.ID}).");
-            RunOnMainThread(() => {
-                var chat = new ChatChannel { DataChannel = channel };
-                ChatChannels.Add(chat);
-                if (ChatChannels.Count == 1)
-                {
-                    chatList.SelectedIndex = 0;
-                }
-                channel.MessageReceived += (byte[] message) =>
-                    RunOnMainThread(() => {
-                        string text = System.Text.Encoding.UTF8.GetString(message);
-                        ChatMessageReceived(chat, text);
-                    });
-            });
-        }
-
-        private void OnDataChannelRemoved(DataChannel channel)
-        {
-            LogMessage($"Removed data channel '{channel.Label}' (#{channel.ID}).");
-            RunOnMainThread(() => {
-                var chat = ChatChannels.Where((c) => c.DataChannel == channel).First();
-                ChatChannels.Remove(chat);
-            });
-        }
-
-        private void OnLocalSdpReadyToSend(string type, string sdp)
-        {
-            var message = new NodeDssSignaler.Message
-            {
-                MessageType = NodeDssSignaler.Message.WireMessageTypeFromString(type),
-                Data = sdp,
-                IceDataSeparator = "|"
-            };
-            dssSignaler.SendMessageAsync(message);
-        }
-
-        private void OnIceCandidateReadyToSend(string candidate, int sdpMlineindex, string sdpMid)
-        {
-            var message = new NodeDssSignaler.Message
-            {
-                MessageType = NodeDssSignaler.Message.WireMessageType.Ice,
-                Data = $"{candidate}|{sdpMlineindex}|{sdpMid}", // see DssSignaler_OnMessage
-                IceDataSeparator = "|"
-            };
-            dssSignaler.SendMessageAsync(message);
-        }
-
-        private void OnIceStateChanged(IceConnectionState newState)
-        {
-            RunOnMainThread(() => {
-                LogMessage($"ICE state changed to {newState}.");
-                iceStateText.Text = newState.ToString();
-            });
-        }
-
-        private void OnIceGatheringStateChanged(IceGatheringState newState)
-        {
-            RunOnMainThread(() => {
-                LogMessage($"ICE gathering changed to {newState}.");
-                iceGatheringStateText.Text = newState.ToString();
-            });
-        }
-
-        private void OnPeerRenegotiationNeeded()
-        {
-            // If already connected, update the connection on the fly.
-            // If not, wait for user action and don't automatically connect.
-            if (_peerConnection.IsConnected && _renegotiationOfferEnabled)
-            {
-                _peerConnection.CreateOffer();
-            }
-        }
+        //private void OnPeerRenegotiationNeeded()
+        //{
+        //    RunOnMainThread(() => negotiationStatusText.Text = "Renegotiation needed");
+        //}
 
         private async void OnLoaded(object sender, RoutedEventArgs e)
         {
-            LogMessage("Initializing the WebRTC native plugin...");
+            // This should move to the App, no need to wait for the main page loaded...
+            await SessionModel.Current.InitializePeerConnectionAsync();
 
-            // Cannot run in UI thread on UWP because this will initialize the global factory
-            // (first library call) which needs to be done on a background thread.
-            await Task.Run(() => Library.ShutdownOptions = Library.ShutdownOptionsFlags.LogLiveObjects);
+            // Automatically start polling for convenience
+            SessionModel.Current.NodeDssSignaler.StartPollingAsync();
+
+            //audioTrackComboBox.IsEnabled = false;
+            //videoTrackComboBox.IsEnabled = false;
 
             // Populate the combo box with the VideoProfileKind enum
             {
                 var values = Enum.GetValues(typeof(VideoProfileKind));
-                KnownVideoProfileKindComboBox.ItemsSource = values.Cast<VideoProfileKind>();
-                KnownVideoProfileKindComboBox.SelectedIndex = Array.IndexOf(values, VideoProfileKind.Unspecified);
+                //KnownVideoProfileKindComboBox.ItemsSource = values.Cast<VideoProfileKind>();
+                //KnownVideoProfileKindComboBox.SelectedIndex = Array.IndexOf(values, VideoProfileKind.Unspecified);
             }
 
-            VideoCaptureDeviceList.SelectionChanged += VideoCaptureDeviceList_SelectionChanged;
-            KnownVideoProfileKindComboBox.SelectionChanged += KnownVideoProfileKindComboBox_SelectionChanged;
-            VideoProfileComboBox.SelectionChanged += VideoProfileComboBox_SelectionChanged;
+            //VideoCaptureDeviceList.SelectionChanged += VideoCaptureDeviceList_SelectionChanged;
+            //KnownVideoProfileKindComboBox.SelectionChanged += KnownVideoProfileKindComboBox_SelectionChanged;
+            //VideoProfileComboBox.SelectionChanged += VideoProfileComboBox_SelectionChanged;
 
-            //localVideo.TransportControls = localVideoControls;
+            //videoPlayerElement.TransportControls = localVideoControls;
 
-            PluginInitialized = false;
 
-            // Ensure that the UWP app was authorized to capture audio (cap:microphone)
-            // and video (cap:webcam), otherwise the native plugin will fail.
-            try
-            {
-                MediaCapture mediaAccessRequester = new MediaCapture();
-                var mediaSettings = new MediaCaptureInitializationSettings
-                {
-                    AudioDeviceId = "",
-                    VideoDeviceId = "",
-                    StreamingCaptureMode = StreamingCaptureMode.AudioAndVideo,
-                    PhotoCaptureSource = PhotoCaptureSource.VideoPreview
-                };
-                await mediaAccessRequester.InitializeAsync(mediaSettings);
-            }
-            catch (UnauthorizedAccessException uae)
-            {
-                LogMessage("Access to A/V denied, check app permissions:: " + uae.Message);
-                return;
-            }
-            catch (Exception ex)
-            {
-                LogMessage("Failed to initialize A/V with unknown exception: " + ex.Message);
-                return;
-            }
 
-            // Populate the list of video capture devices (webcams).
-            // On UWP this uses internally the API:
-            //   Devices.Enumeration.DeviceInformation.FindAllAsync(VideoCapture)
-            // Note that there's no API to pass a given device to WebRTC,
-            // so there's no way to monitor and update that list if a device
-            // gets plugged or unplugged. Even using DeviceInformation.CreateWatcher()
-            // would yield some devices that might become unavailable by the time
-            // WebRTC internally opens the video capture device.
-            // This is more for demo purpose here because using the UWP API is nicer.
-            {
-                var devices = await PeerConnection.GetVideoCaptureDevicesAsync();
-                VideoCaptureDevices.Clear();
-                List<VideoCaptureDeviceInfo> vcds = new List<VideoCaptureDeviceInfo>(devices.Count);
-                foreach (var device in devices)
-                {
-                    LogMessage($"VCD id={device.id} name={device.name}");
-                    VideoCaptureDevices.Add(new VideoCaptureDeviceInfo()
-                    {
-                        Id = device.id,
-                        DisplayName = device.name,
-                        Symbol = Symbol.Video
-                    });
-                }
+            //using (_sessionViewModel.GetNegotiationDeferral())
+            //{
+            //    // As a convenience, add 1 audio and 1 video transceivers
+            //    // TODO - make that more flexible
+            //    AddPendingTransceiver(MediaKind.Audio, "audio_transceiver_0");
+            //    AddPendingTransceiver(MediaKind.Video, "video_transceiver_1");
 
-                // Select first entry by default
-                if (VideoCaptureDevices.Count > 0)
-                {
-                    VideoCaptureDeviceList.SelectedIndex = 0;
-                }
-            }
+            //    // It is CRUCIAL to add any data channel BEFORE the SDP offer is sent, if data channels are
+            //    // to be used at all. Otherwise the SCTP will not be negotiated, and then all channels will
+            //    // stay forever in the kConnecting state.
+            //    // https://stackoverflow.com/questions/43788872/how-are-data-channels-negotiated-between-two-peers-with-webrtc
+            //    await _peerConnection.AddDataChannelAsync(ChatChannelID, "chat", true, true);
+            //}
 
-            // Initialize the native peer connection object
-            try
-            {
-                var config = new PeerConnectionConfiguration();
-                config.IceServers.Add(new IceServer { Urls = { "stun:" + stunServer.Text } });
-                config.SdpSemantic = (sdpSemanticUnifiedPlan.IsChecked.GetValueOrDefault(true)
-                    ? SdpSemantic.UnifiedPlan : SdpSemantic.PlanB);
-                await _peerConnection.InitializeAsync(config);
+            //chatInputBox.IsEnabled = true;
+            //chatSendButton.IsEnabled = true;
 
-                // Add one audio and one video transceiver to signal the connection that it needs
-                // to negotiate one audio transport and one video transport with the remote peer.
-                _audioTransceiver = _peerConnection.AddTransceiver(MediaKind.Audio);
-                _videoTransceiver = _peerConnection.AddTransceiver(MediaKind.Video);
-            }
-            catch (Exception ex)
-            {
-                LogMessage($"WebRTC native plugin init failed: {ex.Message}");
-                return;
-            }
+            //_videoPlayer.CurrentStateChanged += OnMediaStateChanged;
+            //_videoPlayer.MediaOpened += OnMediaOpened;
+            //_videoPlayer.MediaFailed += OnMediaFailed;
+            //_videoPlayer.MediaEnded += OnMediaEnded;
+            //_videoPlayer.RealTimePlayback = true;
+            //_videoPlayer.AutoPlay = false;
 
-            PluginInitialized = true;
-            LogMessage("WebRTC native plugin initialized.");
-
-            // It is CRUCIAL to add any data channel BEFORE the SDP offer is sent, if data channels are
-            // to be used at all. Otherwise the SCTP will not be negotiated, and then all channels will
-            // stay forever in the kConnecting state.
-            // https://stackoverflow.com/questions/43788872/how-are-data-channels-negotiated-between-two-peers-with-webrtc
-            var newDataChannel = await _peerConnection.AddDataChannelAsync(ChatChannelID, "chat", true, true);
-            chatInputBox.IsEnabled = true;
-            chatSendButton.IsEnabled = true;
-
-            startLocalMedia.IsEnabled = true;
-
-            localVideoPlayer.CurrentStateChanged += OnMediaStateChanged;
-            localVideoPlayer.MediaOpened += OnMediaOpened;
-            localVideoPlayer.MediaFailed += OnMediaFailed;
-            localVideoPlayer.MediaEnded += OnMediaEnded;
-            localVideoPlayer.RealTimePlayback = true;
-            localVideoPlayer.AutoPlay = false;
-
-            remoteVideoPlayer.CurrentStateChanged += OnMediaStateChanged;
-            remoteVideoPlayer.MediaOpened += OnMediaOpened;
-            remoteVideoPlayer.MediaFailed += OnMediaFailed;
-            remoteVideoPlayer.MediaEnded += OnMediaEnded;
-            remoteVideoPlayer.RealTimePlayback = true;
-            remoteVideoPlayer.AutoPlay = false;
-
-            // Bind the XAML UI control (localVideo) to the MediaFoundation rendering pipeline (localVideoPlayer)
-            // so that the former can render in the UI the video frames produced in the background by the later.
-            localVideo.SetMediaPlayer(localVideoPlayer);
-            remoteVideo.SetMediaPlayer(remoteVideoPlayer);
+            // Bind the XAML UI control (videoPlayerElement) to the MediaFoundation rendering pipeline (_videoPlayer)
+            // so that the former can render in the UI the video frames produced in the background by the latter.
+            //videoPlayerElement.SetMediaPlayer(_videoPlayer);
         }
 
-        private void PreferredAudioCodecChecked(object sender, RoutedEventArgs args)
-        {
-            // Ignore calls during startup, before components are initialized
-            if (PreferredAudioCodec_Custom == null)
-            {
-                return;
-            }
-
-            if (PreferredAudioCodec_Custom.IsChecked.GetValueOrDefault(false))
-            {
-                CustomPreferredAudioCodecHelpText.Visibility = Visibility.Visible;
-                CustomPreferredAudioCodec.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                CustomPreferredAudioCodecHelpText.Visibility = Visibility.Collapsed;
-                CustomPreferredAudioCodec.Visibility = Visibility.Collapsed;
-            }
-        }
-
-        private void PreferredVideoCodecChecked(object sender, RoutedEventArgs args)
-        {
-            // Ignore calls during startup, before components are initialized
-            if (PreferredVideoCodec_Custom == null)
-            {
-                return;
-            }
-
-            if (PreferredVideoCodec_Custom.IsChecked.GetValueOrDefault(false))
-            {
-                CustomPreferredVideoCodecHelpText.Visibility = Visibility.Visible;
-                CustomPreferredVideoCodec.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                CustomPreferredVideoCodecHelpText.Visibility = Visibility.Collapsed;
-                CustomPreferredVideoCodec.Visibility = Visibility.Collapsed;
-            }
-        }
-
-        /// <summary>
-        /// Update the list of video profiles stored in <cref>VideoProfiles</cref>
-        /// when the selected video capture device or known video profile kind change.
-        /// </summary>
-        private async void UpdateVideoProfiles()
-        {
-            VideoProfiles.Clear();
-            VideoCaptureFormats.Clear();
-
-            // Get the video capture device selected by the user
-            var deviceIndex = VideoCaptureDeviceList.SelectedIndex;
-            if (deviceIndex < 0)
-            {
-                return;
-            }
-            var device = VideoCaptureDevices[deviceIndex];
-
-            // Ensure that the video capture device actually supports video profiles
-            if (MediaCapture.IsVideoProfileSupported(device.Id))
-            {
-                // Get the kind of known video profile selected by the user
-                var videoProfileKindIndex = KnownVideoProfileKindComboBox.SelectedIndex;
-                if (videoProfileKindIndex < 0)
-                {
-                    return;
-                }
-                var videoProfileKind = (VideoProfileKind)Enum.GetValues(typeof(VideoProfileKind)).GetValue(videoProfileKindIndex);
-
-                // List all video profiles for the select device (and kind, if any specified)
-                IReadOnlyList<MediaCaptureVideoProfile> profiles;
-                if (videoProfileKind == VideoProfileKind.Unspecified)
-                {
-                    profiles = MediaCapture.FindAllVideoProfiles(device.Id);
-                }
-                else
-                {
-                    profiles = MediaCapture.FindKnownVideoProfiles(device.Id, (KnownVideoProfile)(videoProfileKind - 1));
-                }
-                foreach (var profile in profiles)
-                {
-                    VideoProfiles.Add(profile);
-                }
-                if (profiles.Any())
-                {
-                    VideoProfileComboBox.SelectedIndex = 0;
-                }
-            }
-            else
-            {
-                // Device doesn't support video profiles; fall back on flat list of capture formats.
-                List<VideoCaptureFormat> formatsList = await PeerConnection.GetVideoCaptureFormatsAsync(device.Id);
-                foreach (var format in formatsList)
-                {
-                    VideoCaptureFormats.Add(format);
-                }
-
-                // Default to first format, so that user can start the video capture even without selecting
-                // explicitly a format in a different application tab.
-                if (formatsList.Count > 0)
-                {
-                    VideoCaptureFormatList.SelectedIndex = 0;
-                }
-            }
-        }
-
-        private void VideoCaptureDeviceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            // Get the video capture device selected by the user
-            var deviceIndex = VideoCaptureDeviceList.SelectedIndex;
-            if (deviceIndex < 0)
-            {
-                return;
-            }
-            var device = VideoCaptureDevices[deviceIndex];
-
-            // Select a default video profile kind
-            var values = Enum.GetValues(typeof(VideoProfileKind));
-            if (MediaCapture.IsVideoProfileSupported(device.Id))
-            {
-                var defaultProfile = VideoProfileKind.VideoConferencing;
-                var profiles = MediaCapture.FindKnownVideoProfiles(device.Id, (KnownVideoProfile)(defaultProfile - 1));
-                if (!profiles.Any())
-                {
-                    // Fall back to VideoRecording if VideoConferencing has no profiles (e.g. HoloLens).
-                    defaultProfile = VideoProfileKind.VideoRecording;
-                }
-                KnownVideoProfileKindComboBox.SelectedIndex = Array.IndexOf(values, defaultProfile);
-
-                KnownVideoProfileKindComboBox.IsEnabled = true; //< TODO - Use binding
-                VideoProfileComboBox.IsEnabled = true;
-                RecordMediaDescList.IsEnabled = true;
-                VideoCaptureFormatList.IsEnabled = false;
-            }
-            else
-            {
-                KnownVideoProfileKindComboBox.SelectedIndex = Array.IndexOf(values, VideoProfileKind.Unspecified);
-                KnownVideoProfileKindComboBox.IsEnabled = false;
-                VideoProfileComboBox.IsEnabled = false;
-                RecordMediaDescList.IsEnabled = false;
-                VideoCaptureFormatList.IsEnabled = true;
-            }
-
-            UpdateVideoProfiles();
-        }
-
-        private void KnownVideoProfileKindComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            UpdateVideoProfiles();
-        }
-
-        private void VideoProfileComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            RecordMediaDescs.Clear();
-
-            var profile = SelectedVideoProfile;
-            if (profile == null)
-            {
-                return;
-            }
-
-            foreach (var desc in profile.SupportedRecordMediaDescription)
-            {
-                RecordMediaDescs.Add(desc);
-            }
-        }
-
-        //private void Shutdown(object sender, Windows.UI.Core.CoreWindowEventArgs e)
+        //private void ChatList_ItemClick(object sender, ItemClickEventArgs e)
         //{
-        //    webRTCNativePlugin.Uninitialize();
+        //    if (e.ClickedItem is ChatChannelModel chat)
+        //    {
+        //        chatTextBox.Text = chat.FullText;
+        //    }
         //}
 
-        /// <summary>
-        /// Callback invoked when the peer connection is established.
-        /// </summary>
-        private void OnPeerConnected()
-        {
-            RunOnMainThread(() => {
-                sessionStatusText.Text = "(session joined)";
-                chatTextBox.IsEnabled = true;
+        ///// <summary>
+        ///// Callback on Send button from text chat clicker.
+        ///// If connected, this sends the text message to the remote peer using
+        ///// the previously opened data channel.
+        ///// </summary>
+        ///// <param name="sender">The object which invoked the event.</param>
+        ///// <param name="e">Event arguments.</param>
+        //private void ChatSendButton_Click(object sender, RoutedEventArgs e)
+        //{
+        //    if (string.IsNullOrWhiteSpace(chatInputBox.Text))
+        //        return;
 
-                // Reset "Create Offer" button, and re-enable if signaling is available
-                createOfferButton.Content = "Create Offer";
-                createOfferButton.IsEnabled = isDssPolling;
-            });
-        }
+        //    var chat = SelectedChatChannel;
+        //    if (chat == null)
+        //        return;
 
-        private void DssSignaler_OnMessage(NodeDssSignaler.Message message)
+        //    // Send the message through the data channel
+        //    byte[] chatMessage = System.Text.Encoding.UTF8.GetBytes(chatInputBox.Text);
+        //    chat.DataChannel.SendMessage(chatMessage);
+
+        //    // Save and display in the UI
+        //    var newLine = $"[local] {chatInputBox.Text}\n";
+        //    chat.Text += newLine;
+        //    chatTextBox.Text = chat.Text; // reassign or append? not sure...
+        //    chatScrollViewer.ChangeView(chatScrollViewer.HorizontalOffset,
+        //        chatScrollViewer.ScrollableHeight,
+        //        chatScrollViewer.ZoomFactor); // scroll to end
+        //    chatInputBox.Text = string.Empty;
+        //}
+
+        ///// <summary>
+        ///// Callback on key down event invoked in the chat window, to handle
+        ///// the "press Enter to send" text chat functionality.
+        ///// </summary>
+        ///// <param name="sender">The object which invoked the event.</param>
+        ///// <param name="e">Event arguments.</param>
+        //private void OnChatKeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        //{
+        //    if (e.Key == Windows.System.VirtualKey.Enter)
+        //    {
+        //        ChatSendButton_Click(this, null);
+        //    }
+        //}
+
+        private void OnNavigationViewItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
         {
-            Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            if (args.IsSettingsInvoked)
             {
-                // Ensure that the filtering values are up to date before passing the message on.
-                UpdateCodecFilters();
-            }).AsTask().ContinueWith(async _ =>
-            {
-                switch (message.MessageType)
-                {
-                    case NodeDssSignaler.Message.WireMessageType.Offer:
-                        await _peerConnection.SetRemoteDescriptionAsync("offer", message.Data);
-                        // If we get an offer, we immediately send an answer back once the offer is applied
-                        _peerConnection.CreateAnswer();
-                        break;
-
-                    case NodeDssSignaler.Message.WireMessageType.Answer:
-                        _ = _peerConnection.SetRemoteDescriptionAsync("answer", message.Data);
-                        break;
-
-                    case NodeDssSignaler.Message.WireMessageType.Ice:
-                        // TODO - This is NodeDSS-specific
-                        // this "parts" protocol is defined above, in OnIceCandidateReadyToSend listener
-                        var parts = message.Data.Split(new string[] { message.IceDataSeparator }, StringSplitOptions.RemoveEmptyEntries);
-                        // Note the inverted arguments; candidate is last here, but first in OnIceCandidateReadyToSend
-                        _peerConnection.AddIceCandidate(parts[2], int.Parse(parts[1]), parts[0]);
-                        break;
-
-                    default:
-                        throw new InvalidOperationException($"Unhandled signaler message type '{message.MessageType}'");
-                }
-            }, TaskScheduler.Default);
-        }
-
-        private void DssSignaler_OnFailure(Exception e)
-        {
-            RunOnMainThread(() => {
-                LogMessage($"DSS polling failed: {e.Message}");
-                // TODO - differentiate between StartPollingAsync() failure and SendMessageAsync() ones!
-                if (dssSignaler.IsPolling)
-                {
-                    LogMessage($"Cancelling polling DSS server...");
-                    //pollDssButton.IsEnabled = false; // will be re-enabled when cancellation is completed, see DssSignaler_OnPollingDone
-                    pollDssButton.Content = "Start polling";
-                    dssSignaler.StopPollingAsync();
-                }
-            });
-        }
-
-        private void DssSignaler_OnPollingDone()
-        {
-            RunOnMainThread(() => {
-                isDssPolling = false;
-                pollDssButton.IsEnabled = true;
-                LogMessage($"Polling DSS server stopped.");
-            });
-        }
-
-        /// <summary>
-        /// Log a message to the debugger and to the Debug tab in the UI.
-        /// This can be called from any thread.
-        /// </summary>
-        /// <param name="message">The message to log.</param>
-        private void LogMessage(string message)
-        {
-            Debugger.Log(4, "TestAppUWP", message);
-            RunOnMainThread(() => {
-                debugMessages.Text += message + "\n";
-            });
-        }
-
-        /// <summary>
-        /// Utility to run some random workload on the main UI thread.
-        /// </summary>
-        /// <param name="handler">The workload to run.</param>
-        private void RunOnMainThread(Windows.UI.Core.DispatchedHandler handler)
-        {
-            if (Dispatcher.HasThreadAccess)
-            {
-                handler.Invoke();
+                rootFrame.Navigate(typeof(SettingsPage));
             }
             else
             {
-                // Note: use a discard "_" to silence CS4014 warning; we don't need to await the result here
-                _ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, handler);
-            }
-        }
-
-        /// <summary>
-        /// Utility to run some random workload on a worker thread (not the main UI thread).
-        /// </summary>
-        /// <param name="handler">The workload to run.</param>
-        private Task RunOnWorkerThread(Action handler)
-        {
-            if (Dispatcher.HasThreadAccess)
-            {
-                return Task.Run(handler);
-            }
-            else
-            {
-                handler.Invoke();
-                return Task.CompletedTask;
-            }
-        }
-
-        /// <summary>
-        /// Create a new 30-fps NV12-encoded video source for the specified video size.
-        /// </summary>
-        /// <param name="width">The width of the video in pixels.</param>
-        /// <param name="height">The height of the video in pixels.</param>
-        /// <returns>The newly created video source.</returns>
-        private MediaStreamSource CreateVideoStreamSource(uint width, uint height, uint framerate)
-        {
-            if (width == 0)
-            {
-                throw new ArgumentException("Invalid zero width for video stream source.", "width");
-            }
-            if (height == 0)
-            {
-                throw new ArgumentException("Invalid zero height for video stream source.", "height");
-            }
-
-            // Note: IYUV and I420 have same memory layout (though different FOURCC)
-            // https://docs.microsoft.com/en-us/windows/desktop/medfound/video-subtype-guids
-            var videoProperties = VideoEncodingProperties.CreateUncompressed(MediaEncodingSubtypes.Iyuv, width, height);
-            var videoStreamDesc = new VideoStreamDescriptor(videoProperties);
-            videoStreamDesc.EncodingProperties.FrameRate.Numerator = framerate;
-            videoStreamDesc.EncodingProperties.FrameRate.Denominator = 1;
-            videoStreamDesc.EncodingProperties.Bitrate = (framerate * width * height * 12); // NV12=12bpp
-            var videoStreamSource = new MediaStreamSource(videoStreamDesc);
-            videoStreamSource.BufferTime = TimeSpan.Zero; // TODO : playback breaks if buffering, need to investigate
-            videoStreamSource.Starting += OnMediaStreamSourceStarting;
-            videoStreamSource.Closed += OnMediaStreamSourceClosed;
-            videoStreamSource.Paused += OnMediaStreamSourcePaused;
-            videoStreamSource.SampleRequested += OnMediaStreamSourceRequested;
-            videoStreamSource.IsLive = true; // Enables optimizations for live sources
-            videoStreamSource.CanSeek = false; // Cannot seek live WebRTC video stream
-            return videoStreamSource;
-        }
-
-        private void OnMediaStreamSourceStarting(MediaStreamSource sender, MediaStreamSourceStartingEventArgs args)
-        {
-            Debug.Assert(Dispatcher.HasThreadAccess == false);
-            if (sender == localVideoSource)
-            {
-                LogMessage("Starting local A/V stream...");
-                //webRTCNativePlugin.Peer.AddStream(audio: true, video_device_index: _video_device_index);
-            }
-            else if (sender == remoteVideoSource)
-            {
-                LogMessage("Starting remote A/V stream...");
-            }
-            args.Request.SetActualStartPosition(TimeSpan.Zero);
-        }
-
-        private void OnMediaStreamSourceClosed(MediaStreamSource sender, MediaStreamSourceClosedEventArgs args)
-        {
-            Debug.Assert(Dispatcher.HasThreadAccess == false);
-            if (sender == localVideoSource)
-            {
-                LogMessage("Closing local A/V stream...");
-                //webRTCNativePlugin.Peer.RemoveStream(audio: true, video: true);
-            }
-            else if (sender == remoteVideoSource)
-            {
-                LogMessage("Closing remote A/V stream...");
-            }
-        }
-
-        private void OnMediaStreamSourcePaused(MediaStreamSource sender, object args)
-        {
-            Debug.Assert(Dispatcher.HasThreadAccess == false);
-            if (sender == localVideoSource)
-            {
-                LogMessage("Pausing local A/V stream...");
-                //webRTCNativePlugin.Peer.RemoveStream(audio: true, video: true); // NOT YET!
-            }
-            else if (sender == remoteVideoSource)
-            {
-                LogMessage("Pausing remote A/V stream...");
-            }
-        }
-
-        /// <summary>
-        /// Callback from the Media Foundation pipeline when a new video frame is needed.
-        /// </summary>
-        /// <param name="sender">The stream source requesting a new sample.</param>
-        /// <param name="args">The sample request to fullfil.</param>
-        private void OnMediaStreamSourceRequested(MediaStreamSource sender, MediaStreamSourceSampleRequestedEventArgs args)
-        {
-            VideoBridge videoBridge;
-            if (sender == localVideoSource)
-                videoBridge = localVideoBridge;
-            else if (sender == remoteVideoSource)
-                videoBridge = remoteVideoBridge;
-            else
-                return;
-            videoBridge.TryServeVideoFrame(args);
-        }
-
-        private void OnMediaStateChanged(Windows.Media.Playback.MediaPlayer sender, object args)
-        {
-            RunOnMainThread(() => {
-                if (sender == localVideoPlayer)
+                // TODO: use e.g. args.InvokedItemContainer.Tag to avoid string matching and be more reliable?
+                foreach (var catBase in Categories)
                 {
-                    localVideoStateText.Text = $"State: {sender.PlaybackSession.PlaybackState}";
-                }
-                else if (sender == remoteVideoPlayer)
-                {
-                    remoteVideoStateText.Text = $"State: {sender.PlaybackSession.PlaybackState}";
-                }
-            });
-        }
-
-        /// <summary>
-        /// Callback on Media Foundation pipeline media successfully opened and
-        /// ready to be played in a local media player.
-        /// </summary>
-        /// <param name="sender">The <see xref="MediaPlayer"/> source object owning the media.</param>
-        /// <param name="args">(unused)</param>
-        private void OnMediaOpened(MediaPlayer sender, object args)
-        {
-            // Now it is safe to call Play() on the MediaElement
-            if (sender == localVideoPlayer)
-            {
-                RunOnMainThread(() => {
-                    localVideo.MediaPlayer.Play();
-                });
-            }
-            else if (sender == remoteVideoPlayer)
-            {
-                RunOnMainThread(() => {
-                    remoteVideo.MediaPlayer.Play();
-                });
-            }
-        }
-
-        /// <summary>
-        /// Callback on Media Foundation pipeline media failed to open or to continue playback.
-        /// </summary>
-        /// <param name="sender">The <see xref="MediaPlayer"/> source object owning the media.</param>
-        /// <param name="args">(unused)</param>
-        private void OnMediaFailed(MediaPlayer sender, MediaPlayerFailedEventArgs args)
-        {
-            LogMessage($"MediaElement reported an error: \"{args.ErrorMessage}\" (\"{args.ExtendedErrorCode.Message}\")");
-        }
-
-        /// <summary>
-        /// Callback on Media Foundation pipeline media ended playback.
-        /// </summary>
-        /// <param name="sender">The <see xref="MediaPlayer"/> source object owning the media.</param>
-        /// <param name="args">(unused)</param>
-        /// <remarks>This appears to never be called for live sources.</remarks>
-        private void OnMediaEnded(MediaPlayer sender, object args)
-        {
-            RunOnMainThread(() => {
-                LogMessage("Local MediaElement video playback ended.");
-                //StopLocalMedia();
-                sender.Pause();
-                sender.Source = null;
-                if (sender == localVideoPlayer)
-                {
-                    //< TODO - This should never happen. But what to do with
-                    //         local channels if it happens?
-                    lock (_isLocalMediaPlayingLock)
+                    if (catBase is Category cat)
                     {
-                        _isLocalVideoPlaying = false;
-                    }
-                }
-            });
-        }
-
-        /// <summary>
-        /// Stop playback of the local video from the local webcam, and remove the local
-        /// audio and video tracks from the peer connection.
-        /// This is called on the UI thread.
-        /// </summary>
-        private async void StopLocalMedia()
-        {
-            lock (_isLocalMediaPlayingLock)
-            {
-                if (_isLocalVideoPlaying)
-                {
-                    localVideo.MediaPlayer.Pause();
-                    localVideo.MediaPlayer.Source = null;
-                    localVideo.SetMediaPlayer(null);
-                    localVideoSource.NotifyError(MediaStreamSourceErrorStatus.Other);
-                    localVideoSource = null;
-                    localMediaSource.Dispose();
-                    localMediaSource = null;
-                    _isLocalVideoPlaying = false;
-                    _localAudioTrack.AudioFrameReady -= LocalAudioTrack_FrameReady;
-                    _localVideoTrack.I420AVideoFrameReady -= LocalVideoTrack_I420AFrameReady;
-                }
-            }
-
-            // Avoid deadlock in audio processing stack, as this call is delegated to the WebRTC
-            // signaling thread (and will block the caller thread), and audio processing will
-            // delegate to the UI thread for UWP operations (and will block the signaling thread).
-            await RunOnWorkerThread(() => {
-                lock (_isLocalMediaPlayingLock)
-                {
-                    _audioTransceiver.LocalAudioTrack = null;
-                    _videoTransceiver.LocalVideoTrack = null;
-                    _renegotiationOfferEnabled = true;
-                    if (_peerConnection.IsConnected)
-                    {
-                        _peerConnection.CreateOffer();
-                    }
-                    _localAudioTrack.Dispose();
-                    _localAudioTrack = null;
-                    _localVideoTrack.Dispose();
-                    _localVideoTrack = null;
-                }
-            });
-
-            startLocalMedia.IsEnabled = true;
-        }
-
-        /// <summary>
-        /// Callback on remote media (audio or video) track added.
-        /// Currently does nothing, as starting the media pipeline is done lazily in the
-        /// per-frame callback.
-        /// </summary>
-        /// <param name="track">The audio track added.</param>
-        /// <seealso cref="RemoteAudioTrack_FrameReady"/>
-        private void Peer_RemoteAudioTrackAdded(RemoteAudioTrack track)
-        {
-            LogMessage($"Added remote audio track {track.Name}.");
-            lock (_isRemoteMediaPlayingLock)
-            {
-                if ((_remoteAudioTrack == null) && !_isRemoteAudioPlaying)
-                {
-                    _remoteAudioTrack = track;
-                    _remoteAudioTrack.AudioFrameReady += RemoteAudioTrack_FrameReady;
-
-                    // _isRemoteAudioPlaying will change to true once the first frame is received
-                }
-            }
-        }
-
-        /// <summary>
-        /// Callback on remote media (audio or video) track added.
-        /// Currently does nothing, as starting the media pipeline is done lazily in the
-        /// per-frame callback.
-        /// </summary>
-        /// <param name="track">The video track added.</param>
-        /// <seealso cref="RemoteVideoTrack_I420AFrameReady"/>
-        private void Peer_RemoteVideoTrackAdded(RemoteVideoTrack track)
-        {
-            LogMessage($"Added remote video track {track.Name}.");
-            lock (_isRemoteMediaPlayingLock)
-            {
-                if ((_remoteVideoTrack == null) && !_isRemoteVideoPlaying)
-                {
-                    _remoteVideoTrack = track;
-                    _remoteVideoTrack.I420AVideoFrameReady += RemoteVideoTrack_I420AFrameReady;
-
-                    // _isRemoteVideoPlaying will change to true once the first frame is received
-
-                    RunOnMainThread(() => {
-                        remoteVideoStatsTimer.Interval = TimeSpan.FromSeconds(1.0);
-                        remoteVideoStatsTimer.Start();
-                    });
-                }
-            }
-        }
-
-        /// <summary>
-        /// Callback on remote media (audio or video) track removed.
-        /// </summary>
-        /// <param name="track">The audio track removed.</param>
-        private void Peer_RemoteAudioTrackRemoved(Transceiver transceiver, RemoteAudioTrack track)
-        {
-            LogMessage($"Removed remote audio track {track.Name} from transceiver {transceiver.Name}.");
-
-            // Just double-check that the remote audio track is indeed playing
-            // before scheduling a task to stop it. Currently the remote audio
-            // playback is exclusively controlled by the remote track being present
-            // or not, so these should be always in sync.
-            lock (_isRemoteMediaPlayingLock)
-            {
-                if ((_remoteAudioTrack == track) && _isRemoteAudioPlaying)
-                {
-                    _remoteAudioTrack.AudioFrameReady -= RemoteAudioTrack_FrameReady;
-                    _remoteAudioTrack = null;
-
-                    // Schedule on the main UI thread to access STA objects.
-                    RunOnMainThread(() => {
-                        ClearRemoteAudioStats();
-                        // Check that the remote audio is still playing.
-                        // This ensures that rapid calls to add/remove the audio track
-                        // are serialized, and an earlier remove call doesn't remove the
-                        // track added by a later call, due to delays in scheduling the task.
-                        lock (_isRemoteMediaPlayingLock)
+                        if (cat.PageType == null)
                         {
-                            if (_isRemoteAudioPlaying)
-                            {
-                                _isRemoteAudioPlaying = false;
-                            }
+                            continue;
                         }
-                    });
-                }
-            }
-        }
-
-        /// <summary>
-        /// Callback on remote media (audio or video) track removed.
-        /// </summary>
-        /// <param name="track">The video track removed.</param>
-        private void Peer_RemoteVideoTrackRemoved(Transceiver transceiver, RemoteVideoTrack track)
-        {
-            LogMessage($"Removed remote video track {track.Name} from transceiver {transceiver.Name}.");
-
-            // Just double-check that the remote video track is indeed playing
-            // before scheduling a task to stop it. Currently the remote video
-            // playback is exclusively controlled by the remote track being present
-            // or not, so these should be always in sync.
-            lock (_isRemoteMediaPlayingLock)
-            {
-                if ((_remoteVideoTrack == track) && _isRemoteVideoPlaying)
-                {
-                    _remoteVideoTrack.I420AVideoFrameReady -= RemoteVideoTrack_I420AFrameReady;
-                    _remoteVideoTrack = null;
-
-                    // Schedule on the main UI thread to access STA objects.
-                    RunOnMainThread(() => {
-                        remoteVideoStatsTimer.Stop();
-                        // Check that the remote video is still playing.
-                        // This ensures that rapid calls to add/remove the video track
-                        // are serialized, and an earlier remove call doesn't remove the
-                        // track added by a later call, due to delays in scheduling the task.
-                        lock (_isRemoteMediaPlayingLock)
+                        if ((args.InvokedItem as string) == cat.Name)
                         {
-                            if (_isRemoteVideoPlaying)
-                            {
-                                remoteVideo.MediaPlayer.Pause();
-                                _isRemoteVideoPlaying = false;
-                            }
+                            rootFrame.Navigate(cat.PageType);
                         }
-                    });
-                }
-            }
-        }
-
-        /// <summary>
-        /// Callback on video frame received from the local video capture device,
-        /// for local rendering before (or in parallel of) being sent to the remote peer.
-        /// </summary>
-        /// <param name="frame">The newly captured video frame.</param>
-        private void LocalVideoTrack_I420AFrameReady(I420AVideoFrame frame)
-        {
-            localVideoBridge.HandleIncomingVideoFrame(frame);
-        }
-
-        /// <summary>
-        /// Callback on video frame received from the remote peer, for local rendering
-        /// (or any other use).
-        /// </summary>
-        /// <param name="frame">The newly received video frame.</param>
-        private void RemoteVideoTrack_I420AFrameReady(I420AVideoFrame frame)
-        {
-            // Lazily start the remote video media player when receiving
-            // the first video frame from the remote peer. Currently there
-            // is no exposed API to tell once connected that the remote peer
-            // will be sending some video track.
-            //< TODO - See if we can add an API to enumerate the remote channels,
-            //         or an On(Audio|Video|Data)Channel(Added|Removed) event?
-            bool needNewSource = false;
-            uint width = frame.width;
-            uint height = frame.height;
-            lock (_isRemoteMediaPlayingLock)
-            {
-                if (!_isRemoteVideoPlaying)
-                {
-                    _isRemoteVideoPlaying = true;
-                    _remoteVideoWidth = width;
-                    _remoteVideoHeight = height;
-                    needNewSource = true;
-                }
-                else if ((width != _remoteVideoWidth) || (height != _remoteVideoHeight))
-                {
-                    _remoteVideoWidth = width;
-                    _remoteVideoHeight = height;
-                    needNewSource = true;
-                }
-            }
-            if (needNewSource)
-            {
-                // We don't know the remote video framerate yet, so use a default.
-                uint framerate = 30;
-                RunOnMainThread(() => {
-                    remoteVideoPlayer.Pause();
-                    remoteVideoPlayer.Source = null;
-                    remoteVideo.SetMediaPlayer(null);
-                    remoteVideoSource?.NotifyError(MediaStreamSourceErrorStatus.Other);
-                    remoteMediaSource?.Dispose();
-                    remoteVideoSource = CreateVideoStreamSource(width, height, framerate);
-                    remoteMediaSource = MediaSource.CreateFromMediaStreamSource(remoteVideoSource);
-                    remoteVideoPlayer.Source = remoteMediaSource;
-                    remoteVideo.SetMediaPlayer(remoteVideoPlayer);
-                });
-            }
-
-            remoteVideoBridge.HandleIncomingVideoFrame(frame);
-        }
-
-        /// <summary>
-        /// Callback on audio frame produced by the local peer.
-        /// </summary>
-        /// <param name="frame">The newly produced audio frame.</param>
-        private void LocalAudioTrack_FrameReady(AudioFrame frame)
-        {
-        }
-
-        /// <summary>
-        /// Callback on audio frame received from the remote peer, for local output
-        /// (or any other use).
-        /// </summary>
-        /// <param name="frame">The newly received audio frame.</param>
-        private void RemoteAudioTrack_FrameReady(AudioFrame frame)
-        {
-            lock (_isRemoteMediaPlayingLock)
-            {
-                uint channelCount = frame.channelCount;
-                uint sampleRate = frame.sampleRate;
-                if (!_isRemoteAudioPlaying || (_remoteAudioChannelCount != channelCount)
-                    || (_remoteAudioSampleRate != sampleRate))
-                {
-                    _isRemoteAudioPlaying = true;
-                    _remoteAudioChannelCount = channelCount;
-                    _remoteAudioSampleRate = sampleRate;
-
-                    // As an example of handling, update the UI to display the number of audio
-                    // channels and the sample rate of the audio track.
-                    RunOnMainThread(() => UpdateRemoteAudioStats(channelCount, sampleRate));
-                }
-            }
-        }
-
-        private void ClearRemoteAudioStats()
-        {
-            remoteAudioChannelCount.Text = "-";
-            remoteAudioSampleRate.Text = "-";
-        }
-
-        private void UpdateRemoteAudioStats(uint channelCount, uint sampleRate)
-        {
-            remoteAudioChannelCount.Text = channelCount.ToString();
-            remoteAudioSampleRate.Text = $"{sampleRate} Hz";
-        }
-
-        private void MuteLocalVideoClicked(object sender, RoutedEventArgs e)
-        {
-            if (_localVideoTrack.Enabled)
-            {
-                _localVideoTrack.Enabled = false;
-                muteLocalVideoStroke.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                _localVideoTrack.Enabled = true;
-                muteLocalVideoStroke.Visibility = Visibility.Collapsed;
-            }
-        }
-
-        private void MuteLocalAudioClicked(object sender, RoutedEventArgs e)
-        {
-            if (_localAudioTrack.Enabled)
-            {
-                _localAudioTrack.Enabled = false;
-                muteLocalAudioStroke.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                _localAudioTrack.Enabled = true;
-                muteLocalAudioStroke.Visibility = Visibility.Collapsed;
-            }
-        }
-
-        /// <summary>
-        /// Toggle local audio and video playback on/off, adding or removing tracks as needed.
-        /// </summary>
-        /// <param name="sender">The object which invoked the event.</param>
-        /// <param name="e">Event arguments.</param>
-        private async void StartLocalMediaClicked(object sender, RoutedEventArgs e)
-        {
-            // The button will be re-enabled once the current action is finished
-            startLocalMedia.IsEnabled = false;
-
-            // Toggle between start and stop local audio/video feeds
-            if (localVideoStatsTimer.IsEnabled && (_localVideoTrack != null))
-            {
-                StopLocalMedia();
-                localVideoStatsTimer.Stop();
-                localLoadText.Text = "Produce: -";
-                localPresentText.Text = "Render: -";
-                localSkipText.Text = "Skip: -";
-                localLateText.Text = "Late: -";
-                muteLocalVideo.IsEnabled = false;
-                muteLocalAudio.IsEnabled = false;
-                startLocalMediaIcon.Symbol = Symbol.Play;
-                muteLocalAudioStroke.Visibility = Visibility.Collapsed;
-                muteLocalVideoStroke.Visibility = Visibility.Collapsed;
-                return;
-            }
-
-            // Only start video if previous track was completely shutdown
-            if (_localVideoTrack == null)
-            {
-                LogMessage("Opening local A/V stream...");
-
-                var captureDevice = SelectedVideoCaptureDevice;
-                var captureDeviceInfo = new VideoCaptureDevice()
-                {
-                    id = captureDevice?.Id,
-                    name = captureDevice?.DisplayName
-                };
-                var videoProfile = SelectedVideoProfile;
-                string videoProfileId = videoProfile?.Id;
-                uint width;
-                uint height;
-                double framerate;
-                if (videoProfile != null)
-                {
-                    var recordMediaDesc = SelectedRecordMediaDesc ?? videoProfile.SupportedRecordMediaDescription[0];
-                    width = recordMediaDesc.Width;
-                    height = recordMediaDesc.Height;
-                    framerate = recordMediaDesc.FrameRate;
-                }
-                else
-                {
-                    var captureFormat = SelectedVideoCaptureFormat;
-                    if (captureFormat.HasValue)
-                    {
-                        width = captureFormat.Value.width;
-                        height = captureFormat.Value.height;
-                        framerate = captureFormat.Value.framerate;
-                    }
-                    else
-                    {
-                        LogMessage("Cannot start video capture; no capture format selected.");
-                        return;
                     }
                 }
-
-                localVideoPlayer.Source = null;
-                localVideoSource?.NotifyError(MediaStreamSourceErrorStatus.Other);
-                localMediaSource?.Dispose();
-                localVideo.SetMediaPlayer(null);
-                localVideoSource = CreateVideoStreamSource(width, height, (uint)framerate);
-                localMediaSource = MediaSource.CreateFromMediaStreamSource(localVideoSource);
-                localVideoPlayer.Source = localMediaSource;
-                localVideo.SetMediaPlayer(localVideoPlayer);
-
-                // Disable auto-offer on renegotiation needed event, to bundle the audio + video tracks
-                // change together into a single SDP offer. Otherwise each added track will send a
-                // separate offer message, which is currently not handled correctly (the second message
-                // will arrive too soon, before the core implementation finished processing the first one
-                // and is in kStable state, and it will get discarded so remote video will not start).
-                _renegotiationOfferEnabled = false;
-
-                // Ensure that the filtering values are up to date before creating new tracks.
-                UpdateCodecFilters();
-
-                // The default start bitrate is quite low (300 kbps); use a higher value to get
-                // better quality on local network.
-                _peerConnection.SetBitrate(startBitrateBps: (uint)(width * height * framerate / 20));
-
-                try
-                {
-                    // Create the local audio track captured from the local microphone
-                    _localAudioTrack = await LocalAudioTrack.CreateFromDeviceAsync();
-                    _localAudioTrack.AudioFrameReady += LocalAudioTrack_FrameReady;
-
-                    // Create the local video track captured from the local webcam
-                    var videoConfig = new LocalVideoTrackSettings
-                    {
-                        trackName = "local_video",
-                        videoDevice = captureDeviceInfo,
-                        videoProfileId = videoProfileId,
-                        videoProfileKind = SelectedVideoProfileKind,
-                        width = width,
-                        height = height,
-                        framerate = framerate,
-                        enableMrc = false // TestAppUWP is a shared app, MRC will not get permission anyway
-                    };
-                    _localVideoTrack = await LocalVideoTrack.CreateFromDeviceAsync(videoConfig);
-                    _localVideoTrack.I420AVideoFrameReady += LocalVideoTrack_I420AFrameReady;
-
-                    // Add the local tracks to the peer connection
-                    _audioTransceiver.LocalAudioTrack = _localAudioTrack;
-                    _videoTransceiver.LocalVideoTrack = _localVideoTrack;
-                }
-                catch (Exception ex)
-                {
-                    LogMessage(ex.Message);
-                    _renegotiationOfferEnabled = true;
-                    return;
-                }
-
-                localVideoStatsTimer.Interval = TimeSpan.FromSeconds(1.0);
-                localVideoStatsTimer.Start();
-                muteLocalVideo.IsEnabled = true;
-                muteLocalAudio.IsEnabled = true;
-                startLocalMediaIcon.Symbol = Symbol.Stop;
-                muteLocalAudioStroke.Visibility = Visibility.Collapsed;
-                muteLocalVideoStroke.Visibility = Visibility.Collapsed;
-
-                localVideoSourceName.Text = $"({SelectedVideoCaptureDevice?.DisplayName})";
-                lock (_isLocalMediaPlayingLock)
-                {
-                    _isLocalVideoPlaying = true;
-                }
-
-                // Re-enable auto-offer on track change, and manually apply above changes
-                // by creating a manual SDP offer to negotiate the new tracks.
-                _renegotiationOfferEnabled = true;
-                if (_peerConnection.IsConnected)
-                {
-                    _peerConnection.CreateOffer();
-                }
-
-                // Enable stopping the local audio and video
-                startLocalMedia.IsEnabled = true;
-            }
-        }
-
-        private void OnLocalVideoStatsTimerTicked(object sender, object e)
-        {
-            localLoadText.Text = $"Produce: {localVideoBridge.FrameLoad:F2}";
-            localPresentText.Text = $"Render: {localVideoBridge.FramePresent:F2}";
-            localSkipText.Text = $"Skip: {localVideoBridge.FrameSkip:F2}";
-            //localLateText.Text = $"Late: {localVideoBridge.LateFrame:F2}";
-        }
-
-        private void OnRemoteVideoStatsTimerTicked(object sender, object e)
-        {
-            remoteLoadText.Text = $"Receive: {remoteVideoBridge.FrameLoad:F2}";
-            remotePresentText.Text = $"Render: {remoteVideoBridge.FramePresent:F2}";
-            remoteSkipText.Text = $"Skip: {remoteVideoBridge.FrameSkip:F2}";
-            //remoteLateText.Text = $"Late: {remoteVideoBridge.LateFrame:F2}";
-        }
-
-        void UpdateCodecFilters()
-        {
-            _peerConnection.PreferredAudioCodec = PreferredAudioCodec;
-            _peerConnection.PreferredAudioCodecExtraParamsRemote = PreferredAudioCodecExtraParamsRemoteTextBox.Text;
-            _peerConnection.PreferredAudioCodecExtraParamsLocal = PreferredAudioCodecExtraParamsLocalTextBox.Text;
-            _peerConnection.PreferredVideoCodec = PreferredVideoCodec;
-            _peerConnection.PreferredVideoCodecExtraParamsRemote = PreferredVideoCodecExtraParamsRemoteTextBox.Text;
-            _peerConnection.PreferredVideoCodecExtraParamsLocal = PreferredVideoCodecExtraParamsLocalTextBox.Text;
-        }
-
-        private void CreateOfferButtonClicked(object sender, RoutedEventArgs e)
-        {
-            if (!PluginInitialized)
-            {
-                return;
-            }
-
-            createOfferButton.IsEnabled = false;
-            createOfferButton.Content = "Joining...";
-
-            // Ensure that the filtering values are up to date before starting to create messages.
-            UpdateCodecFilters();
-            _peerConnection.CreateOffer();
-        }
-
-        private async void AddExtraDataChannelButtonClicked(object sender, RoutedEventArgs e)
-        {
-            if (!PluginInitialized)
-            {
-                return;
-            }
-            await _peerConnection.AddDataChannelAsync("extra_channel", true, true);
-        }
-
-        private void PollDssButtonClicked(object sender, RoutedEventArgs e)
-        {
-            // If already polling, stop
-            if (isDssPolling)
-            {
-                LogMessage($"Cancelling polling DSS server...");
-                pollDssButton.IsEnabled = false; // will be re-enabled when cancellation is completed, see DssSignaler_OnPollingDone
-                pollDssButton.Content = "Start polling";
-                dssSignaler.StopPollingAsync();
-                // Cannot create offer before signaling is ready
-                createOfferButton.IsEnabled = false;
-                return;
-            }
-
-            // If not polling, try to start if the poll parameters are valid
-            if (!float.TryParse(dssPollTimeMs.Text, out float pollTimeMs))
-            {
-                // Invalid time format, cannot start polling
-                return;
-            }
-            if (string.IsNullOrEmpty(localPeerUidTextBox.Text) || string.IsNullOrEmpty(remotePeerUidTextBox.Text))
-            {
-                // Invalid peer ID, cannot start polling
-                return;
-            }
-
-            dssSignaler.HttpServerAddress = dssServer.Text;
-            dssSignaler.LocalPeerId = localPeerUidTextBox.Text;
-            dssSignaler.RemotePeerId = remotePeerUidTextBox.Text;
-            dssSignaler.PollTimeMs = pollTimeMs;
-            if (dssSignaler.StartPollingAsync())
-            {
-                pollDssButton.Content = "Stop polling";
-                isDssPolling = true;
-                // Cannot create offer before signaling is ready
-                createOfferButton.IsEnabled = true;
-            }
-        }
-
-        private void NavLinksList_ItemClick(object sender, ItemClickEventArgs e)
-        {
-
-        }
-
-        private void ChatList_ItemClick(object sender, ItemClickEventArgs e)
-        {
-            if (e.ClickedItem is ChatChannel chat)
-            {
-                chatTextBox.Text = chat.Text;
-            }
-        }
-
-        /// <summary>
-        /// Callback on Send button from text chat clicker.
-        /// If connected, this sends the text message to the remote peer using
-        /// the previously opened data channel.
-        /// </summary>
-        /// <param name="sender">The object which invoked the event.</param>
-        /// <param name="e">Event arguments.</param>
-        private void ChatSendButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(chatInputBox.Text))
-                return;
-
-            var chat = SelectedChatChannel;
-            if (chat == null)
-                return;
-
-            // Send the message through the data channel
-            byte[] chatMessage = System.Text.Encoding.UTF8.GetBytes(chatInputBox.Text);
-            chat.DataChannel.SendMessage(chatMessage);
-
-            // Save and display in the UI
-            var newLine = $"[local] {chatInputBox.Text}\n";
-            chat.Text += newLine;
-            chatTextBox.Text = chat.Text; // reassign or append? not sure...
-            chatScrollViewer.ChangeView(chatScrollViewer.HorizontalOffset,
-                chatScrollViewer.ScrollableHeight,
-                chatScrollViewer.ZoomFactor); // scroll to end
-            chatInputBox.Text = string.Empty;
-        }
-
-        /// <summary>
-        /// Callback on text message received through the data channel.
-        /// </summary>
-        /// <param name="message">The raw data channel message.</param>
-        private void ChatMessageReceived(ChatChannel chat, string text)
-        {
-            chat.Text += $"[remote] {text}\n";
-            if (SelectedChatChannel == chat)
-            {
-                chatTextBox.Text = chat.Text; // reassign or append? not sure...
-                chatScrollViewer.ChangeView(chatScrollViewer.HorizontalOffset,
-                    chatScrollViewer.ScrollableHeight,
-                    chatScrollViewer.ZoomFactor); // scroll to end
-            }
-        }
-
-        /// <summary>
-        /// Callback on key down event invoked in the chat window, to handle
-        /// the "press Enter to send" text chat functionality.
-        /// </summary>
-        /// <param name="sender">The object which invoked the event.</param>
-        /// <param name="e">Event arguments.</param>
-        private void OnChatKeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
-        {
-            if (e.Key == Windows.System.VirtualKey.Enter)
-            {
-                ChatSendButton_Click(this, null);
             }
         }
     }

--- a/examples/TestAppUwp/MainPage.xaml.cs
+++ b/examples/TestAppUwp/MainPage.xaml.cs
@@ -110,18 +110,11 @@ namespace TestAppUwp
             //        navigationView.MenuItems.Add(new NavigationViewItemSeparator());
             //    }
             //}
-
-            // Open the "Signaling" page by default
             //navigationView.MenuItemsSource = Categories;
+
+            // Open the first page by default
             rootFrame.Navigate((Categories[0] as Category).PageType);
             //((NavigationViewItem)(navigationView.MenuItems[0])).IsSelected = true; // doesn't work...
-
-            // Those are called during InitializeComponent() but before the controls are initialized (!).
-            // Force-call again to actually initialize the panels correctly.
-            //PreferredAudioCodecChecked(null, null);
-            //PreferredVideoCodecChecked(null, null);
-
-            //Window.Current.Closed += Shutdown; // doesn't work
 
             this.Loaded += OnLoaded;
             Application.Current.Suspending += App_Suspending;

--- a/examples/TestAppUwp/MediaPlayerPage.xaml
+++ b/examples/TestAppUwp/MediaPlayerPage.xaml
@@ -1,0 +1,212 @@
+<Page
+    x:Class="TestAppUwp.MediaPlayerPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <Page.Resources>
+        <DataTemplate x:Key="AudioTrackTypeItemTemplate" x:DataType="local:AudioTrackTypeViewModel">
+            <TextBlock Text="{x:Bind DisplayName}"/>
+        </DataTemplate>
+        <DataTemplate x:Key="VideoTrackTypeItemTemplate" x:DataType="local:VideoTrackTypeViewModel">
+            <TextBlock Text="{x:Bind DisplayName}"/>
+        </DataTemplate>
+        <DataTemplate x:Key="AudioTrackItemTemplate" x:DataType="local:AudioTrackViewModel">
+            <TextBlock Text="{x:Bind DisplayName}" Margin="0,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Left" />
+        </DataTemplate>
+        <DataTemplate x:Key="VideoTrackItemTemplate" x:DataType="local:VideoTrackViewModel">
+            <TextBlock Text="{x:Bind DisplayName}" Margin="0,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Left" />
+        </DataTemplate>
+        <!--<DataTemplate x:Key="ChatChannelItemTemplate" x:DataType="local:ChatChannel">
+            <StackPanel Orientation="Horizontal" Margin="2,0,0,0" AutomationProperties.Name="{x:Bind Label}">
+                <TextBlock Text="{x:Bind Label}" Margin="24,0,0,0" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>-->
+    </Page.Resources>
+    <Grid HorizontalAlignment="Stretch" Margin="8,8,0,8" VerticalAlignment="Stretch">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="40"/>
+            <RowDefinition Height="40"/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <Grid Grid.Row="0" Margin="0,0,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="100px"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="150px"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="Audio track" FontWeight="Bold" VerticalAlignment="Center" />
+            <!--<Button x:Name="addAudioSenderButton" Grid.Column="1" Height="32" Width="80">
+                <Button.Content>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="32"/>
+                            <ColumnDefinition Width="40"/>
+                        </Grid.ColumnDefinitions>
+                        <SymbolIcon Grid.Column="0" Symbol="Add" Width="32" Height="32" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="1" Text="Add" VerticalAlignment="Center"/>
+                    </Grid>
+                </Button.Content>
+                <Button.Flyout>
+                    <Flyout>
+                        <StackPanel>
+                            <ListView x:Name="addAudioTrackTypeList"
+                                      ItemTemplate="{StaticResource AudioTrackTypeItemTemplate}"/>
+                            <Button Content="Add audio track" Click="AddAudioTrack_Click" />
+                        </StackPanel>
+                    </Flyout>
+                </Button.Flyout>
+            </Button>-->
+            <ComboBox x:Name="audioTrackComboBox" SelectionChanged="AudioTrackComboBox_SelectionChanged"
+                      Grid.Column="2" Margin="16,0,16,0" HorizontalAlignment="Stretch"
+                      ItemsSource="{x:Bind SessionModel.AudioTracks, Mode=OneWay}"
+                      ItemTemplate="{StaticResource AudioTrackItemTemplate}"
+                      SelectedItem="{x:Bind SessionModel.AudioTracks.SelectedItem, Mode=TwoWay}"
+                      IsEnabled="{x:Bind SessionModel.AudioTracks.Count, Mode=OneWay, Converter={StaticResource CountToBoolNotEmptyConvert}}"/>
+            <TextBlock x:Name="audioStateText" Text="State:" Grid.Column="3" VerticalAlignment="Center" />
+        </Grid>
+        <Grid Grid.Row="1" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="100px"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="150px"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="Video track" FontWeight="Bold" VerticalAlignment="Center" />
+            <!--<Button x:Name="addVideoSenderButton" Grid.Column="1" Height="32" Width="80">
+                <Button.Content>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="32"/>
+                            <ColumnDefinition Width="40"/>
+                        </Grid.ColumnDefinitions>
+                        <SymbolIcon Grid.Column="0" Symbol="Add" Width="32" Height="32" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="1" Text="Add" VerticalAlignment="Center"/>
+                    </Grid>
+                </Button.Content>
+                <Button.Flyout>
+                    <Flyout>
+                        <StackPanel>
+                            <ListView x:Name="addVideoTrackTypeList" 
+                                      ItemTemplate="{StaticResource VideoTrackTypeItemTemplate}"/>
+                            <Button Content="Add video track" Click="AddVideoTrack_Click" />
+                        </StackPanel>
+                    </Flyout>
+                </Button.Flyout>
+            </Button>-->
+            <ComboBox x:Name="videoTrackComboBox" SelectionChanged="VideoTrackComboBox_SelectionChanged"
+                      Grid.Column="2" Margin="16,0,16,0" HorizontalAlignment="Stretch"
+                      ItemsSource="{x:Bind SessionModel.VideoTracks, Mode=OneWay}"
+                      ItemTemplate="{StaticResource VideoTrackItemTemplate}"
+                      SelectedItem="{x:Bind SessionModel.VideoTracks.SelectedItem, Mode=TwoWay}"
+                      IsEnabled="{x:Bind SessionModel.VideoTracks.Count, Mode=OneWay, Converter={StaticResource CountToBoolNotEmptyConvert}}"/>
+            <TextBlock x:Name="videoStateText" Text="State:" Grid.Column="3" VerticalAlignment="Center" />
+        </Grid>
+        <SplitView Grid.Row="2" PaneBackground="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+            IsPaneOpen="True" OpenPaneLength="256" CompactPaneLength="48" DisplayMode="Inline" PanePlacement="Right">
+            <SplitView.Pane>
+                <Grid Margin="8,8,8,8">
+                    <Button Content="Close" Height="32" Width="54" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="Video track" FontWeight="Bold"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="80"/>
+                                <ColumnDefinition Width="8"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Text="Width" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                            <TextBlock x:Name="videoFrameWidth" Text="{x:Bind _viewModel.FrameWidth, Mode=OneWay}"
+                                       VerticalAlignment="Center" Grid.Column="2"/>
+                            <TextBlock Text="Height" VerticalAlignment="Center" Grid.Row="1" HorizontalAlignment="Right"/>
+                            <TextBlock x:Name="videoFrameHeight" Text="{x:Bind _viewModel.FrameHeight, Mode=OneWay}"
+                                       VerticalAlignment="Center" Grid.Row="1" Grid.Column="2"/>
+                            <TextBlock Text="Framerate" VerticalAlignment="Center" Grid.Row="2" HorizontalAlignment="Right"/>
+                            <TextBlock x:Name="videoFrameRate" Text="-" VerticalAlignment="Center" Grid.Row="2" Grid.Column="2"/>
+                        </Grid>
+                        <TextBlock Text="Video render pipeline" FontWeight="Bold" Margin="0,16,0,0"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="80"/>
+                                <ColumnDefinition Width="8"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Text="Produce" HorizontalAlignment="Right" Grid.Row="0"/>
+                            <TextBlock x:Name="localLoadText" Grid.Row="0" Grid.Column="2"
+                                       Text="{x:Bind _viewModel.FrameLoaded, Mode=OneWay,
+                                           Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F2}'}"/>
+                            <TextBlock Text="Render" HorizontalAlignment="Right" Grid.Row="1"/>
+                            <TextBlock x:Name="localPresentText" Grid.Row="1" Grid.Column="2"
+                                       Text="{x:Bind _viewModel.FramePresented, Mode=OneWay,
+                                           Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F2}'}"/>
+                            <TextBlock Text="Skip" HorizontalAlignment="Right" Grid.Row="2" Grid.Column="0" Margin="44,0,0,0"/>
+                            <TextBlock x:Name="localSkipText" Grid.Row="2" Grid.Column="2"
+                                       Text="{x:Bind _viewModel.FrameSkipped, Mode=OneWay,
+                                           Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F2}'}"/>
+                            <TextBlock Text="Late" HorizontalAlignment="Right" Grid.Row="3" Grid.Column="0" Margin="44,0,0,0"/>
+                            <TextBlock x:Name="localLateText" Grid.Row="3" Grid.Column="2"
+                                       Text="{x:Bind _viewModel.FrameLate, Mode=OneWay,
+                                           Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F2}'}"/>
+                        </Grid>
+                        <TextBlock Text="Audio track" FontWeight="Bold" Margin="0,16,0,0"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="80"/>
+                                <ColumnDefinition Width="8"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Text="Channels" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                            <TextBlock x:Name="remoteAudioChannelCount" Text="-" VerticalAlignment="Center" Grid.Column="2" Height="19" />
+                            <TextBlock Text="Sample rate" VerticalAlignment="Center" Grid.Row="1" HorizontalAlignment="Right" />
+                            <TextBlock x:Name="remoteAudioSampleRate" Text="-" VerticalAlignment="Center" Grid.Row="1" Grid.Column="2" Height="19" />
+                        </Grid>
+                    </StackPanel>
+                </Grid>
+            </SplitView.Pane>
+            <Grid>
+                <Border BorderBrush="#66000000" BorderThickness="2,2,2,2" Background="#AAFFFFFF" Margin="0,0,8,0">
+                    <MediaPlayerElement x:Name="videoPlayerElement" Height="480" Width="640" />
+                </Border>
+                <StackPanel x:Name="localMediaPanel" Orientation="Horizontal" Height="68" VerticalAlignment="Bottom"
+                            HorizontalAlignment="Center" Background="#CCB2D0FF" Padding="10,10,10,10" Width="126" Margin="0,0,0,32"
+                            Visibility="{x:Bind _viewModel.VideoTrack.IsRemote, Mode=OneWay, Converter={StaticResource BooleanToVisibilityInvertedConverter}}">
+                    <Button Name="muteLocalVideo" IsEnabled="False" VerticalAlignment="Center" Click="MuteLocalVideoClicked" Width="48" HorizontalAlignment="Center" Height="48" Padding="0,0,0,0">
+                        <Grid Width="32" Height="32" VerticalAlignment="Center">
+                            <SymbolIcon Symbol="Video" />
+                            <Path x:Name="muteLocalVideoStroke" Stroke="Black" Data="M 32,0 L 0,32" Width="32" Height="32" />
+                        </Grid>
+                    </Button>
+                    <Button Name="muteLocalAudio" IsEnabled="False" VerticalAlignment="Center" Click="MuteLocalAudioClicked" Width="48" HorizontalAlignment="Center" Height="48" Margin="10,0,0,0" Padding="0,0,0,0">
+                        <Grid Width="32" Height="32" VerticalAlignment="Center">
+                            <SymbolIcon Symbol="Microphone" />
+                            <Path x:Name="muteLocalAudioStroke" Stroke="Black" Data="M 32,0 L 0,32" Width="32" Height="32" />
+                        </Grid>
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </SplitView>
+    </Grid>
+</Page>

--- a/examples/TestAppUwp/MediaPlayerPage.xaml.cs
+++ b/examples/TestAppUwp/MediaPlayerPage.xaml.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using Microsoft.MixedReality.WebRTC;
+using TestAppUwp.Video;
+using Windows.Media.Core;
+using Windows.Media.MediaProperties;
+using Windows.Media.Playback;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// Model for video tracks, whether local or remote, for rendering in video player.
+    /// </summary>
+    public class VideoTrackViewModel
+    {
+        public IVideoTrack Track;
+        public MediaTrack TrackImpl;
+        public bool IsRemote;
+        public string DeviceName;
+        public string DisplayName
+        {
+            get
+            {
+                string label;
+                string deviceName = (string.IsNullOrWhiteSpace(DeviceName) ?
+                    (IsRemote ? "Remote track" : "Custom track") : DeviceName);
+                string videoTrackName = TrackImpl?.Name;
+                if (!string.IsNullOrWhiteSpace(videoTrackName))
+                {
+                    label = $"{videoTrackName} ({deviceName})";
+                }
+                else
+                {
+                    // The empty track placeholder
+                    Debug.Assert(videoTrackName == null);
+                    Debug.Assert(DeviceName == null);
+                    label = "<none>";
+                }
+                return label;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Model for audio tracks, whether local or remote, for output in audio player.
+    /// </summary>
+    public class AudioTrackViewModel
+    {
+        public IAudioTrack Track;
+        public MediaTrack TrackImpl;
+        public bool IsRemote;
+        public string DeviceName;
+        public string DisplayName
+        {
+            get
+            {
+                string label;
+                string deviceName = (string.IsNullOrWhiteSpace(DeviceName) ?
+                    (IsRemote ? "Remote track" : "Custom track") : DeviceName);
+                string audioTrackName = TrackImpl?.Name;
+                if (!string.IsNullOrWhiteSpace(audioTrackName))
+                {
+                    label = $"{audioTrackName} ({deviceName})";
+                }
+                else
+                {
+                    // The empty track placeholder
+                    Debug.Assert(audioTrackName == null);
+                    Debug.Assert(DeviceName == null);
+                    label = "<none>";
+                }
+                return label;
+            }
+        }
+    }
+
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class MediaPlayerPage : Page
+    {
+        private MediaPlayerViewModel _viewModel = new MediaPlayerViewModel();
+
+        public MediaPlayerPage()
+        {
+            this.InitializeComponent();
+
+            // Bind the XAML UI control (videoPlayerElement) to the MediaFoundation rendering pipeline (_videoPlayer)
+            // so that the former can render in the UI the video frames produced in the background by the latter.
+            videoPlayerElement.SetMediaPlayer(_viewModel.VideoPlayer);
+        }
+
+        public SessionModel SessionModel
+        {
+            get { return SessionModel.Current; }
+        }
+
+        //private async void AddAudioTrack_Click(object sender, RoutedEventArgs e)
+        //{
+        //    var viewModel = addAudioTrackTypeList.SelectedItem as AudioTrackTypeViewModel;
+        //    if (viewModel == null)
+        //    {
+        //        return;
+        //    }
+        //    LocalAudioTrack audioTrack = await viewModel.Factory();
+        //    if (audioTrack == null)
+        //    {
+        //        return;
+        //    }
+        //    var item = new AudioTrackViewModel
+        //    {
+        //        DeviceName = viewModel.DisplayName,
+        //        IsRemote = false,
+        //        Track = audioTrack,
+        //        TrackImpl = audioTrack
+        //    };
+        //    SessionModel.Current.AudioTracks.Add(item);
+        //    // Select the newly-created track for convenience
+        //    SessionModel.Current.AudioTracks.SelectedItem = item;
+        //}
+
+        //private async void AddVideoTrack_Click(object sender, RoutedEventArgs e)
+        //{
+        //    var viewModel = addVideoTrackTypeList.SelectedItem as VideoTrackTypeViewModel;
+        //    if (viewModel == null)
+        //    {
+        //        return;
+        //    }
+        //    LocalVideoTrack videoTrack = await viewModel.Factory();
+        //    if (videoTrack == null)
+        //    {
+        //        return;
+        //    }
+        //    var item = new VideoTrackViewModel
+        //    {
+        //        DeviceName = viewModel.DisplayName,
+        //        IsRemote = false,
+        //        Track = videoTrack,
+        //        TrackImpl = videoTrack
+        //    };
+        //    SessionModel.Current.VideoTracks.Add(item);
+        //    // Select the newly-created track for convenience
+        //    SessionModel.Current.VideoTracks.SelectedItem = item;
+        //}
+
+        private void MuteLocalVideoClicked(object sender, RoutedEventArgs e)
+        {
+            //if (_playbackVideoTrack is LocalVideoTrack localVideoTrack)
+            //{
+            //    if (localVideoTrack.Enabled)
+            //    {
+            //        localVideoTrack.Enabled = false;
+            //        muteLocalVideoStroke.Visibility = Visibility.Visible;
+            //    }
+            //    else
+            //    {
+            //        localVideoTrack.Enabled = true;
+            //        muteLocalVideoStroke.Visibility = Visibility.Collapsed;
+            //    }
+            //}
+            //else
+            //{
+            //    throw new ArgumentException("Cannot mute remote video track.");
+            //}
+        }
+
+        private void MuteLocalAudioClicked(object sender, RoutedEventArgs e)
+        {
+            //if (_playbackAudioTrack is LocalAudioTrack localAudioTrack)
+            //{
+            //    if (localAudioTrack.Enabled)
+            //    {
+            //        localAudioTrack.Enabled = false;
+            //        muteLocalAudioStroke.Visibility = Visibility.Visible;
+            //    }
+            //    else
+            //    {
+            //        localAudioTrack.Enabled = true;
+            //        muteLocalAudioStroke.Visibility = Visibility.Collapsed;
+            //    }
+            //}
+            //else
+            //{
+            //    throw new ArgumentException("Cannot mute remote audio track.");
+            //}
+        }
+
+        private void AudioTrackComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var audioTrackViewModel = (AudioTrackViewModel)audioTrackComboBox.SelectedItem;
+            _viewModel.AudioTrack = audioTrackViewModel;
+        }
+
+        private void VideoTrackComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var videoTrackViewModel = (VideoTrackViewModel)videoTrackComboBox.SelectedItem;
+            _viewModel.VideoTrack = videoTrackViewModel;
+        }
+
+        private void UpdateVideoStats(float loaded, float presented, float skipped)
+        {
+            localLoadText.Text = $"Receive: {loaded:F2}";
+            localPresentText.Text = $"Render: {presented:F2}";
+            localSkipText.Text = $"Skip: {skipped:F2}";
+            //localLateText.Text = $"Late: {late:F2}";
+        }
+
+        private void ClearVideoStats()
+        {
+            localLoadText.Text = $"Receive: -";
+            localPresentText.Text = $"Render: -";
+            localSkipText.Text = $"Skip: -";
+            //localLateText.Text = $"Late: -";
+        }
+
+        private void ClearRemoteAudioStats()
+        {
+            remoteAudioChannelCount.Text = "-";
+            remoteAudioSampleRate.Text = "-";
+        }
+
+        private void UpdateRemoteAudioStats(uint channelCount, uint sampleRate)
+        {
+            remoteAudioChannelCount.Text = channelCount.ToString();
+            remoteAudioSampleRate.Text = $"{sampleRate} Hz";
+        }
+
+        private void SwitchMediaPlayerSource(IAudioTrack audioTrack, IVideoTrack videoTrack)
+        {
+            //lock (_mediaPlaybackLock)
+            //{
+            //    if (videoTrack != _playbackVideoTrack)
+            //    {
+            //        // Notify media player that source changed
+            //        if (_isVideoPlaying)
+            //        {
+            //            _videoStreamSource.NotifyError(MediaStreamSourceErrorStatus.ConnectionToServerLost);
+            //            _videoPlayer.Pause();
+            //            _isVideoPlaying = false;
+            //        }
+
+            //        // Detach old source
+            //        if (_playbackVideoTrack != null)
+            //        {
+            //            _playbackVideoTrack.I420AVideoFrameReady -= VideoTrack_I420AFrameReady;
+            //            _videoWidth = 0;
+            //            _videoHeight = 0;
+            //            ClearVideoStats();
+            //        }
+
+            //        _playbackVideoTrack = videoTrack;
+
+            //        // Attach new source
+            //        if (_playbackVideoTrack != null)
+            //        {
+            //            _playbackVideoTrack.I420AVideoFrameReady += VideoTrack_I420AFrameReady;
+            //        }
+
+            //        LogMessage($"Changed video playback track.");
+            //    }
+
+            //    if (audioTrack != _playbackAudioTrack)
+            //    {
+            //        // Detach old source
+            //        if (_playbackAudioTrack != null)
+            //        {
+            //            _playbackAudioTrack.AudioFrameReady -= AudioTrack_FrameReady;
+            //            _audioSampleRate = 0;
+            //            _audioChannelCount = 0;
+            //            ClearRemoteAudioStats();
+            //        }
+
+            //        _playbackAudioTrack = audioTrack;
+
+            //        // Attach new source
+            //        if (_playbackAudioTrack != null)
+            //        {
+            //            _playbackAudioTrack.AudioFrameReady += AudioTrack_FrameReady;
+            //        }
+
+            //        LogMessage($"Changed video playback track.");
+            //    }
+            //}
+
+            //// Update local media overlay panel
+            //bool hasLocalMedia = ((_playbackVideoTrack != null) || (_playbackAudioTrack != null));
+            //localMediaPanel.Visibility = (hasLocalMedia ? Visibility.Visible : Visibility.Collapsed);
+            //muteLocalAudio.IsEnabled = (_playbackAudioTrack != null);
+            //muteLocalVideo.IsEnabled = (_playbackVideoTrack != null);
+        }
+
+
+
+    }
+}

--- a/examples/TestAppUwp/MediaPlayerPage.xaml.cs
+++ b/examples/TestAppUwp/MediaPlayerPage.xaml.cs
@@ -81,11 +81,12 @@ namespace TestAppUwp
     }
 
     /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// Page displaying the media player to preview the content of audio and video tracks,
+    /// both local and remote.
     /// </summary>
     public sealed partial class MediaPlayerPage : Page
     {
-        private MediaPlayerViewModel _viewModel = new MediaPlayerViewModel();
+        private readonly MediaPlayerViewModel _viewModel = new MediaPlayerViewModel();
 
         public MediaPlayerPage()
         {

--- a/examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
+++ b/examples/TestAppUwp/Microsoft.MixedReality.WebRTC.TestAppUWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>TestAppUwp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>15</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -54,9 +54,39 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AddAudioTrackPage.xaml.cs">
+      <DependentUpon>AddAudioTrackPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="AddVideoTrackPage.xaml.cs">
+      <DependentUpon>AddVideoTrackPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="DebugConsolePage.xaml.cs">
+      <DependentUpon>DebugConsolePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="MediaPlayerPage.xaml.cs">
+      <DependentUpon>MediaPlayerPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Model\SessionModel.cs" />
+    <Compile Include="SessionPage.xaml.cs">
+      <DependentUpon>SessionPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="SettingsPage.xaml.cs">
+      <DependentUpon>SettingsPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="SignalingPage.xaml.cs">
+      <DependentUpon>SignalingPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="TrackListPage.xaml.cs">
+      <DependentUpon>TrackListPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="TracksPage.xaml.cs">
+      <DependentUpon>TracksPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ViewModel\AudioCaptureViewModel.cs" />
+    <Compile Include="ViewModel\Converters.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
@@ -65,6 +95,14 @@
     <Compile Include="Video\StreamSamplePool.cs" />
     <Compile Include="Video\VideoBridge.cs" />
     <Compile Include="Video\YuvUtils.cs" />
+    <Compile Include="ViewModel\MediaPlayerViewModel.cs" />
+    <Compile Include="ViewModel\SessionViewModel.cs" />
+    <Compile Include="ViewModel\CollectionViewModel.cs" />
+    <Compile Include="ViewModel\SignalerViewModel.cs" />
+    <Compile Include="ViewModel\TransceiverCollectionViewModel.cs" />
+    <Compile Include="ViewModel\TransceiverViewModel.cs" />
+    <Compile Include="ViewModel\NotifierBase.cs" />
+    <Compile Include="ViewModel\VideoCaptureViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -98,9 +136,45 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="AddAudioTrackPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="AddVideoTrackPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="DebugConsolePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="MediaPlayerPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="SessionPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="SettingsPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="SignalingPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="TrackListPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="TracksPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/examples/TestAppUwp/Model/SessionModel.cs
+++ b/examples/TestAppUwp/Model/SessionModel.cs
@@ -1,0 +1,998 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.MixedReality.WebRTC;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// Negotiation state similar to the one described in the WebRTC 1.0 standard.
+    /// 
+    /// Differences are:
+    /// - Starts in <see cref="Closed"/> state instead of <see cref="Stable"/> state to
+    ///   wait for the peer connection to be initialized.
+    /// - Adds <see cref="Starting"/> state in-between the <see cref="Stable"/> state and
+    ///   the <see cref="HaveLocalOffer"/> state to prevent creating multiple offers locally.
+    /// </summary>
+    /// <seealso href="https://www.w3.org/TR/webrtc/#rtcsignalingstate-enum"/>
+    public enum NegotiationState
+    {
+        /// <summary>
+        /// Peer connection not initialized yet, or closed. Session cannot be established
+        /// in this state.
+        /// </summary>
+        Closed,
+
+        /// <summary>
+        /// Ready to negotiate a new session. This happens once the peer connection is
+        /// initialized, and once again after an answer is either created and applied locally
+        /// (see <see cref="NotifyLocalAnswerApplied"/>) or received from the remote peer
+        /// (see <see cref="ApplyRemoteAnswerAsync(string)"/>.
+        /// </summary>
+        Stable,
+
+        /// <summary>
+        /// New negotitation has been started locally, waiting for offer message to be created.
+        /// This happens when calling <see cref="StartNegotiation"/> locally.
+        /// </summary>
+        Starting,
+
+        /// <summary>
+        /// Negotiation started by the local peer, waiting for answer from the remote peer.
+        /// This happens after the offer message has been created and applied locally (see
+        /// <see cref="NotifyLocalOfferApplied"/>).
+        /// </summary>
+        HaveLocalOffer,
+
+        /// <summary>
+        /// Negotiation started by the remote peer, need to send back an answer.
+        /// This happens when a remote offer has been received and applied locally (see
+        /// <see cref="ApplyRemoteOfferAsync(string)"/>).
+        /// </summary>
+        HaveRemoteOffer,
+    }
+
+    /// <summary>
+    /// Model for a chat channel backed by a WebRTC data channel.
+    /// </summary>
+    public class ChatChannelModel : NotifierBase
+    {
+        /// <summary>
+        /// Backing WebRTC data channel used to transmit the chat messages.
+        /// </summary>
+        public DataChannel DataChannel { get; }
+
+        /// <summary>
+        /// Full chat text.
+        /// </summary>
+        public string FullText
+        {
+            get { return _fullText; }
+            set { SetProperty(ref _fullText, value); }
+        }
+
+        /// <summary>
+        /// Channel label.
+        /// </summary>
+        public string Label { get { return DataChannel?.Label; } }
+
+        private string _fullText = "";
+
+        public ChatChannelModel(DataChannel dataChannel)
+        {
+            DataChannel = dataChannel;
+            dataChannel.MessageReceived += (byte[] message) =>
+            {
+                string text = System.Text.Encoding.UTF8.GetString(message);
+                AppendText($"[remote] {text}\n");
+            };
+        }
+
+        /// <summary>
+        /// Append some text to <see cref="FullText"/>.
+        /// </summary>
+        /// <param name="text">The text to append.</param>
+        public void AppendText(string text)
+        {
+            _fullText += text;
+            RaisePropertyChanged("Text");
+        }
+    }
+
+    /// <summary>
+    /// Model of the WebRTC session, including the peer connection used to implement it.
+    /// </summary>
+    public class SessionModel : NotifierBase
+    {
+        /// <summary>
+        /// Predetermined chat data channel ID, negotiated out of band.
+        /// </summary>
+        private const int ChatChannelID = 42;
+
+        /// <summary>
+        /// Singleton instance of the current session model.
+        /// </summary>
+        public static SessionModel Current
+        {
+            get
+            {
+                lock (_singletonLock)
+                {
+                    if (_current == null)
+                    {
+                        _current = new SessionModel();
+                    }
+                    return _current;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Is the peer connection successfully initialized and ready to be used?
+        /// </summary>
+        public bool IsPeerInitialized
+        {
+            get { return _peerConnection.Initialized; }
+        }
+
+        /// <summary>
+        /// SDP semantic to use for establishing a session. Changes only have effect before
+        /// the peer connection is initialized with <see cref="InitializePeerConnectionAsync"/>.
+        /// </summary>
+        public SdpSemantic SdpSemantic
+        {
+            get { return _sdpSemantic; }
+            set { SetProperty(ref _sdpSemantic, value); }
+        }
+
+        /// <summary>
+        /// ICE server used for NAT punching to establish a session. Changes only have effect before
+        /// the peer connection is initialized with <see cref="InitializePeerConnectionAsync"/>.
+        /// </summary>
+        public IceServer IceServer
+        {
+            get { return _iceServer; }
+            set { SetProperty(ref _iceServer, value); }
+        }
+
+        /// <summary>
+        /// Signaler used to negotiate sessions.
+        /// </summary>
+        public NodeDssSignaler NodeDssSignaler { get; } = new NodeDssSignaler();
+
+        /// <summary>
+        /// Collection of transceivers of the peer connection associated with this session.
+        /// </summary>
+        public TransceiverCollectionViewModel Transceivers { get; } = new TransceiverCollectionViewModel();
+
+        /// <summary>
+        /// Collection of local tracks created and owned by the user, and which can be associated with a transceiver.
+        /// </summary>
+        /// <remarks>
+        /// The collection also contains some UI placeholders for the "Add" buttons (<see cref="AddNewTrackViewModel"/>).
+        /// </remarks>
+        /// <seealso cref="TrackViewModel"/>
+        /// <seealso cref="AddNewTrackViewModel"/>
+        public ObservableCollection<TrackViewModelBase> LocalTracks = new ObservableCollection<TrackViewModelBase>();
+
+        /// <summary>
+        /// Collection of audio tracks known to the session:
+        /// - local tracks owned by the session and optionally attached to a transceiver;
+        /// - remote tracks attached to their transceiver.
+        /// </summary>
+        public CollectionViewModel<AudioTrackViewModel> AudioTracks { get; private set; }
+            = new CollectionViewModel<AudioTrackViewModel>();
+
+        /// <summary>
+        /// Collection of video tracks known to the session:
+        /// - local tracks owned by the session and optionally attached to a transceiver;
+        /// - remote tracks attached to their transceiver.
+        /// </summary>
+        public CollectionViewModel<VideoTrackViewModel> VideoTracks { get; private set; }
+            = new CollectionViewModel<VideoTrackViewModel>();
+
+        /// <summary>
+        /// Placeholder for the null audio track, used to associate no track to a transceiver.
+        /// </summary>
+        public static readonly AudioTrackViewModel NullAudioTrack = new AudioTrackViewModel
+        {
+            Track = null,
+            TrackImpl = null,
+            IsRemote = false,
+            DeviceName = null
+        };
+
+        /// <summary>
+        /// Placeholder for the null video track, used to associate no track to a transceiver.
+        /// </summary>
+        public static readonly VideoTrackViewModel NullVideoTrack = new VideoTrackViewModel
+        {
+            Track = null,
+            TrackImpl = null,
+            IsRemote = false,
+            DeviceName = null
+        };
+
+        /// <summary>
+        /// Collection of chat channels of the current peer connection.
+        /// </summary>
+        public CollectionViewModel<ChatChannelModel> ChatChannels { get; }
+            = new CollectionViewModel<ChatChannelModel>();
+
+        /// <summary>
+        /// Enable automated renegotiation offers. This can be disabled when adding multiple tracks,
+        /// to bundle all changes together and avoid multiple round trips to the signaler and remote peer.
+        /// Alternatively when making batch changes a <see cref="SessionNegotiationDeferral"/> can be
+        /// used to temporarily delay the automated renegotiation.
+        /// </summary>
+        public bool AutomatedNegotiation
+        {
+            get { return _automatedNegotiation; }
+            set { SetProperty(ref _automatedNegotiation, value); }
+        }
+
+        /// <summary>
+        /// Current session negotiation state.
+        /// </summary>
+        public NegotiationState NegotiationState
+        {
+            get
+            {
+                lock (_stateLock)
+                {
+                    return _negotiationState;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check whether a new negotiation can be initiated with <see cref="StartNegotiation"/>.
+        /// This is mostly informative, as the internal state can change again between this call and the
+        /// call to <see cref="StartNegotiation"/>, and make the latter fail.
+        /// </summary>
+        public bool CanNegotiate
+        {
+            get
+            {
+                if (!_signalerReady)
+                {
+                    return false;
+                }
+                lock (_stateLock)
+                {
+                    return (_negotiationState == NegotiationState.Stable);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Is the signaler ready for negotiating a new session?
+        /// </summary>
+        public bool SignalerReady
+        {
+            get { return _signalerReady; }
+        }
+
+        /// <summary>
+        /// Current peer connection state.
+        /// </summary>
+        public IceConnectionState IceConnectionState
+        {
+            get { return _iceConnectionState; }
+            private set { SetProperty(ref _iceConnectionState, value); }
+        }
+
+        /// <summary>
+        /// Current ICE candidate gathering state.
+        /// </summary>
+        public IceGatheringState IceGatheringState
+        {
+            get { return _iceGatheringState; }
+            private set { SetProperty(ref _iceGatheringState, value); }
+        }
+
+        public string PreferredAudioCodec
+        {
+            get { return _preferredAudioCodec; }
+            set { SetProperty(ref _preferredAudioCodec, value); }
+        }
+
+        public string PreferredVideoCodec
+        {
+            get { return _preferredVideoCodec; }
+            set { SetProperty(ref _preferredVideoCodec, value); }
+        }
+
+        public string PreferredAudioCodecExtraParamsLocal
+        {
+            get { return _preferredAudioCodecExtraParamsLocal; }
+            set { SetProperty(ref _preferredAudioCodecExtraParamsLocal, value); }
+        }
+
+        public string PreferredAudioCodecExtraParamsRemote
+        {
+            get { return _preferredAudioCodecExtraParamsRemote; }
+            set { SetProperty(ref _preferredAudioCodecExtraParamsRemote, value); }
+        }
+
+        public string PreferredVideoCodecExtraParamsLocal
+        {
+            get { return _preferredVideoCodecExtraParamsLocal; }
+            set { SetProperty(ref _preferredVideoCodecExtraParamsLocal, value); }
+        }
+
+        public string PreferredVideoCodecExtraParamsRemote
+        {
+            get { return _preferredVideoCodecExtraParamsRemote; }
+            set { SetProperty(ref _preferredVideoCodecExtraParamsRemote, value); }
+        }
+
+        /// <summary>
+        /// Helper class to temporarily defer an automated negotiation until this object
+        /// is diposed.
+        /// </summary>
+        /// <seealso cref="GetNegotiationDeferral"/>
+        public class SessionNegotiationDeferral : IDisposable
+        {
+            private SessionModel _session;
+
+            public SessionNegotiationDeferral(SessionModel session)
+            {
+                _session = session;
+            }
+
+            public void Dispose()
+            {
+                _session.EndDeferral();
+            }
+        }
+
+        /// <summary>
+        /// WebRTC peer connection this session abstracts and uses.
+        /// </summary>
+        private readonly PeerConnection _peerConnection = new PeerConnection();
+
+        /// <summary>
+        /// Is automated negotiation active? If <c>true</c> then a new SDP offer is created
+        /// immediately when the peer connection raises a renegotiation needed event.
+        /// </summary>
+        private bool _automatedNegotiation = false;
+
+        /// <summary>
+        /// Is the signaler ready to send session messages? This prevents allowing to start
+        /// a negotiation if the signaler is not ready to handle the SDP exchange.
+        /// </summary>
+        private bool _signalerReady = false;
+
+        private static readonly object _singletonLock = new object();
+        private static SessionModel _current = null;
+
+        private SdpSemantic _sdpSemantic = SdpSemantic.UnifiedPlan;
+        private IceServer _iceServer;
+
+        private readonly object _stateLock = new object();
+        private bool _needsNegotiation = false;
+        private NegotiationState _negotiationState = NegotiationState.Closed;
+        private int _numNegotiationDeferrals = 0;
+
+        private IceConnectionState _iceConnectionState = IceConnectionState.Closed;
+        private IceGatheringState _iceGatheringState = IceGatheringState.New;
+        private string _preferredAudioCodec;
+        private string _preferredVideoCodec;
+        private string _preferredAudioCodecExtraParamsLocal;
+        private string _preferredAudioCodecExtraParamsRemote;
+        private string _preferredVideoCodecExtraParamsLocal;
+        private string _preferredVideoCodecExtraParamsRemote;
+
+        private SessionModel()
+        {
+            _peerConnection.Connected += OnPeerConnected;
+            _peerConnection.LocalSdpReadytoSend += OnLocalSdpReadyToSend;
+            _peerConnection.IceCandidateReadytoSend += OnIceCandidateReadyToSend;
+            _peerConnection.IceStateChanged += OnIceStateChanged;
+            _peerConnection.IceGatheringStateChanged += OnIceGatheringStateChanged;
+            _peerConnection.RenegotiationNeeded += OnRenegotiationNeeded;
+            _peerConnection.TransceiverAdded += OnTransceiverAdded;
+            _peerConnection.AudioTrackAdded += OnRemoteAudioTrackAdded;
+            _peerConnection.AudioTrackRemoved += OnRemoteAudioTrackRemoved;
+            _peerConnection.VideoTrackAdded += OnRemoteVideoTrackAdded;
+            _peerConnection.VideoTrackRemoved += OnRemoteVideoTrackRemoved;
+            _peerConnection.DataChannelAdded += OnDataChannelAdded;
+            _peerConnection.DataChannelRemoved += OnDataChannelRemoved;
+
+            NodeDssSignaler.OnConnect += DssSignaler_OnConnected;
+            NodeDssSignaler.OnDisconnect += DssSignaler_OnDisconnected;
+            NodeDssSignaler.OnMessage += DssSignaler_OnMessage;
+            NodeDssSignaler.OnFailure += DssSignaler_OnFailure;
+            NodeDssSignaler.OnPollingDone += DssSignaler_OnPollingDone;
+
+            AudioTracks.Add(NullAudioTrack);
+            VideoTracks.Add(NullVideoTrack);
+
+            AudioTracks.CollectionChanged += LocalAudioTrackCollectionChanged;
+            VideoTracks.CollectionChanged += LocalVideoTrackCollectionChanged;
+
+            LocalTracks.Add(new AddNewTrackViewModel() { DisplayName = "Add audio track", PageType = typeof(AddAudioTrackPage) });
+            LocalTracks.Add(new AddNewTrackViewModel() { DisplayName = "Add video track", PageType = typeof(AddVideoTrackPage) });
+        }
+
+        /// <summary>
+        /// Initialize the peer connection.
+        /// </summary>
+        /// <returns>A task that completes once the peer connection is ready to be used.</returns>
+        public async Task InitializePeerConnectionAsync()
+        {
+            Logger.Log("Initializing the peer connection...");
+
+            // Cannot run in UI thread on UWP because this will initialize the global factory
+            // (first library call) which needs to be done on a background thread.
+            await ThreadHelper.RunOnWorkerThread(() => Library.ShutdownOptions = Library.ShutdownOptionsFlags.LogLiveObjects);
+
+            // Initialize the native peer connection object
+            try
+            {
+                var config = new PeerConnectionConfiguration
+                {
+                    SdpSemantic = _sdpSemantic,
+                    IceServers = new List<IceServer> { _iceServer }
+                };
+                await _peerConnection.InitializeAsync(config);
+                RaisePropertyChanged("IsPeerInitialized");
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"WebRTC native plugin init failed: {ex.Message}");
+                throw ex;
+            }
+            Logger.Log("Peer connection initialized.");
+            OnPeerInitialized();
+
+            //using (_sessionViewModel.GetNegotiationDeferral())
+            {
+                //// As a convenience, add 1 audio and 1 video transceivers
+                //// TODO - make that more flexible
+                //AddPendingTransceiver(MediaKind.Audio, "audio_transceiver_0");
+                //AddPendingTransceiver(MediaKind.Video, "video_transceiver_1");
+
+                // It is CRUCIAL to add any data channel BEFORE the SDP offer is sent, if data channels are
+                // to be used at all. Otherwise the SCTP will not be negotiated, and then all channels will
+                // stay forever in the kConnecting state.
+                // https://stackoverflow.com/questions/43788872/how-are-data-channels-negotiated-between-two-peers-with-webrtc
+                await _peerConnection.AddDataChannelAsync(ChatChannelID, "chat", true, true);
+            }
+
+            //_videoPlayer.CurrentStateChanged += OnMediaStateChanged;
+            //_videoPlayer.MediaOpened += OnMediaOpened;
+            //_videoPlayer.MediaFailed += OnMediaFailed;
+            //_videoPlayer.MediaEnded += OnMediaEnded;
+            //_videoPlayer.RealTimePlayback = true;
+            //_videoPlayer.AutoPlay = false;
+
+            // Bind the XAML UI control (videoPlayerElement) to the MediaFoundation rendering pipeline (_videoPlayer)
+            // so that the former can render in the UI the video frames produced in the background by the latter.
+            //videoPlayerElement.SetMediaPlayer(_videoPlayer);
+        }
+
+        public void AddTransceiver(MediaKind mediaKind, TransceiverInitSettings settings)
+        {
+            // This will raise the TransceiverAdded event, which adds a new view model
+            // for the newly added transceiver automatically.
+            _peerConnection.AddTransceiver(mediaKind, settings);
+        }
+
+        /// <summary>
+        /// Start a new session negotiation.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The session is not in an internal state where a new negotiation can be started, either because
+        /// the signaler is not ready (see <see cref="SignalerReady"/>), or because the internal negotiation
+        /// state is not <see cref="NegotiationState.Stable"/> meaning that another session negotiation is
+        /// already in process.
+        /// </exception>
+        public void StartNegotiation()
+        {
+            if (!_signalerReady)
+            {
+                throw new InvalidOperationException($"Cannot start a new session negotiation before the signaler is ready.");
+            }
+            lock (_stateLock)
+            {
+                if (_negotiationState != NegotiationState.Stable)
+                {
+                    throw new InvalidOperationException($"Cannot start a new session negotiation in {_negotiationState} state.");
+                }
+                _negotiationState = NegotiationState.Starting;
+                _needsNegotiation = false;
+                // FIXME - Race condition here; if receiving a RenegotiationNeeded event between this point
+                // and the moment the peer connection actually starts creating the offer message. In that case
+                // _needsNegotiation will become true, but might conceptually be false since the change that 
+                // raised the event will be taken into account in the call to CreateOffer() below. This is because
+                // we are crafting a state machine in C# instead of taping into the native implementation one.
+            }
+            RaisePropertyChanged("NegotiationState");
+            RaisePropertyChanged("CanNegotiate");
+
+            // TODO - Use per-transceiver properties instead of per-connection ones
+            // FIXME - null string crashes, need to pass empty string
+            _peerConnection.PreferredAudioCodec = PreferredAudioCodec ?? "";
+            _peerConnection.PreferredAudioCodecExtraParamsLocal = PreferredAudioCodecExtraParamsLocal ?? "";
+            _peerConnection.PreferredAudioCodecExtraParamsRemote = PreferredAudioCodecExtraParamsRemote ?? "";
+            _peerConnection.PreferredVideoCodec = PreferredVideoCodec ?? "";
+            _peerConnection.PreferredVideoCodecExtraParamsLocal = PreferredVideoCodecExtraParamsLocal ?? "";
+            _peerConnection.PreferredVideoCodecExtraParamsRemote = PreferredVideoCodecExtraParamsRemote ?? "";
+
+            // This cannot be inside the lock, otherwise the UI thread has the lock and block on the WebRTC
+            // signaling thread, which itself might invoked a callback into the UI thread which might require
+            // the lock, in which case we'd have a deadlock.
+            _peerConnection.CreateOffer();
+        }
+
+        /// <summary>
+        /// Notify the view model that the peer connection was initialized and is ready.
+        /// </summary>
+        public void OnPeerInitialized()
+        {
+            lock (_stateLock)
+            {
+                Debug.Assert(_negotiationState == NegotiationState.Closed);
+                _negotiationState = NegotiationState.Stable;
+            }
+            RaisePropertyChanged("NegotiationState");
+            RaisePropertyChanged("CanNegotiate");
+        }
+
+        private void LocalAudioTrackCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            Transceivers.RefreshSenderList(MediaKind.Audio, force: true);
+        }
+
+        private void LocalVideoTrackCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            Transceivers.RefreshSenderList(MediaKind.Video, force: true);
+        }
+
+        /// <summary>
+        /// Callback invoked when an answer is available. This does not necesarilly indicate
+        /// the remote peer has received this answer, if it was generated locally. But the
+        /// local peer at least is in a state where the SDP session exchange is completed on
+        /// its end. WebRTC does not have any built-in way to ensure the remote peer has also
+        /// receveived the answer and finished the session exchange.
+        /// </summary>
+        private void OnPeerConnected()
+        {
+            //RunOnMainThread(() =>
+            //{
+            //    //sessionStatusText.Text = "joined";
+            //    chatTextBox.IsEnabled = true;
+
+            //    // Reset "Create Offer" button, and re-enable if signaling is available
+            //    createOfferButton.Content = "Create Offer";
+            //    createOfferButton.IsEnabled = _isDssPolling;
+            //});
+        }
+
+        private void OnLocalSdpReadyToSend(string type, string sdp)
+        {
+            Logger.Log($"Local {type} ready to be sent to remote peer.");
+            if (type == "offer")
+            {
+                NotifyLocalOfferApplied();
+            }
+            else if (type == "answer")
+            {
+                NotifyLocalAnswerApplied();
+            }
+            var message = new NodeDssSignaler.Message
+            {
+                MessageType = NodeDssSignaler.Message.WireMessageTypeFromString(type),
+                Data = sdp,
+                IceDataSeparator = "|"
+            };
+            NodeDssSignaler.SendMessageAsync(message);
+            //RunOnMainThread(() => negotiationStatusText.Text = (type == "offer" ? "Sending local offer" : "Idle (answer sent)"));
+        }
+
+        private void OnIceCandidateReadyToSend(string candidate, int sdpMlineindex, string sdpMid)
+        {
+            var message = new NodeDssSignaler.Message
+            {
+                MessageType = NodeDssSignaler.Message.WireMessageType.Ice,
+                Data = $"{candidate}|{sdpMlineindex}|{sdpMid}", // see DssSignaler_OnMessage
+                IceDataSeparator = "|"
+            };
+            NodeDssSignaler.SendMessageAsync(message);
+        }
+
+        private void OnIceStateChanged(IceConnectionState newState)
+        {
+            Logger.Log($"Connection state changed to {newState}.");
+            IceConnectionState = newState;
+
+            // ICE was disconnected, which generally indicates that the remote peer was closed.
+            // Shut down the remote media player and clear the remote video statistics.
+            if (newState == IceConnectionState.Disconnected)
+            {
+                //OnPeerDisconnected();
+            }
+        }
+
+        private void OnIceGatheringStateChanged(IceGatheringState newState)
+        {
+            Logger.Log($"ICE gathering changed to {newState}.");
+            IceGatheringState = newState;
+        }
+
+        private void OnPeerDisconnected()
+        {
+            Logger.Log($"Peer disconnected.");
+
+            //// Update the video source if needed
+            //var selectedVideoTrack = LocalVideoTracks.SelectedItem;
+            //if (selectedVideoTrack.IsRemote)
+            //{
+
+            //    _remoteVideoPlayer.Pause();
+            //    _remoteVideoPlayer.Source = null;
+            //    remoteVideo.SetMediaPlayer(null);
+            //    _remoteVideoSource?.NotifyError(MediaStreamSourceErrorStatus.ConnectionToServerLost);
+            //    _remoteMediaSource?.Dispose();
+            //}
+
+            // Remove all remote tracks
+            for (int i = AudioTracks.Count - 1; i >= 0; --i)
+            {
+                if (AudioTracks[i].IsRemote)
+                {
+                    AudioTracks.RemoveAt(i);
+                }
+            }
+            for (int i = VideoTracks.Count - 1; i >= 0; --i)
+            {
+                if (VideoTracks[i].IsRemote)
+                {
+                    VideoTracks.RemoveAt(i);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Notify the peer connection that a local SDP offer message was applied.
+        /// </summary>
+        public void NotifyLocalOfferApplied()
+        {
+            lock (_stateLock)
+            {
+                Debug.Assert(_negotiationState == NegotiationState.Starting);
+                _negotiationState = NegotiationState.HaveLocalOffer;
+            }
+            RaisePropertyChanged("NegotiationState");
+        }
+
+        /// <summary>
+        /// Notify the peer connection that a local SDP answer message was applied.
+        /// </summary>
+        public void NotifyLocalAnswerApplied()
+        {
+            lock (_stateLock)
+            {
+                Debug.Assert(_negotiationState == NegotiationState.HaveRemoteOffer);
+                _negotiationState = NegotiationState.Stable;
+            }
+            RaisePropertyChanged("NegotiationState");
+            RaisePropertyChanged("CanNegotiate");
+        }
+
+        /// <summary>
+        /// Apply a remote SDP offer message to the peer connection.
+        /// </summary>
+        /// <param name="content">The SDP offer message content.</param>
+        public async Task ApplyRemoteOfferAsync(string content)
+        {
+            // Change state first to prevent user from initiating a new negotiation
+            // while the remote peer is known to have already initiated one.
+            // This slightly deviates from the WebRTC standard which says that the
+            // HaveRemoteOffer state is after the remote offer was applied, not before.
+            lock (_stateLock)
+            {
+                Debug.Assert(_negotiationState == NegotiationState.Stable);
+                _negotiationState = NegotiationState.HaveRemoteOffer;
+            }
+            RaisePropertyChanged("NegotiationState");
+            RaisePropertyChanged("CanNegotiate");
+
+            await _peerConnection.SetRemoteDescriptionAsync("offer", content);
+        }
+
+        /// <summary>
+        /// Apply a remote SDP answer message to the peer connection.
+        /// </summary>
+        /// <param name="content">The SDP answer message content.</param>
+        public async Task ApplyRemoteAnswerAsync(string content)
+        {
+            await _peerConnection.SetRemoteDescriptionAsync("answer", content);
+
+            lock (_stateLock)
+            {
+                Debug.Assert(_negotiationState == NegotiationState.HaveLocalOffer);
+                _negotiationState = NegotiationState.Stable;
+            }
+            RaisePropertyChanged("NegotiationState");
+            RaisePropertyChanged("CanNegotiate");
+        }
+
+        /// <summary>
+        /// Get a deferral to temporarily suspend automated session negotiation until
+        /// a batch of changes has been conducted. This is typically used when modifying
+        /// multiple transceivers at once while using automated negotiation, to avoid the
+        /// very first modification starting a negotiation before all changes have been
+        /// applied locally.
+        /// </summary>
+        /// <returns>A deferral temporarily blocking any automated negotiation until disposed.</returns>
+        /// <remarks>
+        /// This is typically used in a <c>using</c> block:
+        /// <code>
+        /// using (session.GetNegotiationDeferral())
+        /// {
+        ///     // Add multiple transceivers...
+        /// }
+        /// </code>
+        /// </remarks>
+        public SessionNegotiationDeferral GetNegotiationDeferral()
+        {
+            var deferral = new SessionNegotiationDeferral(this);
+            lock (_stateLock)
+            {
+                ++_numNegotiationDeferrals;
+            }
+            return deferral;
+        }
+
+        private void EndDeferral()
+        {
+            lock (_stateLock)
+            {
+                --_numNegotiationDeferrals;
+                if ((_numNegotiationDeferrals == 0) && (_negotiationState == NegotiationState.Stable)
+                    && _needsNegotiation && _automatedNegotiation)
+                {
+                    StartNegotiation();
+                }
+            }
+        }
+
+        private void OnRenegotiationNeeded()
+        {
+            lock (_stateLock)
+            {
+                _needsNegotiation = true;
+
+                if ((_numNegotiationDeferrals == 0) && (_negotiationState == NegotiationState.Stable)
+                    && _automatedNegotiation && _signalerReady)
+                {
+                    StartNegotiation();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Callback invoked when a transceiver is added to the peer connection, either from
+        /// applying a remote offer/answer, or from manually adding it. In the latter case, the
+        /// transceiver has already a view model in the pending collection. In the former case,
+        /// create a view model for it and add it to the negotiated collection.
+        /// </summary>
+        /// <param name="transceiver">The newly added transceiver.</param>
+        private void OnTransceiverAdded(Transceiver transceiver)
+        {
+            Logger.Log($"Added transceiver '{transceiver.Name}' (mid=#{transceiver.MlineIndex}).");
+            ThreadHelper.RunOnMainThread(() =>
+            {
+                var trvm = new TransceiverViewModel(transceiver);
+                Transceivers.Add(trvm);
+            });
+        }
+
+
+        /// <summary>
+        /// Callback on remote audio track added.
+        /// 
+        /// For simplicity this grabs the first remote audio track found. However currently the user has no
+        /// control over audio output, so this is only used for audio statistics.
+        /// </summary>
+        /// <param name="track">The audio track added.</param>
+        /// <seealso cref="RemoteAudioTrack_FrameReady"/>
+        private void OnRemoteAudioTrackAdded(RemoteAudioTrack track)
+        {
+            Logger.Log($"Added remote audio track {track.Name} of transceiver {track.Transceiver.Name}.");
+
+            ThreadHelper.RunOnMainThread(() =>
+            {
+                var trvm = Transceivers.SingleOrDefault(tr => tr.Transceiver == track.Transceiver);
+                Debug.Assert(trvm.Transceiver.RemoteAudioTrack == track);
+                trvm.NotifyReceiverChanged(); // this is thread-aware
+                // This raises property changed events in current thread, needs to be main one
+                AudioTracks.Add(new AudioTrackViewModel
+                {
+                    Track = track,
+                    TrackImpl = track,
+                    IsRemote = true
+                });
+            });
+        }
+
+        /// <summary>
+        /// Callback on remote videa track added.
+        /// 
+        /// For simplicity this grabs the first remote video track found and uses it to render its
+        /// content on the right pane of the Tracks window.
+        /// </summary>
+        /// <param name="track">The video track added.</param>
+        /// <seealso cref="RemoteVideoTrack_I420AFrameReady"/>
+        private void OnRemoteVideoTrackAdded(RemoteVideoTrack track)
+        {
+            Logger.Log($"Added remote video track {track.Name} of transceiver {track.Transceiver.Name}.");
+
+            ThreadHelper.RunOnMainThread(() =>
+            {
+                var trvm = Transceivers.SingleOrDefault(tr => tr.Transceiver == track.Transceiver);
+                Debug.Assert(trvm.Transceiver.RemoteVideoTrack == track);
+                trvm.NotifyReceiverChanged(); // this is thread-aware
+                // This raises property changed events in current thread, needs to be main one
+                VideoTracks.Add(new VideoTrackViewModel
+                {
+                    Track = track,
+                    TrackImpl = track,
+                    IsRemote = true
+                });
+            });
+        }
+
+        /// <summary>
+        /// Callback on remote audio track removed.
+        /// </summary>
+        /// <param name="track">The audio track removed.</param>
+        private void OnRemoteAudioTrackRemoved(Transceiver transceiver, RemoteAudioTrack track)
+        {
+            Logger.Log($"Removed remote audio track {track.Name} from transceiver {transceiver.Name}.");
+
+            var atvm = AudioTracks.Single(vm => vm.TrackImpl == track);
+            AudioTracks.Remove(atvm);
+
+            //IAudioTrack newPlaybackAudioTrack = null;
+            //if (LocalAudioTracks.Count > 0)
+            //{
+            //    newPlaybackAudioTrack = LocalAudioTracks[0].Track;
+            //}
+            //SwitchMediaPlayerSource(newPlaybackAudioTrack, _playbackVideoTrack);
+        }
+
+        /// <summary>
+        /// Callback on remote video track removed.
+        /// </summary>
+        /// <param name="track">The video track removed.</param>
+        private void OnRemoteVideoTrackRemoved(Transceiver transceiver, RemoteVideoTrack track)
+        {
+            Logger.Log($"Removed remote video track {track.Name} from transceiver {transceiver.Name}.");
+
+            var vtvm = VideoTracks.Single(vm => vm.TrackImpl == track);
+            VideoTracks.Remove(vtvm);
+
+            //IVideoTrack newPlaybackVideoTrack = null;
+            //if (LocalVideoTracks.Count > 0)
+            //{
+            //    newPlaybackVideoTrack = LocalVideoTracks[0].Track;
+            //}
+            //else
+            //{
+            //    videoTrackComboBox.IsEnabled = false;
+            //    _videoStatsTimer.Stop();
+            //}
+            //SwitchMediaPlayerSource(_playbackAudioTrack, newPlaybackVideoTrack);
+        }
+
+        private void OnDataChannelAdded(DataChannel channel)
+        {
+            Logger.Log($"Added data channel '{channel.Label}' (#{channel.ID}).");
+            ThreadHelper.RunOnMainThread(() =>
+            {
+                var chat = new ChatChannelModel(channel);
+                ChatChannels.Add(chat);
+            });
+        }
+
+        private void OnDataChannelRemoved(DataChannel channel)
+        {
+            Logger.Log($"Removed data channel '{channel.Label}' (#{channel.ID}).");
+            // FIXME - Delegating to another thread means possible race condition if user initiates
+            // some action on the data channel before the delegated remove executes.
+            ThreadHelper.RunOnMainThread(() =>
+            {
+                var chat = ChatChannels.Where(c => c.DataChannel == channel).First();
+                ChatChannels.Remove(chat);
+            });
+        }
+
+        private void DssSignaler_OnConnected()
+        {
+            if (SetProperty(ref _signalerReady, true, "SignalerReady"))
+            {
+                RaisePropertyChanged("CanNegotiate");
+            }
+        }
+
+        private void DssSignaler_OnDisconnected()
+        {
+            if (SetProperty(ref _signalerReady, false, "SignalerReady"))
+            {
+                RaisePropertyChanged("CanNegotiate");
+            }
+        }
+
+        private async void DssSignaler_OnMessage(NodeDssSignaler.Message message)
+        {
+            Logger.Log($"DSS received message: {message.MessageType}");
+
+            // Ensure that the filtering values are up to date before passing the message on.
+            //UpdateCodecFilters();
+            //_peerConnection.PreferredAudioCodec = PreferredAudioCodec;
+            //_peerConnection.PreferredAudioCodecExtraParamsRemote = PreferredAudioCodecExtraParamsRemoteTextBox.Text;
+            //_peerConnection.PreferredAudioCodecExtraParamsLocal = PreferredAudioCodecExtraParamsLocalTextBox.Text;
+            //_peerConnection.PreferredVideoCodec = PreferredVideoCodec;
+            //_peerConnection.PreferredVideoCodecExtraParamsRemote = PreferredVideoCodecExtraParamsRemoteTextBox.Text;
+            //_peerConnection.PreferredVideoCodecExtraParamsLocal = PreferredVideoCodecExtraParamsLocalTextBox.Text;
+
+            switch (message.MessageType)
+            {
+            case NodeDssSignaler.Message.WireMessageType.Offer:
+                await ApplyRemoteOfferAsync(message.Data);
+                // If we get an offer, we immediately send an answer back once the offer is applied
+                _peerConnection.CreateAnswer();
+                break;
+
+            case NodeDssSignaler.Message.WireMessageType.Answer:
+                await ApplyRemoteAnswerAsync(message.Data);
+                break;
+
+            case NodeDssSignaler.Message.WireMessageType.Ice:
+                // TODO - This is NodeDSS-specific
+                // this "parts" protocol is defined above, in OnIceCandidateReadyToSend listener
+                var parts = message.Data.Split(new string[] { message.IceDataSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                // Note the inverted arguments; candidate is last here, but first in OnIceCandidateReadyToSend
+                _peerConnection.AddIceCandidate(parts[2], int.Parse(parts[1]), parts[0]);
+                break;
+
+            default:
+                throw new InvalidOperationException($"Unhandled signaler message type '{message.MessageType}'");
+            }
+        }
+
+        private void DssSignaler_OnFailure(Exception e)
+        {
+            Logger.Log($"DSS polling failed: {e.Message}");
+
+            //// TODO - differentiate between StartPollingAsync() failure and SendMessageAsync() ones!
+            //if (_dssSignaler.IsPolling)
+            //{
+            //    Logger.Log($"Cancelling polling DSS server...");
+            //    //pollDssButton.IsEnabled = false; // will be re-enabled when cancellation is completed, see DssSignaler_OnPollingDone
+            //    //pollDssButton.Content = "Start polling";
+            //    _dssSignaler.StopPollingAsync();
+            //}
+        }
+
+        private void DssSignaler_OnPollingDone()
+        {
+            Logger.Log($"DSS polling done.");
+
+            //_isDssPolling = false;
+            ////pollDssButton.IsEnabled = true;
+            //Logger.Log($"Polling DSS server stopped.");
+        }
+    }
+}

--- a/examples/TestAppUwp/NodeDssSignaler.cs
+++ b/examples/TestAppUwp/NodeDssSignaler.cs
@@ -9,6 +9,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.MixedReality.WebRTC;
+using System.ComponentModel;
+using Newtonsoft.Json.Serialization;
 
 namespace TestAppUwp
 {
@@ -23,6 +25,7 @@ namespace TestAppUwp
     /// server solution.
     /// </remarks>
     public class NodeDssSignaler
+        : NotifierBase // FIXME - Use ViewModel instead
     {
         /// <summary>
         /// Data that makes up a signaler message
@@ -137,7 +140,7 @@ namespace TestAppUwp
         /// interval between polling requests may be longer depending on
         /// network conditions.
         /// </remarks>
-        public float PollTimeMs = 5f;
+        public int PollTimeMs = 500;
 
         /// <summary>
         /// Indicate whether the <c>node-dss</c> server polling is active,
@@ -152,8 +155,10 @@ namespace TestAppUwp
         {
             get
             {
-                // Atomic read
-                return (Interlocked.CompareExchange(ref _isPolling, 1, 1) == 1);
+                lock (_pollingLock)
+                {
+                    return _isPolling;
+                }
             }
         }
 
@@ -162,7 +167,7 @@ namespace TestAppUwp
         /// be restarted with <see cref="StartPollingAsync"/>.
         /// </summary>
         public event Action OnPollingDone;
-        
+
         /// <summary>
         /// Event that occurs when signaling is connected.
         /// </summary>
@@ -171,9 +176,7 @@ namespace TestAppUwp
         /// <summary>
         /// Event that occurs when signaling is disconnected.
         /// </summary>
-#pragma warning disable 67
         public event Action OnDisconnect;
-#pragma warning restore 67
 
         /// <summary>
         /// Event that occurs when the signaler receives a new message.
@@ -213,13 +216,11 @@ namespace TestAppUwp
         private CancellationTokenSource _cancellationTokenSource;
 
         /// <summary>
-        /// Atomic boolean indicating whether polling is underway, including being cancelled.
+        /// Indicates whether polling is underway, including being cancelled.
         /// </summary>
-        /// <remarks>
-        /// This field is an <code>int</code> because it is modified atomically, and
-        /// <see cref="Interlocked"/> does not provide a <code>bool</code> overload.
-        /// </remarks>
-        private int _isPolling = 0;
+        private bool _isPolling = false;
+
+        private readonly object _pollingLock = new object();
 
         public NodeDssSignaler()
         {
@@ -250,6 +251,7 @@ namespace TestAppUwp
                 if (postTask.Exception != null)
                 {
                     OnFailure?.Invoke(postTask.Exception);
+                    OnDisconnect?.Invoke();
                 }
             });
 
@@ -289,18 +291,23 @@ namespace TestAppUwp
         /// This method can safely be called multiple times, and will do nothing if
         /// polling is already underway or waiting to be stopped.
         /// </remarks>
-        public bool StartPollingAsync()
+        public bool StartPollingAsync(CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(LocalPeerId))
             {
-                throw new Exception("Cannot start polling with empty LocalId.");
+                throw new InvalidOperationException("Cannot start polling with empty LocalId.");
             }
 
-            if (Interlocked.CompareExchange(ref _isPolling, 1, 0) == 1)
+            lock (_pollingLock)
             {
-                // Already polling
-                return false;
+                if (_isPolling)
+                {
+                    return false;
+                }
+                _isPolling = true;
+                _cancellationTokenSource = new CancellationTokenSource();
             }
+            RaisePropertyChanged("IsPolling");
 
             // Build the GET polling request
             string requestUri = $"{_httpServerAddress}data/{LocalPeerId}";
@@ -308,70 +315,69 @@ namespace TestAppUwp
             long lastPollTimeTicks = DateTime.UtcNow.Ticks;
             long pollTimeTicks = TimeSpan.FromMilliseconds(PollTimeMs).Ticks;
 
-            _cancellationTokenSource = new CancellationTokenSource();
-            var token = _cancellationTokenSource.Token;
-            token.Register(() =>
+            var masterTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token, cancellationToken);
+            var masterToken = masterTokenSource.Token;
+            masterToken.Register(() =>
             {
-                Interlocked.Exchange(ref _isPolling, 0);
-                // TODO - Potentially a race condition here if StartPollingAsync() called,
-                //        but would be even worse with the exchange being after, as
-                //        StopPollingAsync() would attempt to read from it while being disposed.
-                _cancellationTokenSource.Dispose();
-                _cancellationTokenSource = null;
+                lock (_pollingLock)
+                {
+                    _isPolling = false;
+                    _cancellationTokenSource.Dispose();
+                    _cancellationTokenSource = null;
+                }
+                RaisePropertyChanged("IsPolling");
+                Interlocked.Exchange(ref _connectedEventFired, 0);
+                OnDisconnect?.Invoke();
                 OnPollingDone?.Invoke();
+                masterTokenSource.Dispose();
             });
 
             // Prepare the repeating poll task.
             // In order to poll at the specified frequency but also avoid overlapping requests,
             // use a repeating task which re-schedule itself on completion, either immediately
             // if the polling delay is elapsed, or at a later time otherwise.
-            Action nextAction = null;
-            nextAction = () =>
+            async void PollServerOnce()
             {
-                token.ThrowIfCancellationRequested();
-
-                // Send GET request to DSS server.
-                // In order to avoid exceptions in GetStreamAsync() when the server returns a non-success status code (e.g. 404),
-                // first get the HTTP headers, check the status code, then if successful wait for content.
-                lastPollTimeTicks = DateTime.UtcNow.Ticks;
-                _httpClient.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead).ContinueWith((getTask) =>
+                try
                 {
-                    if (getTask.Exception != null)
+                    masterToken.ThrowIfCancellationRequested();
+
+                    // Send GET request to DSS server.
+                    lastPollTimeTicks = DateTime.UtcNow.Ticks;
+                    HttpResponseMessage response = await _httpClient.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead);
+
+                    // On first successful HTTP request, raise the connected event
+                    if (0 == Interlocked.Exchange(ref _connectedEventFired, 1))
                     {
-                        OnFailure?.Invoke(getTask.Exception);
-                        return;
+                        OnConnect?.Invoke();
                     }
 
-                    token.ThrowIfCancellationRequested();
+                    masterToken.ThrowIfCancellationRequested();
 
-                    HttpResponseMessage response = getTask.Result;
+                    // In order to avoid exceptions in GetStreamAsync() when the server returns a non-success status code (e.g. 404),
+                    // first get the HTTP headers, check the status code, then if successful wait for content.
                     if (response.IsSuccessStatusCode)
                     {
-                        response.Content.ReadAsStringAsync().ContinueWith((readTask) =>
+                        string jsonMsg = await response.Content.ReadAsStringAsync();
+
+                        masterToken.ThrowIfCancellationRequested();
+
+                        var jsonSettings = new JsonSerializerSettings
                         {
-                            if (readTask.Exception != null)
-                            {
-                                OnFailure?.Invoke(readTask.Exception);
-                                return;
-                            }
-
-                            token.ThrowIfCancellationRequested();
-
-                            var jsonMsg = readTask.Result;
-                            var msg = JsonConvert.DeserializeObject<Message>(jsonMsg);
-                            if (msg != null)
-                            {
-                                OnMessage?.Invoke(msg);
-                            }
-                            else
-                            {
-                                OnFailure?.Invoke(new Exception($"Failed to deserialize SignalerMessage object from JSON."));
-                            }
-                        });
+                            Error = (object s, ErrorEventArgs e) => throw new Exception("JSON error: " + e.ErrorContext.Error.Message)
+                        };
+                        Message msg = JsonConvert.DeserializeObject<Message>(jsonMsg, jsonSettings);
+                        if (msg != null)
+                        {
+                            OnMessage?.Invoke(msg);
+                        }
+                        else
+                        {
+                            throw new Exception("Failed to deserialize signaler message from JSON.");
+                        }
                     }
 
-                    // Some time may have passed waiting for GET content; check token again for responsiveness
-                    token.ThrowIfCancellationRequested();
+                    masterToken.ThrowIfCancellationRequested();
 
                     // Repeat task to continue polling
                     long curTime = DateTime.UtcNow.Ticks;
@@ -379,20 +385,25 @@ namespace TestAppUwp
                     if (deltaTicks >= pollTimeTicks)
                     {
                         // Previous GET task took more time than polling delay, execute ASAP
-                        Task.Run(nextAction, token);
+                        Task.Run(PollServerOnce, masterToken);
                     }
                     else
                     {
                         // Previous GET task took less time than polling delay, schedule next polling
                         long remainTicks = pollTimeTicks - deltaTicks;
                         int nextScheduleTimeMs = (int)(new TimeSpan(remainTicks).TotalMilliseconds);
-                        Task.Delay(nextScheduleTimeMs, token).ContinueWith(_ => nextAction(), token);
+                        Task.Delay(nextScheduleTimeMs, masterToken).ContinueWith(_ => PollServerOnce(), masterToken);
                     }
-                });
-            };
+                }
+                catch (Exception ex)
+                {
+                    OnFailure?.Invoke(ex);
+                    masterTokenSource.Cancel();
+                }
+            }
 
             // Start the first poll task immediately
-            Task.Run(nextAction, token);
+            Task.Run(PollServerOnce, masterToken);
             return true;
         }
 
@@ -410,12 +421,14 @@ namespace TestAppUwp
         /// </remarks>
         public bool StopPollingAsync()
         {
-            // Atomic read
-            if (Interlocked.CompareExchange(ref _isPolling, 1, 1) == 1)
+            lock (_pollingLock)
             {
-                // Note: cannot dispose right away, need to wait for end of all tasks.
-                _cancellationTokenSource?.Cancel();
-                return true;
+                if (_isPolling)
+                {
+                    // Note: cannot dispose right away, need to wait for end of all tasks.
+                    _cancellationTokenSource?.Cancel();
+                    return true;
+                }
             }
             return false;
         }

--- a/examples/TestAppUwp/NodeDssSignaler.cs
+++ b/examples/TestAppUwp/NodeDssSignaler.cs
@@ -344,7 +344,8 @@ namespace TestAppUwp
 
                     // Send GET request to DSS server.
                     lastPollTimeTicks = DateTime.UtcNow.Ticks;
-                    HttpResponseMessage response = await _httpClient.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead);
+                    HttpResponseMessage response = await _httpClient.GetAsync(requestUri,
+                        HttpCompletionOption.ResponseHeadersRead, masterToken);
 
                     // On first successful HTTP request, raise the connected event
                     if (0 == Interlocked.Exchange(ref _connectedEventFired, 1))

--- a/examples/TestAppUwp/SessionPage.xaml
+++ b/examples/TestAppUwp/SessionPage.xaml
@@ -1,0 +1,152 @@
+<Page
+    x:Class="TestAppUwp.SessionPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <Page.Resources>
+        <DataTemplate x:Key="TransceiverItemTemplate" x:DataType="local:TransceiverViewModel">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="8px"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Grid Grid.Column="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <SymbolIcon Grid.Row="0"
+                                Symbol="{x:Bind Transceiver.MediaKind, Converter={StaticResource MediaKindToSymbolConverter}}"/>
+                    <SymbolIcon Grid.Row="1"
+                                Symbol="{x:Bind NegotiatedDirection, Mode=OneWay, Converter={StaticResource TransceiverDirectionToSymbolConverter}}"/>
+                </Grid>
+                <Grid Grid.Column="2">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="16"/>
+                        <RowDefinition Height="24"/>
+                        <RowDefinition Height="24"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Text="{x:Bind DisplayName, Mode=OneWay}" Margin="0,0,0,0"
+                               VerticalAlignment="Center" HorizontalAlignment="Left" FontSize="9" />
+                    <TextBlock Grid.Row="1" Text="{x:Bind Sender.DisplayName, Mode=OneWay}" Margin="0,0,0,0"
+                               VerticalAlignment="Center" HorizontalAlignment="Left" />
+                    <TextBlock Grid.Row="2" Text="{x:Bind ReceiverDisplayName, Mode=OneWay}" Margin="0,0,0,0"
+                               VerticalAlignment="Center" HorizontalAlignment="Left" />
+                </Grid>
+            </Grid>
+        </DataTemplate>
+        <DataTemplate x:Key="SenderTrackItemTemplate" x:DataType="local:SenderTrackViewModel">
+            <TextBlock Text="{x:Bind DisplayName}"/>
+        </DataTemplate>
+    </Page.Resources>
+    <Grid Margin="8,0,8,8">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="320"/>
+            <ColumnDefinition Width="8"/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <Border Grid.Column="0" BorderBrush="#66000000" BorderThickness="2,2,2,2" Background="#AAFFFFFF" Padding="8,8,8,8">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="SDP Session Negotiation" FontWeight="Bold" VerticalAlignment="Top"/>
+                    <TextBlock Grid.Column="1" x:Name="signalerNotReadyErrorText" Text="Signaler not ready"
+                                               HorizontalAlignment="Right" Foreground="Red"
+                                               Visibility="{x:Bind SessionModel.SignalerReady, Mode=OneWay, Converter={StaticResource BooleanToVisibilityInvertedConverter}}" VerticalAlignment="Center"/>
+                </Grid>
+                <StackPanel Grid.Row="1" Orientation="Horizontal">
+                    <ToggleSwitch x:Name="automatedNegotiationToggle" Header="Automated negotiation"
+                                                  IsOn="{x:Bind SessionModel.AutomatedNegotiation, Mode=TwoWay}"
+                                                  OnContent="Automated" OffContent="Manual" Margin="0,8,0,0"/>
+                    <Button x:Name="startNegotiationButton" Content="Start Negotiation" Margin="8,0,0,0"
+                                            VerticalAlignment="Center"
+                                            Visibility="{x:Bind SessionModel.AutomatedNegotiation, Mode=OneWay, Converter={StaticResource BooleanToVisibilityInvertedConverter}}"
+                                            IsEnabled="{x:Bind SessionModel.CanNegotiate, Mode=OneWay}"
+                                            Click="StartNegotiationButton_Click"/>
+                </StackPanel>
+                <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Status :" VerticalAlignment="Top" Margin="0,0,8,0"/>
+                    <TextBlock x:Name="negotiationStatusText" VerticalAlignment="Top"
+                               Text="{x:Bind SessionModel.NegotiationState, Mode=OneWay}"/>
+                </StackPanel>
+                <TextBlock Grid.Row="3" Text="Add new transceiver" FontWeight="Bold" VerticalAlignment="Top" Margin="0,16,0,0"/>
+                <TextBox Grid.Row="4" x:Name="newTransceiverName" PlaceholderText="new_transceiver_name" Margin="0,8,0,0"/>
+                <Grid Grid.Row="5" Margin="0,8,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Button Grid.Column="0" Content="Add Audio" HorizontalAlignment="Stretch"
+                            Click="AddAudioTransceiver_Click"/>
+                    <Button Grid.Column="2" Content="Add Video" HorizontalAlignment="Stretch"
+                            Click="AddVideoTransceiver_Click"/>
+                </Grid>
+                <TextBlock Grid.Row="6" Text="Transceivers" FontWeight="Bold" VerticalAlignment="Top" Margin="0,16,0,0"/>
+                <ListView Grid.Row="7" x:Name="transceiverList"
+                          ItemsSource="{x:Bind Transceivers, Mode=OneWay}"
+                          ItemTemplate="{StaticResource TransceiverItemTemplate}"
+                          SelectedItem="{x:Bind Transceivers.SelectedItem, Mode=TwoWay}" Margin="0,8,0,0"/>
+            </Grid>
+        </Border>
+        <StackPanel Orientation="Vertical" Grid.Column="2">
+            <TextBlock Text="Transceiver" Style="{StaticResource TitleTextBlockStyle}"/>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="8"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="Name" Margin="0,8,0,0"/>
+                <TextBox x:Name="transceiverName" Grid.Row="1" IsSpellCheckEnabled="False"
+                         Text="{x:Bind Transceivers.SelectedItem.Name, Mode=OneWay}"
+                         IsReadOnly="True"/><!-- Currently cannot change transceiver name after created, even if not associated -->
+                         <!--IsReadOnly="{x:Bind Transceivers.SelectedItem.IsAssociated, Mode=OneWay}"/>-->
+                <TextBlock Text="Associated" Margin="0,8,0,0" Grid.Row="0" Grid.Column="2"/>
+                <TextBox x:Name="transceiverState" Grid.Row="1" Grid.Column="2" IsEnabled="False"
+                         Text="{x:Bind Transceivers.SelectedItem.IsAssociated, Mode=OneWay}"/>
+            </Grid>
+            <TextBlock Text="Sender track" Margin="0,8,0,0"/>
+            <ComboBox x:Name="transceiverSenderTrack" HorizontalAlignment="Stretch"
+                      DataContext="local:SenderTrackViewModel"
+                      ItemsSource="{x:Bind Transceivers.AvailableSenders, Mode=OneWay}"
+                      IsEnabled="{x:Bind Transceivers.SelectedItem, Mode=OneWay, Converter={StaticResource NullToBoolConverter}}"
+                      SelectionChanged="TransceiverSenderSelectionChanged"
+                      ItemTemplate="{StaticResource SenderTrackItemTemplate}"
+                      SelectedItem="{x:Bind Transceivers.SelectedItem.Sender, Mode=OneWay}">
+                <ComboBox.ItemContainerStyle>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="IsEnabled" Value="{Binding CanBeAttached, Mode=OneWay}"/>
+                    </Style>
+                </ComboBox.ItemContainerStyle>
+            </ComboBox>
+            <TextBlock Text="Receiver track" Margin="0,8,0,0"/>
+            <TextBox x:Name="transceiverReceiverTrack" IsEnabled="False"
+                         Text="{x:Bind Transceivers.SelectedItem.ReceiverDisplayName, Mode=OneWay}"/>
+            <Button Visibility="Collapsed" Name="addExtraDataChannelButton" Content="Add extra data channel" HorizontalAlignment="Left" VerticalAlignment="Top" RenderTransformOrigin="0.511,0.634" Click="AddExtraDataChannelButtonClicked" Width="250" Margin="0,12,0,0"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/examples/TestAppUwp/SessionPage.xaml.cs
+++ b/examples/TestAppUwp/SessionPage.xaml.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.WebRTC;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class SessionPage : Page
+    {
+        public TransceiverCollectionViewModel Transceivers
+        {
+            get { return SessionModel.Current.Transceivers; }
+        }
+
+        public SessionModel SessionModel
+        {
+            get { return SessionModel.Current; }
+        }
+
+        private SessionViewModel _sessionViewModel;
+
+        public SessionPage()
+        {
+            this.InitializeComponent();
+            _sessionViewModel = new SessionViewModel();
+        }
+
+        private void AddPendingTransceiver(MediaKind mediaKind, string name)
+        {
+            var settings = new TransceiverInitSettings
+            {
+                Name = name,
+                InitialDesiredDirection = Transceiver.Direction.SendReceive,
+            };
+            SessionModel.Current.AddTransceiver(mediaKind, settings);
+        }
+
+        private void AddAudioTransceiver_Click(object sender, RoutedEventArgs e)
+        {
+            var name = newTransceiverName.Text ?? "audio_transceiver"; // TODO: validate SDP token
+            AddPendingTransceiver(MediaKind.Audio, name);
+        }
+
+        private void AddVideoTransceiver_Click(object sender, RoutedEventArgs e)
+        {
+            var name = newTransceiverName.Text ?? "video_transceiver"; // TODO: validate SDP token
+            AddPendingTransceiver(MediaKind.Video, name);
+        }
+
+        private void StartNegotiationButton_Click(object sender, RoutedEventArgs e)
+        {
+            SessionModel.Current.StartNegotiation();
+        }
+
+        private void TransceiverSenderSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var senderTrack = transceiverSenderTrack.SelectedItem as SenderTrackViewModel;
+            var transceiverViewModel = SessionModel.Current.Transceivers.SelectedItem;
+            transceiverViewModel.Sender = senderTrack;
+        }
+
+        private async void AddExtraDataChannelButtonClicked(object sender, RoutedEventArgs e)
+        {
+            //if (!PluginInitialized)
+            //{
+            //    return;
+            //}
+            //await _peerConnection.AddDataChannelAsync("extra_channel", true, true);
+        }
+
+        private void TextBlock_SelectionChanged(object sender, RoutedEventArgs e)
+        {
+
+        }
+    }
+}

--- a/examples/TestAppUwp/SettingsPage.xaml
+++ b/examples/TestAppUwp/SettingsPage.xaml
@@ -1,0 +1,104 @@
+<Page
+    x:Class="TestAppUwp.SettingsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <ScrollViewer>
+        <StackPanel Orientation="Vertical" Margin="12,12,12,12">
+            <TextBlock Text="STUN server" Style="{StaticResource TitleTextBlockStyle}"/>
+            <TextBlock FontStyle="Italic" Grid.Row="1" Margin="0,6,0,0">
+                The STUN server is used to establish a peer connection through NATs.<LineBreak/>This can be left empty
+                to not use any server; in that case NAT traversal won't be available.
+            </TextBlock>
+            <TextBox Name="stunServer" Width="400" HorizontalAlignment="Left"
+                     PlaceholderText="address:port (without prefix)"
+                     Grid.Row="2" Margin="0,6,0,6" TextChanged="StunServerTextChanged" />
+            <TextBlock Text="SDP semantic" Style="{StaticResource TitleTextBlockStyle}" Margin="0,16,0,0"/>
+            <TextBlock Margin="0,6,0,6" FontStyle="Italic">
+                Specifies the <Hyperlink NavigateUri="https://webrtc.org/web-apis/chrome/unified-plan/">SDP dialect</Hyperlink>
+                used to negotiate a peer connection.<LineBreak/>The dialect must be the same on both peers, otherwise some
+                features will not work.<LineBreak/>Do not use Plan B unless there is an issue with the Unified Plan.
+            </TextBlock>
+            <RadioButton x:Name="sdpSemanticUnifiedPlan" IsChecked="True"
+                         GroupName="SdpSemanticGroup" Margin="0,0,0,8" Click="SdpSemanticChanged">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="Unified Plan"/>
+                    <TextBlock Margin="0,3,0,0" FontStyle="Italic">
+                        The <Span FontWeight="SemiBold">Unified Plan</Span> semantic is the SDP semantic
+                        adopted in the <Hyperlink NavigateUri="https://www.w3.org/TR/webrtc/">WebRTC 1.0 standard</Hyperlink>.
+                    </TextBlock>
+                </StackPanel>
+            </RadioButton>
+            <RadioButton x:Name="sdpSemanticPlanB" GroupName="SdpSemanticGroup" Click="SdpSemanticChanged">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="Plan B (deprecated)"/>
+                    <TextBlock Margin="0,3,0,0" FontStyle="Italic">
+                        The <Span FontWeight="SemiBold">Plan B</Span> semantic is the historical SDP semantic used in many
+                        WebRTC implementations.
+                    </TextBlock>
+                </StackPanel>
+            </RadioButton>
+            <TextBlock Text="Preferred codecs" Style="{StaticResource TitleTextBlockStyle}" Margin="0,16,0,0"/>
+            <TextBlock FontStyle="Italic" Margin="0,6,0,0" TextWrapping="Wrap">
+                    This option allows filtering the SDP offer to retain only one preferred audio and/or video codec amongst
+                    the supported ones, thereby forcing their use.<LineBreak/>If the selected codec is not supported by the
+                    local peer implemention, this does nothing, and the default codec is used.
+            </TextBlock>
+            <StackPanel Orientation="Vertical" x:Name="preferredAudioCodecsBlock">
+                <StackPanel Orientation="Horizontal">
+                    <RadioButton x:Name="PreferredAudioCodec_Default" GroupName="PreferredAudioCodecGroup"
+                                 Checked="PreferredAudioCodecChecked" Content="(default)" IsChecked="True"/>
+                    <RadioButton x:Name="PreferredAudioCodec_OPUS" GroupName="PreferredAudioCodecGroup"
+                                 Checked="PreferredAudioCodecChecked" Content="OPUS"/>
+                    <RadioButton x:Name="PreferredAudioCodec_Custom" GroupName="PreferredAudioCodecGroup"
+                                 Checked="PreferredAudioCodecChecked" Content="Custom value"/>
+                </StackPanel>
+                <TextBlock x:Name="CustomPreferredAudioCodecHelpText" FontStyle="Italic" Margin="48,6,0,0" Visibility="Collapsed">
+                    Leave blank to use the default video codec. A partial list is
+                    <Hyperlink NavigateUri="https://en.wikipedia.org/wiki/RTP_payload_formats">available from Wikipedia</Hyperlink>.
+                    <LineBreak />Common values include "opus" or "ISAC". Names are case sensitive.
+                </TextBlock>
+                <TextBox Visibility="Collapsed" x:Name="CustomPreferredAudioCodec" Text="" PlaceholderText="(use default)" Margin="48,6,0,6" Width="400" HorizontalAlignment="Left" />
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Local params:</TextBlock>
+                    <TextBox Margin="16,0,0,0" Width="250" PlaceholderText="extra_audio_param_local"
+                             Text="{x:Bind SessionModel.PreferredAudioCodecExtraParamsLocal, Mode=TwoWay}"/>
+                    <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Remote params:</TextBlock>
+                    <TextBox Margin="16,0,0,0" Width="250" PlaceholderText="extra_audio_param_remote"
+                             Text="{x:Bind SessionModel.PreferredAudioCodecExtraParamsRemote, Mode=TwoWay}"/>
+                </StackPanel>
+            </StackPanel>
+            <StackPanel Orientation="Vertical" x:Name="preferredVideoCodecsBlock">
+                <StackPanel Orientation="Horizontal">
+                    <RadioButton x:Name="PreferredVideoCodec_Default" GroupName="PreferredVideoCodecGroup"
+                                 Checked="PreferredVideoCodecChecked" Content="(default)" IsChecked="True"/>
+                    <RadioButton x:Name="PreferredVideoCodec_H264" GroupName="PreferredVideoCodecGroup"
+                                 Checked="PreferredVideoCodecChecked" Content="H.264"/>
+                    <RadioButton x:Name="PreferredVideoCodec_VP8" GroupName="PreferredVideoCodecGroup"
+                                 Checked="PreferredVideoCodecChecked" Content="VP8"/>
+                    <RadioButton x:Name="PreferredVideoCodec_Custom" GroupName="PreferredVideoCodecGroup"
+                                 Checked="PreferredVideoCodecChecked" Content="Custom value"/>
+                </StackPanel>
+                <TextBlock x:Name="CustomPreferredVideoCodecHelpText" FontStyle="Italic" Margin="48,6,0,0" Visibility="Collapsed">
+                    Leave blank to use the default video codec. A partial list is
+                    <Hyperlink NavigateUri="https://en.wikipedia.org/wiki/RTP_payload_formats">available from Wikipedia</Hyperlink>.
+                    <LineBreak />Common values include "H264" or "VP8". Names are case sensitive.
+                </TextBlock>
+                <TextBox Visibility="Collapsed" x:Name="CustomPreferredVideoCodec" PlaceholderText="(use default)" Margin="48,6,0,6" Width="400" HorizontalAlignment="Left" />
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Local params:</TextBlock>
+                    <TextBox Margin="16,0,0,0" Width="250" PlaceholderText="extra_video_param_local"
+                             Text="{x:Bind SessionModel.PreferredVideoCodecExtraParamsLocal, Mode=TwoWay}"/>
+                    <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Remote params:</TextBlock>
+                    <TextBox Margin="16,0,0,0" Width="250" PlaceholderText="extra_video_param_remote"
+                             Text="{x:Bind SessionModel.PreferredVideoCodecExtraParamsRemote, Mode=TwoWay}"/>
+                </StackPanel>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/examples/TestAppUwp/SettingsPage.xaml.cs
+++ b/examples/TestAppUwp/SettingsPage.xaml.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.MixedReality.WebRTC;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// Page for general application settings.
+    /// </summary>
+    public sealed partial class SettingsPage : Page
+    {
+        public SessionModel SessionModel
+        {
+            get { return SessionModel.Current; }
+        }
+
+        /// <summary>
+        /// Get the string representing the preferred audio codec the user selected.
+        /// </summary>
+        // TODO - Use per-transceiver properties instead of per-connection ones
+        public string PreferredAudioCodec
+        {
+            get
+            {
+                if (PreferredAudioCodec_Custom.IsChecked.GetValueOrDefault(false))
+                {
+                    return CustomPreferredAudioCodec.Text;
+                }
+                else if (PreferredAudioCodec_OPUS.IsChecked.GetValueOrDefault(false))
+                {
+                    return "opus";
+                }
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Get the string representing the preferred video codec the user selected.
+        /// </summary>
+        // TODO - Use per-transceiver properties instead of per-connection ones
+        public string PreferredVideoCodec
+        {
+            get
+            {
+                if (PreferredVideoCodec_Custom.IsChecked.GetValueOrDefault(false))
+                {
+                    return CustomPreferredVideoCodec.Text;
+                }
+                else if (PreferredVideoCodec_H264.IsChecked.GetValueOrDefault(false))
+                {
+                    return "H264";
+                }
+                else if (PreferredVideoCodec_VP8.IsChecked.GetValueOrDefault(false))
+                {
+                    return "VP8";
+                }
+                return string.Empty;
+            }
+        }
+
+        public SettingsPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void SdpSemanticChanged(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            if (sender == sdpSemanticUnifiedPlan)
+            {
+                SessionModel.Current.SdpSemantic = SdpSemantic.UnifiedPlan;
+            }
+            else if (sender == sdpSemanticPlanB)
+            {
+                SessionModel.Current.SdpSemantic = SdpSemantic.PlanB;
+            }
+        }
+
+        private void StunServerTextChanged(object sender, TextChangedEventArgs e)
+        {
+            SessionModel.Current.IceServer = new IceServer
+            {
+                Urls = new List<string> { "stun:" + stunServer.Text }
+            };
+        }
+
+        // TODO - Use MVVM
+        // TODO - Use per-transceiver properties instead of per-connection ones
+        private void PreferredAudioCodecChecked(object sender, RoutedEventArgs args)
+        {
+            // Ignore calls during startup, before components are initialized
+            if (PreferredAudioCodec_Custom == null)
+            {
+                return;
+            }
+
+            if (PreferredAudioCodec_Custom.IsChecked.GetValueOrDefault(false))
+            {
+                CustomPreferredAudioCodecHelpText.Visibility = Visibility.Visible;
+                CustomPreferredAudioCodec.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                CustomPreferredAudioCodecHelpText.Visibility = Visibility.Collapsed;
+                CustomPreferredAudioCodec.Visibility = Visibility.Collapsed;
+            }
+
+            SessionModel.Current.PreferredAudioCodec = PreferredAudioCodec;
+        }
+
+        // TODO - Use MVVM
+        // TODO - Use per-transceiver properties instead of per-connection ones
+        private void PreferredVideoCodecChecked(object sender, RoutedEventArgs args)
+        {
+            // Ignore calls during startup, before components are initialized
+            if (PreferredVideoCodec_Custom == null)
+            {
+                return;
+            }
+
+            if (PreferredVideoCodec_Custom.IsChecked.GetValueOrDefault(false))
+            {
+                CustomPreferredVideoCodecHelpText.Visibility = Visibility.Visible;
+                CustomPreferredVideoCodec.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                CustomPreferredVideoCodecHelpText.Visibility = Visibility.Collapsed;
+                CustomPreferredVideoCodec.Visibility = Visibility.Collapsed;
+            }
+
+            SessionModel.Current.PreferredVideoCodec = PreferredVideoCodec;
+        }
+    }
+}

--- a/examples/TestAppUwp/SignalingPage.xaml
+++ b/examples/TestAppUwp/SignalingPage.xaml
@@ -1,0 +1,60 @@
+<Page
+    x:Class="TestAppUwp.SignalingPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <Grid Margin="12,12,12,12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <TextBlock Text="Signaling server" Style="{StaticResource TitleTextBlockStyle}" Grid.ColumnSpan="2" Margin="0,0,0,8"/>
+        <TextBlock Style="{StaticResource BodyTextBlockStyle}" FontStyle="Italic" Grid.Row="1" Grid.ColumnSpan="2">
+            The signaling server is used to discover a peer to connect to. This app
+            uses <Hyperlink NavigateUri="https://github.com/bengreenier/node-dss">node-dss</Hyperlink>.
+        </TextBlock>
+        <TextBlock Text="Server address" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,12,0" Grid.Row="2"/>
+        <TextBox Name="dssServer" HorizontalAlignment="Left" PlaceholderText="http://server:port/"
+                 VerticalAlignment="Center" Width="285"
+                 Grid.Row="2" Grid.Column="1" Margin="0,6,0,6"
+                 Text="{x:Bind _signalerViewModel.Signaler.HttpServerAddress, Mode=TwoWay}"
+                 IsEnabled="{x:Bind _signalerViewModel.Signaler.IsPolling, Mode=OneWay, Converter={StaticResource BooleanInverter}}"/>
+        <TextBlock Text="Poll delay" VerticalAlignment="Center" Grid.Row="3" HorizontalAlignment="Right" Margin="0,0,12,0"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Margin="0,6,0,6">
+            <TextBox x:Name="dssPollTimeMs" MinWidth="100" Text="500" TextAlignment="Right"
+                 IsEnabled="{x:Bind _signalerViewModel.Signaler.IsPolling, Mode=OneWay, Converter={StaticResource BooleanInverter}}"/>
+            <TextBlock Text="ms" VerticalAlignment="Center" Margin="4,0,0,0"/>
+        </StackPanel>
+        <TextBlock Text="Local peer UID" VerticalAlignment="Center" Grid.Row="4" HorizontalAlignment="Right"
+                   Margin="0,0,12,0" Height="20"/>
+        <TextBox x:Name="localPeerUidTextBox" MinWidth="250" Grid.Row="4" Grid.Column="1" Margin="0,6,0,6"
+                 Text="{x:Bind _signalerViewModel.Signaler.LocalPeerId, Mode=TwoWay}"
+                 IsEnabled="{x:Bind _signalerViewModel.Signaler.IsPolling, Mode=OneWay, Converter={StaticResource BooleanInverter}}"/>
+        <TextBlock Text="Remote peer UID" VerticalAlignment="Center" Margin="0,0,12,0" Grid.Row="5" HorizontalAlignment="Right"/>
+        <TextBox x:Name="remotePeerUidTextBox" MinWidth="250" Grid.Row="5" Grid.Column="1" Margin="0,6,0,6"
+                 Text="{x:Bind _signalerViewModel.Signaler.RemotePeerId, Mode=TwoWay}"
+                 IsEnabled="{x:Bind _signalerViewModel.Signaler.IsPolling, Mode=OneWay, Converter={StaticResource BooleanInverter}}"/>
+        <TextBlock Foreground="Red" Grid.Row="6" Grid.ColumnSpan="2" Margin="0,6,0,0"
+                   Text="{x:Bind _signalerViewModel.ErrorMessage, Mode=OneWay}"
+                   Visibility="{x:Bind _signalerViewModel.ErrorMessage, Mode=OneWay, Converter={StaticResource VisibleIfNotEmptyConverter}}"/>
+        <Button x:Name="pollDssButton" HorizontalAlignment="Left" Margin="0,12,0,0"
+                VerticalAlignment="Center" Width="150" Click="PollDssButtonClicked" Grid.Row="7" Grid.ColumnSpan="2"
+                Content="{x:Bind _signalerViewModel.ButtonText, Mode=OneWay}"
+                IsEnabled="{x:Bind _signalerViewModel.IsButtonEnabled, Mode=OneWay}"/>
+    </Grid>
+</Page>

--- a/examples/TestAppUwp/SignalingPage.xaml.cs
+++ b/examples/TestAppUwp/SignalingPage.xaml.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class SignalingPage : Page
+    {
+        private SignalerViewModel _signalerViewModel;
+
+        public SignalingPage()
+        {
+            this.InitializeComponent();
+            _signalerViewModel = new SignalerViewModel(SessionModel.Current.NodeDssSignaler);
+        }
+
+        private void PollDssButtonClicked(object sender, RoutedEventArgs e)
+        {
+            // If already polling, stop
+            if (_signalerViewModel.Signaler.IsPolling)
+            {
+                Logger.Log($"Stop polling node-dss signaling server");
+                _signalerViewModel.StopPolling();
+                return;
+            }
+
+            // If not polling, try to start if the poll parameters are valid
+            if (!int.TryParse(dssPollTimeMs.Text, out int pollTimeMs))
+            {
+                _signalerViewModel.ErrorMessage = "Failed to parse poll time";
+                return;
+            }
+            Logger.Log($"Start polling node-dss signaling server");
+            _signalerViewModel.StartPolling(pollTimeMs);
+        }
+    }
+}

--- a/examples/TestAppUwp/SignalingPage.xaml.cs
+++ b/examples/TestAppUwp/SignalingPage.xaml.cs
@@ -7,7 +7,9 @@ using Windows.UI.Xaml.Controls;
 namespace TestAppUwp
 {
     /// <summary>
-    /// 
+    /// Page displaying the content of the signaling navigation tab, with controls and options
+    /// to manage the <see cref="NodeDssSignaler"/> instance used for the WebRTC signaling of the
+    /// current session.
     /// </summary>
     public sealed partial class SignalingPage : Page
     {

--- a/examples/TestAppUwp/TrackListPage.xaml
+++ b/examples/TestAppUwp/TrackListPage.xaml
@@ -1,0 +1,45 @@
+<Page
+    x:Class="TestAppUwp.TrackListPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <Page.Resources>
+        <DataTemplate x:Key="AddTrackDataTemplate" x:DataType="local:AddNewTrackViewModel">
+            <StackPanel Orientation="Horizontal" Height="64">
+                <Border Width="48" Height="48" Background="LightGray" Margin="0,8,8,8">
+                    <SymbolIcon Symbol="Add"/>
+                </Border>
+                <TextBlock Text="{x:Bind DisplayName}" VerticalAlignment="Center"/>
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate x:Key="TrackDataTemplate" x:DataType="local:TrackViewModel">
+            <StackPanel Orientation="Horizontal" Height="64">
+                <SymbolIcon Width="48" Height="48" Symbol="{x:Bind Symbol}" Margin="0,8,8,8"/>
+                <Grid Height="64">
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Text="{x:Bind DisplayName}" VerticalAlignment="Bottom"/>
+                    <TextBlock Grid.Row="1" Text="{x:Bind Status}" VerticalAlignment="Top" Foreground="Gray"/>
+                </Grid>
+            </StackPanel>
+        </DataTemplate>
+        <local:TrackDataTemplateSelector x:Key="TrackDataTemplateSelector"
+                                         Normal="{StaticResource TrackDataTemplate}"
+                                         AddItem="{StaticResource AddTrackDataTemplate}"/>
+    </Page.Resources>
+    <ScrollViewer>
+        <StackPanel Orientation="Vertical">
+            <ListView x:Name="tracksListView"
+                      ItemsSource="{x:Bind SessionModel.LocalTracks, Mode=OneWay}"
+                      ItemTemplateSelector="{StaticResource TrackDataTemplateSelector}"
+                      ItemClick="ListView_ItemClick" IsItemClickEnabled="True"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/examples/TestAppUwp/TrackListPage.xaml.cs
+++ b/examples/TestAppUwp/TrackListPage.xaml.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class TrackListPage : Page
+    {
+        public SessionModel SessionModel
+        {
+            get { return SessionModel.Current; }
+        }
+
+        public TrackListPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void ListView_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            if (e.ClickedItem is AddNewTrackViewModel addNewTrackViewModel)
+            {
+                tracksListView.SelectedItem = null;
+                Frame.Navigate(addNewTrackViewModel.PageType, null,
+                    new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromRight });
+            }
+        }
+    }
+}

--- a/examples/TestAppUwp/TracksPage.xaml
+++ b/examples/TestAppUwp/TracksPage.xaml
@@ -1,0 +1,19 @@
+<Page
+    x:Class="TestAppUwp.TracksPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppUwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <Grid Margin="8,0,8,8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <TextBlock Text="Tracks" Style="{StaticResource TitleTextBlockStyle}"/>
+        <Frame x:Name="contentFrame" Grid.Row="1"/>
+    </Grid>
+</Page>

--- a/examples/TestAppUwp/TracksPage.xaml.cs
+++ b/examples/TestAppUwp/TracksPage.xaml.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Navigation;
+
+namespace TestAppUwp
+{
+    public class TrackViewModelBase : NotifierBase
+    {
+    }
+
+    public class AddNewTrackViewModel : TrackViewModelBase
+    {
+        public string DisplayName;
+        public Type PageType;
+    }
+
+    public class TrackViewModel : TrackViewModelBase
+    {
+        public readonly Symbol Symbol;
+
+        public string DisplayName;
+
+        public string Status
+        {
+            get { return "status..."; }
+        }
+
+        public TrackViewModel(Symbol symbol)
+        {
+            Symbol = symbol;
+        }
+    }
+
+    public class TrackDataTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate Normal { get; set; }
+        public DataTemplate AddItem { get; set; }
+
+        protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
+        {
+            if ((container is FrameworkElement) && (item != null) && (item is TrackViewModelBase))
+            {
+                if (item is TrackViewModel)
+                {
+                    return Normal;
+                }
+                else
+                {
+                    return AddItem;
+                }
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Top-level page for all tracks-related settings.
+    ///
+    /// Starts by displaying the list of existing tracks.
+    /// </summary>
+    public sealed partial class TracksPage : Page
+    {
+        public TracksPage()
+        {
+            this.InitializeComponent();
+            contentFrame.Navigate(typeof(TrackListPage), null, new SuppressNavigationTransitionInfo());
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            // When navigating away from the Tracks page, reset its content back to the list
+            // of pages (TrackListPage), cancelling any track creation process.
+            while (contentFrame.CanGoBack)
+            {
+                contentFrame.GoBack();
+            }
+
+            base.OnNavigatedFrom(e);
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.MixedReality.WebRTC;
+using Windows.Media.Capture;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    public class AudioCaptureViewModel : NotifierBase
+    {
+        private bool _canCreateTrack = true;
+
+        public bool CanCreateTrack
+        {
+            get { return _canCreateTrack; }
+            set { SetProperty(ref _canCreateTrack, value); }
+        }
+
+        public string ErrorMessage
+        {
+            get { return _errorMessage; }
+            set { SetProperty(ref _errorMessage, value); }
+        }
+
+        private string _errorMessage;
+
+        public async Task AddAudioTrackFromDeviceAsync(string trackName)
+        {
+            const string DefaultAudioDeviceName = "Default audio device";
+
+            await RequestMediaAccesssAsync(StreamingCaptureMode.Audio);
+
+            var settings = new LocalAudioTrackSettings
+            {
+                trackName = trackName
+            };
+            var track = await LocalAudioTrack.CreateFromDeviceAsync(settings);
+
+            SessionModel.Current.AudioTracks.Add(new AudioTrackViewModel
+            {
+                Track = track,
+                TrackImpl = track,
+                IsRemote = false,
+                DeviceName = DefaultAudioDeviceName
+            });
+            SessionModel.Current.LocalTracks.Add(new TrackViewModel(Symbol.Volume) { DisplayName = DefaultAudioDeviceName });
+        }
+
+        private async Task RequestMediaAccesssAsync(StreamingCaptureMode mode)
+        {
+            // Ensure that the UWP app was authorized to capture audio (cap:microphone)
+            // or video (cap:webcam), otherwise the native plugin will fail.
+            try
+            {
+                MediaCapture mediaAccessRequester = new MediaCapture();
+                var mediaSettings = new MediaCaptureInitializationSettings
+                {
+                    AudioDeviceId = "",
+                    VideoDeviceId = "",
+                    StreamingCaptureMode = mode,
+                    PhotoCaptureSource = PhotoCaptureSource.VideoPreview
+                };
+                await mediaAccessRequester.InitializeAsync(mediaSettings);
+            }
+            catch (UnauthorizedAccessException uae)
+            {
+                Logger.Log("Access to A/V denied, check app permissions: " + uae.Message);
+                throw uae;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Failed to initialize A/V with unknown exception: " + ex.Message);
+                throw ex;
+            }
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
@@ -31,7 +31,7 @@ namespace TestAppUwp
         {
             const string DefaultAudioDeviceName = "Default audio device";
 
-            await RequestMediaAccesssAsync(StreamingCaptureMode.Audio);
+            await RequestMediaAccessAsync(StreamingCaptureMode.Audio);
 
             var settings = new LocalAudioTrackSettings
             {
@@ -49,7 +49,7 @@ namespace TestAppUwp
             SessionModel.Current.LocalTracks.Add(new TrackViewModel(Symbol.Volume) { DisplayName = DefaultAudioDeviceName });
         }
 
-        private async Task RequestMediaAccesssAsync(StreamingCaptureMode mode)
+        private async Task RequestMediaAccessAsync(StreamingCaptureMode mode)
         {
             // Ensure that the UWP app was authorized to capture audio (cap:microphone)
             // or video (cap:webcam), otherwise the native plugin will fail.

--- a/examples/TestAppUwp/ViewModel/CollectionViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/CollectionViewModel.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// Base class for observable collections with a single selected item.
+    /// </summary>
+    /// <typeparam name="T">The type of collection items.</typeparam>
+    public class CollectionViewModel<T> : ObservableCollection<T> where T : class
+    {
+        T _selectedItem;
+        bool _autoSelectOnAdd = true;
+
+        public event Action SelectionChanged;
+
+        /// <summary>
+        /// Item currently selected in the collection.
+        /// </summary>
+        public T SelectedItem
+        {
+            get { return _selectedItem; }
+            set
+            {
+                if (SetProperty(ref _selectedItem, value))
+                {
+                    OnSelectedItemChanged();
+                    SelectionChanged?.Invoke();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Automatically select an element when the collection is not empty and
+        /// no element is selected yet.
+        /// </summary>
+        public bool AutoSelectOnAdd
+        {
+            get { return _autoSelectOnAdd; }
+            set
+            {
+                if (SetProperty(ref _autoSelectOnAdd, value) && _autoSelectOnAdd)
+                {
+                    // If autoselect set to true, try to select immediately
+                    if ((Count > 0) && (_selectedItem == null))
+                    {
+                        SelectedItem = this[0];
+                    }
+                }
+            }
+        }
+
+        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
+            base.OnCollectionChanged(e);
+
+            // Auto-select on add
+            if (_autoSelectOnAdd && (_selectedItem == null) && (e.Action == NotifyCollectionChangedAction.Add))
+            {
+                SelectedItem = this[0];
+            }
+        }
+
+        /// <summary>
+        /// Callback invoked when the selected item changed, to allow derived classes to do some extra
+        /// work based on the selected item. The default implementation does nothing.
+        /// </summary>
+        protected virtual void OnSelectedItemChanged() { }
+
+        /// <summary>
+        /// Try to set a property to a new value, and raise the <see cref="PropertyChanged"/> event if
+        /// the value actually changed, or does nothing if not. Values are compared with the built-in
+        /// <see cref="object.Equals(object, object)"/> method.
+        /// </summary>
+        /// <typeparam name="T">The property type.</typeparam>
+        /// <param name="storage">Storage field for the property, whose value is overwritten with the new value.</param>
+        /// <param name="value">New property value to set, which is possibly the same value it currently has.</param>
+        /// <param name="propertyName">
+        /// Property name. This is automatically inferred by the compiler if the method is called from
+        /// within a property setter block <c>set { }</c>.
+        /// </param>
+        /// <returns>Return <c>true</c> if the property value actually changed, or <c>false</c> otherwise.</returns>
+        protected bool SetProperty<U>(ref U storage, U value, [CallerMemberName] string propertyName = null)
+        {
+            if (Equals(storage, value))
+            {
+                return false;
+            }
+            storage = value;
+            OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/Converters.cs
+++ b/examples/TestAppUwp/ViewModel/Converters.cs
@@ -15,14 +15,14 @@ namespace TestAppUwp
     /// </summary>
     public class BooleanInverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, string langauge)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             // true          => false
             // anything else => true
             return (!(value is bool boolValue) || !boolValue);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             // true  => false
             // false => true
@@ -44,7 +44,7 @@ namespace TestAppUwp
     /// </summary>
     public class BooleanToVisibilityInvertedConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, string langauge)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             if ((value is bool boolValue) && boolValue)
             {
@@ -53,7 +53,7 @@ namespace TestAppUwp
             return Visibility.Visible;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             return (!(value is Visibility visibilityValue) || (visibilityValue != Visibility.Visible));
         }
@@ -61,7 +61,7 @@ namespace TestAppUwp
 
     public class VisibleIfNotEmptyConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, string langauge)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             if ((value is string stringValue) && !string.IsNullOrWhiteSpace(stringValue))
             {
@@ -70,7 +70,7 @@ namespace TestAppUwp
             return Visibility.Collapsed;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             throw new NotImplementedException("VisibilleIfNotEmptyConverter is a one-way converter by design.");
         }
@@ -78,12 +78,12 @@ namespace TestAppUwp
 
     public class NullToBoolConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, string langauge)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             return (value != null);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             throw new NotImplementedException("NullToBoolConverter is a one-way converter by design.");
         }
@@ -91,12 +91,12 @@ namespace TestAppUwp
 
     public class CountToBoolNotEmptyConvert : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, string langauge)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             return ((value is int intValue) && (intValue > 0));
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             throw new NotImplementedException("CountToBoolNotEmptyConvert is a one-way converter by design.");
         }
@@ -110,7 +110,7 @@ namespace TestAppUwp
         private const Symbol AudioSymbol = Symbol.Volume;
         private const Symbol VideoSymbol = Symbol.Video;
 
-        public object Convert(object value, Type targetType, object parameter, string langauge)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is MediaKind mediaKind)
             {
@@ -123,7 +123,7 @@ namespace TestAppUwp
             throw new ArgumentOutOfRangeException($"Cannot convert non-MediaKind to Symbol.");
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             if (value is Symbol symbolValue)
             {
@@ -149,7 +149,7 @@ namespace TestAppUwp
         private const Symbol SendReceiveSymbol = Symbol.Switch;
         private const Symbol NullSymbol = Symbol.Sync;
 
-        public object Convert(object value, Type targetType, object parameter, string langauge)
+        public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is Transceiver.Direction directionValue)
             {
@@ -169,7 +169,7 @@ namespace TestAppUwp
             throw new ArgumentOutOfRangeException($"Cannot convert non-Transceiver.Direction to Symbol.");
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             if (value is Symbol symbolValue)
             {

--- a/examples/TestAppUwp/ViewModel/Converters.cs
+++ b/examples/TestAppUwp/ViewModel/Converters.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.MixedReality.WebRTC;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// Convert <c>true</c> to <c>false</c>, and anything else (including <c>false</c>) to <c>true</c>.
+    /// The back-conversion is also available, and simply negate the boolean value.
+    /// </summary>
+    public class BooleanInverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string langauge)
+        {
+            // true          => false
+            // anything else => true
+            return (!(value is bool boolValue) || !boolValue);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        {
+            // true  => false
+            // false => true
+            if (value is bool boolValue)
+            {
+                return !boolValue;
+            }
+            throw new ArgumentException("Cannot back-convert generic non-bool object with BooleanInverter.");
+        }
+    }
+
+    /// <summary>
+    /// Adapter to convert a boolean to a <see cref="Visibility"/> value, with inverted meaning
+    /// as the default implicit converter:
+    /// - <c>true</c> <=> <c>Visibility.Collapsed</c>
+    /// - <c>false</c> <=> <c>Visibility.Visible</c>
+    /// 
+    /// Useful for mapping a property <c>IsHidden</c> to the visibility of a control.
+    /// </summary>
+    public class BooleanToVisibilityInvertedConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string langauge)
+        {
+            if ((value is bool boolValue) && boolValue)
+            {
+                return Visibility.Collapsed;
+            }
+            return Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        {
+            return (!(value is Visibility visibilityValue) || (visibilityValue != Visibility.Visible));
+        }
+    }
+
+    public class VisibleIfNotEmptyConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string langauge)
+        {
+            if ((value is string stringValue) && !string.IsNullOrWhiteSpace(stringValue))
+            {
+                return Visibility.Visible;
+            }
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        {
+            throw new NotImplementedException("VisibilleIfNotEmptyConverter is a one-way converter by design.");
+        }
+    }
+
+    public class NullToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string langauge)
+        {
+            return (value != null);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        {
+            throw new NotImplementedException("NullToBoolConverter is a one-way converter by design.");
+        }
+    }
+
+    public class CountToBoolNotEmptyConvert : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string langauge)
+        {
+            return ((value is int intValue) && (intValue > 0));
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        {
+            throw new NotImplementedException("CountToBoolNotEmptyConvert is a one-way converter by design.");
+        }
+    }
+
+    /// <summary>
+    /// Convert a WebRTC <see cref="MediaKind"/> to a <see cref="Symbol"/> for UI display.
+    /// </summary>
+    public class MediaKindToSymbolConverter : IValueConverter
+    {
+        private const Symbol AudioSymbol = Symbol.Volume;
+        private const Symbol VideoSymbol = Symbol.Video;
+
+        public object Convert(object value, Type targetType, object parameter, string langauge)
+        {
+            if (value is MediaKind mediaKind)
+            {
+                switch (mediaKind)
+                {
+                case MediaKind.Audio: return AudioSymbol;
+                case MediaKind.Video: return VideoSymbol;
+                }
+            }
+            throw new ArgumentOutOfRangeException($"Cannot convert non-MediaKind to Symbol.");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        {
+            if (value is Symbol symbolValue)
+            {
+                switch (symbolValue)
+                {
+                case AudioSymbol: return MediaKind.Audio;
+                case VideoSymbol: return MediaKind.Video;
+                default: throw new ArgumentOutOfRangeException($"Cannot convert unknown Symbol to WebRTC MediaKind.");
+                }
+            }
+            throw new ArgumentOutOfRangeException($"Cannot convert non-Symbol to WebRTC MediaKind.");
+        }
+    }
+
+    /// <summary>
+    /// Convert a WebRTC <see cref="Transceiver.Direction"/> to a <see cref="Symbol"/> for UI display.
+    /// </summary>
+    public class TransceiverDirectionToSymbolConverter : IValueConverter
+    {
+        private const Symbol InactiveSymbol = Symbol.Clear;
+        private const Symbol SendOnlySymbol = Symbol.Forward;
+        private const Symbol ReceiveOnlySymbol = Symbol.Back;
+        private const Symbol SendReceiveSymbol = Symbol.Switch;
+        private const Symbol NullSymbol = Symbol.Sync;
+
+        public object Convert(object value, Type targetType, object parameter, string langauge)
+        {
+            if (value is Transceiver.Direction directionValue)
+            {
+                switch (directionValue)
+                {
+                case Transceiver.Direction.Inactive: return InactiveSymbol;
+                case Transceiver.Direction.SendOnly: return SendOnlySymbol;
+                case Transceiver.Direction.ReceiveOnly: return ReceiveOnlySymbol;
+                case Transceiver.Direction.SendReceive: return SendReceiveSymbol;
+                default: break;
+                }
+            }
+            else if (value is null)
+            {
+                return NullSymbol;
+            }
+            throw new ArgumentOutOfRangeException($"Cannot convert non-Transceiver.Direction to Symbol.");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string langauge)
+        {
+            if (value is Symbol symbolValue)
+            {
+                switch (symbolValue)
+                {
+                case InactiveSymbol: return Transceiver.Direction.Inactive;
+                case SendOnlySymbol: return Transceiver.Direction.SendOnly;
+                case ReceiveOnlySymbol: return Transceiver.Direction.ReceiveOnly;
+                case SendReceiveSymbol: return Transceiver.Direction.SendReceive;
+                default: throw new ArgumentOutOfRangeException($"Cannot convert unknown Symbol to WebRTC Transceiver.Direction.");
+                }
+            }
+            throw new ArgumentOutOfRangeException($"Cannot convert non-Symbol to WebRTC Transceiver.Direction.");
+        }
+    }
+
+    public class StringFormatConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (parameter is string stringParameter)
+            {
+                return string.Format(stringParameter, value);
+            }
+            return value.ToString();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException("StringFormatConverter is a one-way converter by design.");
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
@@ -1,0 +1,499 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.MixedReality.WebRTC;
+using TestAppUwp.Video;
+using Windows.Media.Core;
+using Windows.Media.MediaProperties;
+using Windows.Media.Playback;
+using Windows.UI.Xaml;
+
+namespace TestAppUwp
+{
+    public delegate Task<LocalAudioTrack> AudioTrackFactoryDelegate();
+    public delegate Task<LocalVideoTrack> VideoTrackFactoryDelegate();
+
+    public class AudioTrackTypeViewModel
+    {
+        public string DisplayName;
+        public AudioTrackFactoryDelegate Factory;
+    }
+
+    public class VideoTrackTypeViewModel
+    {
+        public string DisplayName;
+        public VideoTrackFactoryDelegate Factory;
+    }
+
+    public class VideoCaptureFormatViewModel
+    {
+        public VideoCaptureFormat Format;
+    }
+
+    public class MediaPlayerViewModel : NotifierBase
+    {
+        public ObservableCollection<AudioTrackTypeViewModel> AudioTrackTypeList { get; }
+            = new ObservableCollection<AudioTrackTypeViewModel>();
+
+        public ObservableCollection<VideoTrackTypeViewModel> VideoTrackTypeList { get; }
+            = new ObservableCollection<VideoTrackTypeViewModel>();
+
+        public MediaPlayer VideoPlayer => _videoPlayer;
+
+        public MediaPlaybackState VideoPlaybackState
+        {
+            get { return _videoPlayer.PlaybackSession.PlaybackState; }
+        }
+
+        public AudioTrackViewModel AudioTrack
+        {
+            get { return _playbackAudioTrack; }
+            set { SetAudioTrack(value); }
+        }
+
+        public VideoTrackViewModel VideoTrack
+        {
+            get { return _playbackVideoTrack; }
+            set { SetVideoTrack(value); }
+        }
+
+        public uint FrameWidth
+        {
+            get
+            {
+                lock (_mediaPlaybackLock) 
+                {
+                    return _videoWidth;
+                }
+            }
+        }
+
+        public uint FrameHeight
+        {
+            get
+            {
+                lock (_mediaPlaybackLock)
+                {
+                    return _videoHeight;
+                }
+            }
+        }
+
+        public float FrameLoaded
+        {
+            get { return _videoBridge.FrameLoad; }
+        }
+
+        public float FramePresented
+        {
+            get { return _videoBridge.FramePresent; }
+        }
+
+        public float FrameSkipped
+        {
+            get { return _videoBridge.FrameSkip; }
+        }
+
+        public float FrameLate
+        {
+            get { return _videoBridge.LateFrame; }
+        }
+
+        public MediaPlayerViewModel()
+        {
+            _videoPlayer.CurrentStateChanged += OnMediaStateChanged;
+            _videoPlayer.MediaOpened += OnMediaOpened;
+            _videoPlayer.MediaFailed += OnMediaFailed;
+            _videoPlayer.MediaEnded += OnMediaEnded;
+            _videoPlayer.RealTimePlayback = true;
+            _videoPlayer.AutoPlay = false;
+
+            AudioTrackTypeList.Add(new AudioTrackTypeViewModel
+            {
+                DisplayName = "Local microphone (default device)",
+                Factory = async () =>
+                {
+                    return await LocalAudioTrack.CreateFromDeviceAsync();
+                }
+            });
+
+            VideoTrackTypeList.Add(new VideoTrackTypeViewModel
+            {
+                DisplayName = "Local webcam (default device)",
+                Factory = async () =>
+                {
+                    return await LocalVideoTrack.CreateFromDeviceAsync();
+                }
+            });
+
+            _videoStatsTimer.Interval = TimeSpan.FromMilliseconds(300);
+            _videoStatsTimer.Tick += (_1, _2) => UpdateVideoStats();
+        }
+
+        /// <summary>
+        /// Set the audio track used as the audio source of the media player.
+        /// </summary>
+        /// <param name="audioTrack">The audio track to use.</param>
+        public void SetAudioTrack(AudioTrackViewModel audioTrack)
+        {
+            if (_playbackAudioTrack == audioTrack)
+            {
+                return;
+            }
+
+            // Detach old source
+            if (_playbackAudioTrack?.Track != null)
+            {
+                _playbackAudioTrack.Track.AudioFrameReady -= AudioTrack_FrameReady;
+                _audioSampleRate = 0;
+                _audioChannelCount = 0;
+                //ClearAudioStats();
+            }
+
+            _playbackAudioTrack = audioTrack;
+
+            // Attach new source
+            if (_playbackAudioTrack?.Track != null)
+            {
+                _playbackAudioTrack.Track.AudioFrameReady += AudioTrack_FrameReady;
+            }
+
+            RaisePropertyChanged("AudioTrack");
+        }
+
+        /// <summary>
+        /// Set the video track used as the video source of the media player.
+        /// </summary>
+        /// <param name="videoTrack">The video track to use.</param>
+        public void SetVideoTrack(VideoTrackViewModel videoTrack)
+        {
+            if (_playbackVideoTrack == videoTrack)
+            {
+                return;
+            }
+
+            // Notify media player that source changed
+            if (_isVideoPlaying)
+            {
+                _videoStreamSource.NotifyError(MediaStreamSourceErrorStatus.ConnectionToServerLost);
+                _videoPlayer.Pause();
+                _isVideoPlaying = false;
+            }
+
+            // Detach old source
+            if (_playbackVideoTrack?.Track != null)
+            {
+                _playbackVideoTrack.Track.I420AVideoFrameReady -= VideoTrack_I420AFrameReady;
+                _videoWidth = 0;
+                _videoHeight = 0;
+                _videoStatsTimer.Stop();
+                _videoBridge.Clear();
+                UpdateVideoStats();
+                ThreadHelper.RunOnMainThread(() =>
+                {
+                    RaisePropertyChanged("FrameWidth");
+                    RaisePropertyChanged("FrameHeight");
+                });
+            }
+
+            _playbackVideoTrack = videoTrack;
+
+            // Attach new source
+            if (_playbackVideoTrack?.Track != null)
+            {
+                _playbackVideoTrack.Track.I420AVideoFrameReady += VideoTrack_I420AFrameReady;
+                _videoStatsTimer.Start();
+            }
+
+            RaisePropertyChanged("VideoTrack");
+        }
+
+        private VideoBridge _videoBridge = new VideoBridge(3);
+        private readonly object _mediaPlaybackLock = new object();
+        private MediaStreamSource _videoStreamSource = null;
+        private MediaSource _videoSource = null;
+        private readonly MediaPlayer _videoPlayer = new MediaPlayer();
+        private bool _isVideoPlaying = false;
+        private bool _isAudioPlaying = false;
+        private AudioTrackViewModel _playbackAudioTrack = null;
+        private VideoTrackViewModel _playbackVideoTrack = null;
+        private uint _videoWidth = 0;
+        private uint _videoHeight = 0;
+        private uint _audioChannelCount = 0;
+        private uint _audioSampleRate = 0;
+        private DispatcherTimer _videoStatsTimer = new DispatcherTimer();
+
+        /// <summary>
+        /// Create a new 30-fps NV12-encoded video source for the specified video size.
+        /// </summary>
+        /// <param name="width">The width of the video in pixels.</param>
+        /// <param name="height">The height of the video in pixels.</param>
+        /// <returns>The newly created video source.</returns>
+        private MediaStreamSource CreateVideoStreamSource(uint width, uint height, uint framerate)
+        {
+            if (width == 0)
+            {
+                throw new ArgumentException("Invalid zero width for video stream source.", "width");
+            }
+            if (height == 0)
+            {
+                throw new ArgumentException("Invalid zero height for video stream source.", "height");
+            }
+
+            // Note: IYUV and I420 have same memory layout (though different FOURCC)
+            // https://docs.microsoft.com/en-us/windows/desktop/medfound/video-subtype-guids
+            var videoProperties = VideoEncodingProperties.CreateUncompressed(MediaEncodingSubtypes.Iyuv, width, height);
+            var videoStreamDesc = new VideoStreamDescriptor(videoProperties);
+            videoStreamDesc.EncodingProperties.FrameRate.Numerator = framerate;
+            videoStreamDesc.EncodingProperties.FrameRate.Denominator = 1;
+            videoStreamDesc.EncodingProperties.Bitrate = (framerate * width * height * 12); // NV12=12bpp
+            var videoStreamSource = new MediaStreamSource(videoStreamDesc);
+            videoStreamSource.BufferTime = TimeSpan.Zero; // TODO : playback breaks if buffering, need to investigate
+            videoStreamSource.Starting += OnMediaStreamSourceStarting;
+            videoStreamSource.Closed += OnMediaStreamSourceClosed;
+            videoStreamSource.Paused += OnMediaStreamSourcePaused;
+            videoStreamSource.SampleRequested += OnMediaStreamSourceRequested;
+            videoStreamSource.IsLive = true; // Enables optimizations for live sources
+            videoStreamSource.CanSeek = false; // Cannot seek live WebRTC video stream
+            return videoStreamSource;
+        }
+
+        private void OnMediaStreamSourceStarting(MediaStreamSource sender, MediaStreamSourceStartingEventArgs args)
+        {
+            //Debug.Assert(Dispatcher.HasThreadAccess == false);
+            Logger.Log("Video playback stream source starting...");
+            args.Request.SetActualStartPosition(TimeSpan.Zero);
+        }
+
+        private void OnMediaStreamSourceClosed(MediaStreamSource sender, MediaStreamSourceClosedEventArgs args)
+        {
+            //Debug.Assert(Dispatcher.HasThreadAccess == false);
+            Logger.Log("Video playback stream source closed.");
+        }
+
+        private void OnMediaStreamSourcePaused(MediaStreamSource sender, object args)
+        {
+            //Debug.Assert(Dispatcher.HasThreadAccess == false);
+            Logger.Log("Video playback stream source paused.");
+        }
+
+        /// <summary>
+        /// Callback from the Media Foundation pipeline when a new video frame is needed.
+        /// </summary>
+        /// <param name="sender">The stream source requesting a new sample.</param>
+        /// <param name="args">The sample request to fullfil.</param>
+        private void OnMediaStreamSourceRequested(MediaStreamSource sender, MediaStreamSourceSampleRequestedEventArgs args)
+        {
+            _videoBridge.TryServeVideoFrame(args);
+        }
+
+        private void OnMediaStateChanged(MediaPlayer sender, object args)
+        {
+            if (sender == _videoPlayer)
+            {
+                Logger.Log($"Media player state changed to {sender.PlaybackSession.PlaybackState}.");
+                ThreadHelper.RunOnMainThread(() => RaisePropertyChanged("VideoPlaybackState"));
+            }
+        }
+
+        /// <summary>
+        /// Callback on Media Foundation pipeline media successfully opened and
+        /// ready to be played in a local media player.
+        /// </summary>
+        /// <param name="sender">The <see xref="MediaPlayer"/> source object owning the media.</param>
+        /// <param name="args">(unused)</param>
+        private void OnMediaOpened(MediaPlayer sender, object args)
+        {
+            // Now it is safe to call Play() on the MediaElement
+            //ThreadHelper.RunOnMainThread(() => sender.Play());
+            sender.Play();
+        }
+
+        /// <summary>
+        /// Callback on Media Foundation pipeline media failed to open or to continue playback.
+        /// </summary>
+        /// <param name="sender">The <see xref="MediaPlayer"/> source object owning the media.</param>
+        /// <param name="args">(unused)</param>
+        private void OnMediaFailed(MediaPlayer sender, MediaPlayerFailedEventArgs args)
+        {
+            Logger.Log($"MediaElement reported an error: \"{args.ErrorMessage}\" (\"{args.ExtendedErrorCode.Message}\")");
+        }
+
+        /// <summary>
+        /// Callback on Media Foundation pipeline media ended playback.
+        /// </summary>
+        /// <param name="sender">The <see xref="MediaPlayer"/> source object owning the media.</param>
+        /// <param name="args">(unused)</param>
+        /// <remarks>This appears to never be called for live sources.</remarks>
+        private void OnMediaEnded(MediaPlayer sender, object args)
+        {
+            //ThreadHelper.RunOnMainThread(() =>
+            {
+                Logger.Log("Local MediaElement video playback ended.");
+                //StopLocalMedia();
+                sender.Pause();
+                sender.Source = null;
+                if (sender == _videoPlayer)
+                {
+                    //< TODO - This should never happen. But what to do with
+                    //         local channels if it happens?
+                    lock (_mediaPlaybackLock)
+                    {
+                        _videoStreamSource.NotifyError(MediaStreamSourceErrorStatus.Other);
+                        _videoStreamSource = null;
+                        _videoSource.Dispose();
+                        _videoSource = null;
+                        _isVideoPlaying = false;
+                    }
+                }
+            }//);
+        }
+
+
+        /// <summary>
+        /// Stop playback of the local video from the local webcam, and remove the local
+        /// audio and video tracks from the peer connection. This is called on the UI thread.
+        /// </summary>
+        private async void StopLocalMedia()
+        {
+            lock (_mediaPlaybackLock)
+            {
+                if (_isVideoPlaying)
+                {
+                    _videoPlayer.Pause();
+                    _videoPlayer.Source = null;
+                    //videoPlayerElement.SetMediaPlayer(null);
+                    _videoStreamSource.NotifyError(MediaStreamSourceErrorStatus.Other);
+                    _videoStreamSource = null;
+                    _videoSource.Dispose();
+                    _videoSource = null;
+                    _isVideoPlaying = false;
+
+                    //_playbackAudioTrack.AudioFrameReady -= AudioTrack_FrameReady;
+                    //_playbackVideoTrack.I420AVideoFrameReady -= VideoTrack_I420AFrameReady;
+                }
+            }
+
+            //LocalVideoTracks.Remove(LocalVideoTracks.Single(t => t.Track == _playbackVideoTrack));
+            //videoTrackComboBox.IsEnabled = (LocalVideoTracks.Count > 0);
+
+            //// Avoid deadlock in audio processing stack, as this call is delegated to the WebRTC
+            //// signaling thread (and will block the caller thread), and audio processing will
+            //// delegate to the UI thread for UWP operations (and will block the signaling thread).
+            //await RunOnWorkerThread(() =>
+            //{
+            //    lock (_mediaPlaybackLock)
+            //    {
+            //        SelectedAudioTransceiver.LocalAudioTrack = null;
+            //        SelectedVideoTransceiver.LocalVideoTrack = null;
+            //        _sdpSessionViewModel.AutomatedNegotiation = true;
+            //        if (_peerConnection.IsConnected)
+            //        {
+            //            _sdpSessionViewModel.StartNegotiation();
+            //        }
+            //        _playbackAudioTrack.Dispose();
+            //        _playbackAudioTrack = null;
+            //        _playbackVideoTrack.Dispose();
+            //        _playbackVideoTrack = null;
+            //    }
+            //});
+
+        }
+
+
+        /// <summary>
+        /// Callback on video frame received from the local video capture device,
+        /// for local rendering before (or in parallel of) being sent to the remote peer.
+        /// </summary>
+        /// <param name="frame">The newly captured video frame.</param>
+        private void VideoTrack_I420AFrameReady(I420AVideoFrame frame)
+        {
+            // Lazily start the video media player when receiving the first video frame from
+            // the video track. Currently there is no exposed API to tell once connected that
+            // the remote peer will be sending some video track, so handle local and remote
+            // video tracks the same for simplicity.
+            bool needNewSource = false;
+            uint width = frame.width;
+            uint height = frame.height;
+            lock (_mediaPlaybackLock)
+            {
+                if (!_isVideoPlaying)
+                {
+                    _isVideoPlaying = true;
+                    _videoWidth = width;
+                    _videoHeight = height;
+                    needNewSource = true;
+                }
+                else if ((width != _videoWidth) || (height != _videoHeight))
+                {
+                    _videoWidth = width;
+                    _videoHeight = height;
+                    needNewSource = true;
+                }
+            }
+            if (needNewSource)
+            {
+                // We don't know the remote video framerate yet, so use a default.
+                uint framerate = 30;
+                //RunOnMainThread(() =>
+                {
+                    Logger.Log($"Creating new video source: {width}x{height}@{framerate}");
+                    _videoPlayer.Pause();
+                    //_videoPlayer.Source = null;
+                    _videoStreamSource?.NotifyError(MediaStreamSourceErrorStatus.Other);
+                    _videoSource?.Dispose();
+                    _videoStreamSource = CreateVideoStreamSource(width, height, framerate);
+                    _videoSource = MediaSource.CreateFromMediaStreamSource(_videoStreamSource);
+                    _videoPlayer.Source = _videoSource;
+                }//);
+
+                ThreadHelper.RunOnMainThread(() =>
+                {
+                    RaisePropertyChanged("FrameWidth");
+                    RaisePropertyChanged("FrameHeight");
+                });
+            }
+
+            _videoBridge.HandleIncomingVideoFrame(frame);
+        }
+
+        /// <summary>
+        /// Callback on audio frame produced by the local peer.
+        /// </summary>
+        /// <param name="frame">The newly produced audio frame.</param>
+        private void AudioTrack_FrameReady(AudioFrame frame)
+        {
+            //uint channelCount = frame.channelCount;
+            //uint sampleRate = frame.sampleRate;
+            //bool sourceChanged = false;
+            //lock (_mediaPlaybackLock)
+            //{
+            //    if (!_isAudioPlaying || (_audioChannelCount != channelCount) || (_audioSampleRate != sampleRate))
+            //    {
+            //        _isAudioPlaying = true;
+            //        _audioChannelCount = channelCount;
+            //        _audioSampleRate = sampleRate;
+            //        sourceChanged = true;
+            //    }
+            //}
+
+            //if (sourceChanged)
+            //{
+            //    // As an example of handling, update the UI to display the number of audio
+            //    // channels and the sample rate of the audio track.
+            //    //RunOnMainThread(() => UpdateRemoteAudioStats(channelCount, sampleRate));
+            //}
+        }
+
+        private void UpdateVideoStats()
+        {
+            RaisePropertyChanged("FrameLoaded");
+            RaisePropertyChanged("FramePresented");
+            RaisePropertyChanged("FrameSkipped");
+            RaisePropertyChanged("FrameLate");
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/NotifierBase.cs
+++ b/examples/TestAppUwp/ViewModel/NotifierBase.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Windows.UI.Core;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// Base class for models and view models implementing <see cref="INotifyPropertyChanged"/>.
+    /// </summary>
+    public class NotifierBase : INotifyPropertyChanged
+    {
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private readonly CoreDispatcher _dispatcher;
+
+        protected NotifierBase()
+        {
+            _dispatcher = Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher;
+        }
+
+        /// <summary>
+        /// Try to set a property to a new value, and raise the <see cref="PropertyChanged"/> event if
+        /// the value actually changed, or does nothing if not. Values are compared with the built-in
+        /// <see cref="object.Equals(object, object)"/> method.
+        /// </summary>
+        /// <typeparam name="T">The property type.</typeparam>
+        /// <param name="storage">Storage field for the property, whose value is overwritten with the new value.</param>
+        /// <param name="value">New property value to set, which is possibly the same value it currently has.</param>
+        /// <param name="propertyName">
+        /// Property name. This is automatically inferred by the compiler if the method is called from
+        /// within a property setter block <c>set { }</c>.
+        /// </param>
+        /// <returns>Return <c>true</c> if the property value actually changed, or <c>false</c> otherwise.</returns>
+        protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (Equals(storage, value))
+            {
+                return false;
+            }
+            storage = value;
+            RaisePropertyChanged(propertyName);
+            return true;
+        }
+
+        /// <summary>
+        /// Raise the <see cref="PropertyChanged"/> event for the given property name, taking care of dispatching
+        /// the call to the appropriate thread.
+        /// </summary>
+        /// <param name="propertyName">Name of the property which changed.</param>
+        protected void RaisePropertyChanged(string propertyName)
+        {
+            // The event must be raised on the UI thread
+            if (_dispatcher.HasThreadAccess)
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            }
+            else
+            {
+                _ = _dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+                    () => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName)));
+            }
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/SessionViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/SessionViewModel.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.MixedReality.WebRTC;
+
+namespace TestAppUwp
+{
+    public static class ThreadHelper
+    {
+        public static Task RunOnMainThread(Windows.UI.Core.DispatchedHandler handler)
+        {
+            var dispatcher = Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher;
+            if (dispatcher.HasThreadAccess)
+            {
+                handler.Invoke();
+                return Task.CompletedTask;
+            }
+            else
+            {
+                return dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, handler).AsTask();
+            }
+        }
+
+        public static Task RunOnWorkerThread(Action handler)
+        {
+            var dispatcher = Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher;
+            if (dispatcher.HasThreadAccess)
+            {
+                return Task.Run(handler);
+            }
+            else
+            {
+                handler.Invoke();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    /// <summary>
+    /// View model for the SDP session.
+    /// </summary>
+    public class SessionViewModel : NotifierBase
+    {
+        /// <summary>
+        /// Peer connection this view model is providing the session binding of.
+        /// </summary>
+        //private PeerConnection _peerConnection;
+
+        public SessionViewModel()
+        {
+            //_peerConnection = peerConnection;
+            //_peerConnection.RenegotiationNeeded += OnRenegotiationNeeded;
+        }
+
+
+    }
+}

--- a/examples/TestAppUwp/ViewModel/SignalerViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/SignalerViewModel.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace TestAppUwp
+{
+    public class SignalerViewModel : NotifierBase
+    {
+        private static readonly string ButtonStartText = "Start polling";
+        private static readonly string ButtonStopText = "Stop polling";
+
+        private string _errorMessage;
+        private bool _isButtonEnabled = true;
+        private string _buttonText = ButtonStartText;
+
+        public NodeDssSignaler Signaler { get; }
+
+        public string ErrorMessage
+        {
+            get { return _errorMessage; }
+            set { SetProperty(ref _errorMessage, value); }
+        }
+
+        public bool IsButtonEnabled
+        {
+            get { return _isButtonEnabled; }
+            private set { SetProperty(ref _isButtonEnabled, value); }
+        }
+
+        public string ButtonText
+        {
+            get { return _buttonText; }
+            private set { SetProperty(ref _buttonText, value); }
+        }
+
+        public SignalerViewModel(NodeDssSignaler signaler)
+        {
+            Signaler = signaler;
+            Signaler.OnConnect += OnConnect;
+            Signaler.OnDisconnect += OnDisconnect;
+            Signaler.OnFailure += OnFailure;
+        }
+
+        public void StartPolling(int pollTimeMs)
+        {
+            ErrorMessage = string.Empty;
+            IsButtonEnabled = false;
+
+            if (string.IsNullOrWhiteSpace(Signaler.HttpServerAddress))
+            {
+                ErrorMessage = "Empty node-dss HTTP server address";
+                IsButtonEnabled = true;
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(Signaler.LocalPeerId) || string.IsNullOrWhiteSpace(Signaler.RemotePeerId))
+            {
+                ErrorMessage = "Empty local or remote peer ID";
+                IsButtonEnabled = true;
+                return;
+            }
+
+            Signaler.PollTimeMs = pollTimeMs;
+            try
+            {
+                Signaler.StartPollingAsync();
+                ButtonText = ButtonStopText;
+            }
+            catch
+            {
+                ButtonText = ButtonStartText;
+                IsButtonEnabled = true;
+            }
+        }
+
+        public void StopPolling()
+        {
+            ErrorMessage = string.Empty;
+            IsButtonEnabled = false;
+
+            try
+            {
+                Signaler.StopPollingAsync();
+            }
+            catch
+            {
+                ButtonText = ButtonStopText;
+                IsButtonEnabled = true;
+            }
+        }
+
+        private void OnConnect()
+        {
+            ButtonText = ButtonStopText;
+            IsButtonEnabled = true;
+        }
+
+        private void OnDisconnect()
+        {
+            ButtonText = ButtonStartText;
+            IsButtonEnabled = true;
+        }
+
+        private void OnFailure(Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            ButtonText = ButtonStartText;
+            IsButtonEnabled = true;
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/TransceiverCollectionViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/TransceiverCollectionViewModel.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using Microsoft.MixedReality.WebRTC;
+
+namespace TestAppUwp
+{
+    public class SenderTrackViewModel
+    {
+        public SenderTrackViewModel(MediaTrack track, string displayName = null)
+        {
+            Track = track;
+            DisplayName = string.IsNullOrWhiteSpace(displayName) ? Track?.Name : displayName;
+        }
+
+        public MediaTrack Track { get; }
+
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// Can the sender track be attached to a transceiver? This is <c>false</c> if already
+        /// attached to a transceiver, and <c>true</c> if not already attached to any transceiver.
+        /// </summary>
+        public bool CanBeAttached = false;
+    }
+
+    /// <summary>
+    /// View model for the collection of transceivers of the peer connection. the currently
+    /// selected transceiver in the Tracks window side panel, and the list of available sender
+    /// and receiver tracks for that selected transceiver.
+    /// </summary>
+    public class TransceiverCollectionViewModel : CollectionViewModel<TransceiverViewModel>
+    {
+        private MediaKind _availableMediaKind = MediaKind.Audio;
+        private ObservableCollection<SenderTrackViewModel> _availableSenders;
+
+        public static readonly SenderTrackViewModel NullSenderTrack = new SenderTrackViewModel(null, "<none>");
+
+        /// <summary>
+        /// Collection of available sender tracks that can be assigned
+        /// to the local track of the currently selected transceiver.
+        /// </summary>
+        public ObservableCollection<SenderTrackViewModel> AvailableSenders
+        {
+            get { return _availableSenders; }
+            set { SetProperty(ref _availableSenders, value); }
+        }
+
+        public void RefreshSenderList(MediaKind mediaKind, bool force = false)
+        {
+            if ((mediaKind != _availableMediaKind) || force)
+            {
+                _availableMediaKind = mediaKind;
+
+                // Rebuild the list of sender tracks for the given media kind
+                var senders = new ObservableCollection<SenderTrackViewModel>();
+                senders.Add(NullSenderTrack);
+                if (_availableMediaKind == MediaKind.Audio)
+                {
+                    foreach (var trackViewModel in SessionModel.Current.AudioTracks)
+                    {
+                        if (trackViewModel.IsRemote)
+                        {
+                            continue;
+                        }
+                        var track = trackViewModel?.TrackImpl;
+                        if (track != null)
+                        {
+                            senders.Add(new SenderTrackViewModel(track));
+                        }
+                    }
+                }
+                else if (_availableMediaKind == MediaKind.Video)
+                {
+                    foreach (var trackViewModel in SessionModel.Current.VideoTracks)
+                    {
+                        if (trackViewModel.IsRemote)
+                        {
+                            continue;
+                        }
+                        var track = trackViewModel?.TrackImpl;
+                        if (track != null)
+                        {
+                            senders.Add(new SenderTrackViewModel(track));
+                        }
+                    }
+                }
+                AvailableSenders = senders; // FIXME - this is not thread-aware, and RefreshSenderList() can be called from non-UI thread... 
+                SelectedItem?.NotifySenderChanged();
+            }
+        }
+
+        protected override void OnSelectedItemChanged()
+        {
+            var tr = SelectedItem?.Transceiver;
+            if (tr == null)
+            {
+                return;
+            }
+            RefreshSenderList(tr.MediaKind);
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/TransceiverViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/TransceiverViewModel.cs
@@ -130,16 +130,6 @@ namespace TestAppUwp
         public bool IsAudioTransceiver => Transceiver.MediaKind == MediaKind.Audio;
         public bool IsVideoTransceiver => Transceiver.MediaKind == MediaKind.Video;
 
-        /// <summary>
-        /// Collection of available sender tracks for the currently selected transceiver
-        /// media kind. This collection is rebuilt each time the selected transceiver changed
-        /// and its media kind is different from the previous transceiver.
-        /// </summary>
-        /// FIXME - There is no check to avoid assigning the same sender track to 2 tranceivers,
-        /// which asserts internally as this is not supported.
-        public ObservableCollection<SenderTrackViewModel> AvailableSenders { get; }
-            = new ObservableCollection<SenderTrackViewModel>();
-
         public TransceiverViewModel(Transceiver transceiver)
         {
             Transceiver = transceiver;

--- a/examples/TestAppUwp/ViewModel/TransceiverViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/TransceiverViewModel.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.ObjectModel;
+using Microsoft.MixedReality.WebRTC;
+
+namespace TestAppUwp
+{
+    /// <summary>
+    /// View model for a transceiver.
+    /// </summary>
+    public class TransceiverViewModel : NotifierBase
+    {
+        /// <summary>
+        /// The peer connection transceiver this instance is a view model of.
+        /// </summary>
+        public Transceiver Transceiver { get; }
+
+        /// <summary>
+        /// Current sender track for the transceiver. This is the track used as the media
+        /// source to send to the remote peer. This can be the null sender track
+        /// (<see cref="TransceiverCollectionViewModel.NullSenderTrack"/>), but cannot be
+        /// a <c>null</c> sender track view model (ignored).
+        /// </summary>
+        public SenderTrackViewModel Sender
+        {
+            get { return _sender; }
+            set
+            {
+                // Ignore null values; this happens when the transceiver selection changes before
+                // the list of senders is re-populated and the combo box selected item re-assigned.
+                // A null track is actually abstracted inside a valid SenderTrack object, so this
+                // doesn't prevent assigning a null track to the transceiver.
+                if (value == null)
+                {
+                    return;
+                }
+
+                if (SetProperty(ref _sender, value))
+                {
+                    // Don't set tracks from main UI thread on UWP, that will most likely deadlock,
+                    // as the current call with block on the signaling thread, which blocks on media
+                    // being updated on the worker thread, which on UWP often uses some async API that
+                    // need to pump the main UI thread, resulting in a 3-thread deadlock loop.
+                    // See e.g. https://github.com/webrtc-uwp/webrtc-uwp-sdk/issues/143
+                    MediaKind mediaKind = Transceiver.MediaKind;
+                    MediaTrack newTrack = _sender.Track;
+                    ThreadHelper.RunOnWorkerThread(() =>
+                    {
+                        if (mediaKind == MediaKind.Audio)
+                        {
+                            if (newTrack == null)
+                            {
+                                Transceiver.LocalAudioTrack = null;
+                            }
+                            else if (newTrack is LocalAudioTrack localAudioTrack)
+                            {
+                                Transceiver.LocalAudioTrack = localAudioTrack;
+                            }
+                            else
+                            {
+                                throw new ArgumentException();
+                            }
+                        }
+                        else if (mediaKind == MediaKind.Video)
+                        {
+                            if (newTrack == null)
+                            {
+                                Transceiver.LocalVideoTrack = null;
+                            }
+                            else if (newTrack is LocalVideoTrack localVideoTrack)
+                            {
+                                Transceiver.LocalVideoTrack = localVideoTrack;
+                            }
+                            else
+                            {
+                                throw new ArgumentException();
+                            }
+                        }
+                    });
+                }
+            }
+        }
+
+        /// <summary>
+        /// Is the transceiver associated with a media line?
+        /// </summary>
+        public bool IsAssociated
+        {
+            get { return _isAssociated; }
+            set { SetProperty(ref _isAssociated, value); }
+        }
+
+        /// <summary>
+        /// Display name for the transceiver, shown above the sender/receiver tracks.
+        /// </summary>
+        public string DisplayName
+        {
+            get { return $"{Transceiver.MlineIndex}. {Transceiver.Name}"; }
+        }
+
+        /// <summary>
+        /// Transceiver SDP name.
+        /// </summary>
+        public string Name => Transceiver.Name;
+
+        /// <summary>
+        /// Transceiver negotiated direction.
+        /// </summary>
+        public Transceiver.Direction? NegotiatedDirection
+        {
+            get
+            {
+                return Transceiver.NegotiatedDirection;
+            }
+        }
+
+        /// <summary>
+        /// Receiver track SDP name.
+        /// </summary>
+        public string ReceiverDisplayName
+        {
+            get
+            {
+                return Transceiver.RemoteTrack?.Name;
+            }
+        }
+
+        public bool IsAudioTransceiver => Transceiver.MediaKind == MediaKind.Audio;
+        public bool IsVideoTransceiver => Transceiver.MediaKind == MediaKind.Video;
+
+        /// <summary>
+        /// Collection of available sender tracks for the currently selected transceiver
+        /// media kind. This collection is rebuilt each time the selected transceiver changed
+        /// and its media kind is different from the previous transceiver.
+        /// </summary>
+        /// FIXME - There is no check to avoid assigning the same sender track to 2 tranceivers,
+        /// which asserts internally as this is not supported.
+        public ObservableCollection<SenderTrackViewModel> AvailableSenders { get; }
+            = new ObservableCollection<SenderTrackViewModel>();
+
+        public TransceiverViewModel(Transceiver transceiver)
+        {
+            Transceiver = transceiver;
+            IsAssociated = (transceiver.MlineIndex >= 0);
+            transceiver.Associated += OnAssociated;
+            transceiver.DirectionChanged += OnDirectionChanged;
+
+            // Sender defaults to the NULL track
+            _sender = TransceiverCollectionViewModel.NullSenderTrack;
+        }
+
+        /// <summary>
+        /// Notify the current transceiver that its sender track may have changed, generally
+        /// because the list of senders was refreshed after a new transceiver was selected.
+        /// </summary>
+        public void NotifySenderChanged()
+        {
+            RaisePropertyChanged("Sender");
+        }
+
+        /// <summary>
+        /// Notify the current transceiver that its receiver track has changed, generally
+        /// because a new remote track was created after an offer or answer was applied.
+        /// </summary>
+        public void NotifyReceiverChanged()
+        {
+            RaisePropertyChanged("ReceiverDisplayName");
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="IsAssociated"/>.
+        /// </summary>
+        private bool _isAssociated = false;
+
+        /// <summary>
+        /// Backing field for <see cref="Sender"/>.
+        /// </summary>
+        private SenderTrackViewModel _sender;
+
+        private void OnDirectionChanged(Transceiver transceiver)
+        {
+            // Transceiver.NegotiatedDirection changed, which is used
+            // by the NegotiatedDirection bind property
+            RaisePropertyChanged("NegotiatedDirection");
+        }
+
+        /// <summary>
+        /// Callback when the transceiver gets associated as a result of an offer being applied.
+        /// </summary>
+        /// <param name="transceiver">The current transceiver being associated.</param>
+        private void OnAssociated(Transceiver transceiver)
+        {
+            IsAssociated = (transceiver.MlineIndex >= 0);
+            // Transceiver.MlineIndex changed, which is used by DisplayName
+            RaisePropertyChanged("DisplayName");
+        }
+    }
+}

--- a/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
@@ -1,0 +1,343 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.MixedReality.WebRTC;
+using Windows.Media.Capture;
+using Windows.UI.Xaml.Controls;
+
+namespace TestAppUwp
+{
+    public class VideoCaptureDeviceInfo
+    {
+        public readonly string Id;
+        public readonly string DisplayName;
+        public readonly Symbol Symbol = Symbol.Video;
+
+        public VideoCaptureDeviceInfo(string id, string displayName)
+        {
+            Id = id;
+            DisplayName = displayName;
+            if (!string.IsNullOrWhiteSpace(Id))
+            {
+                SupportsVideoProfiles = MediaCapture.IsVideoProfileSupported(Id);
+            }
+            else
+            {
+                SupportsVideoProfiles = false;
+            }
+        }
+
+        public bool SupportsVideoProfiles { get; }
+    }
+
+    public class VideoCaptureViewModel : NotifierBase
+    {
+        private CollectionViewModel<VideoCaptureDeviceInfo> _videoCaptureDevices
+            = new CollectionViewModel<VideoCaptureDeviceInfo>();
+        private CollectionViewModel<VideoCaptureFormatViewModel> _videoCaptureFormats
+            = new CollectionViewModel<VideoCaptureFormatViewModel>();
+        private bool _canCreateTrack = false;
+
+        public CollectionViewModel<VideoCaptureDeviceInfo> VideoCaptureDevices
+        {
+            get { return _videoCaptureDevices; }
+            set
+            {
+                if (SetProperty(ref _videoCaptureDevices, value))
+                {
+                    _videoCaptureDevices.SelectionChanged += VideoCaptureDevices_SelectionChanged;
+                }
+            }
+        }
+
+        public CollectionViewModel<VideoCaptureFormatViewModel> VideoCaptureFormats
+        {
+            get { return _videoCaptureFormats; }
+            set { SetProperty(ref _videoCaptureFormats, value); }
+        }
+
+        public VideoProfileKind SelectedVideoProfileKind
+        {
+            get
+            {
+                //var videoProfileKindIndex = KnownVideoProfileKindComboBox.SelectedIndex;
+                //if (videoProfileKindIndex < 0)
+                //{
+                //    return VideoProfileKind.Unspecified;
+                //}
+                //return (VideoProfileKind)Enum.GetValues(typeof(VideoProfileKind)).GetValue(videoProfileKindIndex);
+                return VideoProfileKind.Unspecified;
+            }
+        }
+
+        public CollectionViewModel<MediaCaptureVideoProfile> VideoProfiles { get; private set; }
+            = new CollectionViewModel<MediaCaptureVideoProfile>();
+
+        public CollectionViewModel<MediaCaptureVideoProfileMediaDescription> RecordMediaDescs { get; private set; }
+            = new CollectionViewModel<MediaCaptureVideoProfileMediaDescription>();
+
+        public bool CanCreateTrack
+        {
+            get { return _canCreateTrack; }
+            set { SetProperty(ref _canCreateTrack, value); }
+        }
+
+        public string ErrorMessage
+        {
+            get { return _errorMessage; }
+            set { SetProperty(ref _errorMessage, value); }
+        }
+
+        private string _errorMessage;
+
+        public async Task RefreshVideoCaptureDevicesAsync()
+        {
+            Logger.Log($"Refreshing list of video capture devices");
+
+            ErrorMessage = null;
+            try
+            {
+                await RequestMediaAccesssAsync(StreamingCaptureMode.Video);
+            }
+            catch (UnauthorizedAccessException uae)
+            {
+                ErrorMessage = "This application is not authorized to access the local camera device. Change permission settings and restart the application.";
+                throw uae;
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = ex.Message;
+                throw ex;
+            }
+
+            // Populate the list of video capture devices (webcams).
+            // On UWP this uses internally the API:
+            //   Devices.Enumeration.DeviceInformation.FindAllAsync(VideoCapture)
+            // Note that there's no API to pass a given device to WebRTC,
+            // so there's no way to monitor and update that list if a device
+            // gets plugged or unplugged. Even using DeviceInformation.CreateWatcher()
+            // would yield some devices that might become unavailable by the time
+            // WebRTC internally opens the video capture device.
+            // This is more for demo purpose here because using the UWP API is nicer.
+            var devices = await PeerConnection.GetVideoCaptureDevicesAsync();
+            var deviceList = new CollectionViewModel<VideoCaptureDeviceInfo>();
+            List<VideoCaptureDeviceInfo> vcds = new List<VideoCaptureDeviceInfo>(devices.Count);
+            foreach (var device in devices)
+            {
+                Logger.Log($"Found video capture device: id={device.id} name={device.name}");
+                deviceList.Add(new VideoCaptureDeviceInfo(id: device.id, displayName: device.name));
+            }
+            VideoCaptureDevices = deviceList;
+        }
+
+        private void VideoCaptureDevices_SelectionChanged()
+        {
+            CanCreateTrack = (VideoCaptureDevices.SelectedItem != null);
+            _ = RefreshVideoCaptureFormatsAsync(VideoCaptureDevices.SelectedItem);
+        }
+
+        public async Task RefreshVideoCaptureFormatsAsync(VideoCaptureDeviceInfo item)
+        {
+            // Device doesn't support video profiles; fall back on flat list of capture formats.
+            List<VideoCaptureFormat> formatsList = await PeerConnection.GetVideoCaptureFormatsAsync(item.Id);
+            var formats = new CollectionViewModel<VideoCaptureFormatViewModel>();
+            foreach (var format in formatsList)
+            {
+                formats.Add(new VideoCaptureFormatViewModel { Format = format });
+            }
+            VideoCaptureFormats = formats;
+        }
+
+        public async Task AddVideoTrackFromDeviceAsync(string trackName)
+        {
+            await RequestMediaAccesssAsync(StreamingCaptureMode.Video);
+
+            VideoCaptureDeviceInfo deviceInfo = VideoCaptureDevices.SelectedItem;
+            if (deviceInfo == null)
+            {
+                throw new InvalidOperationException("No video capture device selected");
+            }
+            var settings = new LocalVideoTrackSettings
+            {
+                trackName = trackName,
+                videoDevice = new VideoCaptureDevice { id = deviceInfo.Id },
+            };
+            VideoCaptureFormatViewModel formatInfo = VideoCaptureFormats.SelectedItem;
+            if (formatInfo != null)
+            {
+                settings.width = formatInfo.Format.width;
+                settings.height = formatInfo.Format.height;
+                settings.framerate = formatInfo.Format.framerate;
+            }
+            var track = await LocalVideoTrack.CreateFromDeviceAsync(settings);
+
+            SessionModel.Current.VideoTracks.Add(new VideoTrackViewModel
+            {
+                Track = track,
+                TrackImpl = track,
+                IsRemote = false,
+                DeviceName = deviceInfo.DisplayName
+            });
+            SessionModel.Current.LocalTracks.Add(new TrackViewModel(Symbol.Video) { DisplayName = deviceInfo.DisplayName });
+        }
+
+        private async Task RequestMediaAccesssAsync(StreamingCaptureMode mode)
+        {
+            // Ensure that the UWP app was authorized to capture audio (cap:microphone)
+            // or video (cap:webcam), otherwise the native plugin will fail.
+            try
+            {
+                MediaCapture mediaAccessRequester = new MediaCapture();
+                var mediaSettings = new MediaCaptureInitializationSettings
+                {
+                    AudioDeviceId = "",
+                    VideoDeviceId = "",
+                    StreamingCaptureMode = mode,
+                    PhotoCaptureSource = PhotoCaptureSource.VideoPreview
+                };
+                await mediaAccessRequester.InitializeAsync(mediaSettings);
+            }
+            catch (UnauthorizedAccessException uae)
+            {
+                Logger.Log("Access to A/V denied, check app permissions: " + uae.Message);
+                throw uae;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Failed to initialize A/V with unknown exception: " + ex.Message);
+                throw ex;
+            }
+        }
+
+
+        /// <summary>
+        /// Update the list of video profiles stored in <cref>VideoProfiles</cref>
+        /// when the selected video capture device or known video profile kind change.
+        /// </summary>
+        private async void UpdateVideoProfiles()
+        {
+            VideoProfiles.Clear();
+            VideoCaptureFormats.Clear();
+
+            //// Get the video capture device selected by the user
+            //var deviceIndex = VideoCaptureDeviceList.SelectedIndex;
+            //if (deviceIndex < 0)
+            //{
+            //    return;
+            //}
+            //var device = VideoCaptureDevices[deviceIndex];
+
+            //// Ensure that the video capture device actually supports video profiles
+            //if (MediaCapture.IsVideoProfileSupported(device.Id))
+            //{
+            //    // Get the kind of known video profile selected by the user
+            //    var videoProfileKindIndex = KnownVideoProfileKindComboBox.SelectedIndex;
+            //    if (videoProfileKindIndex < 0)
+            //    {
+            //        return;
+            //    }
+            //    var videoProfileKind = (VideoProfileKind)Enum.GetValues(typeof(VideoProfileKind)).GetValue(videoProfileKindIndex);
+
+            //    // List all video profiles for the select device (and kind, if any specified)
+            //    IReadOnlyList<MediaCaptureVideoProfile> profiles;
+            //    if (videoProfileKind == VideoProfileKind.Unspecified)
+            //    {
+            //        profiles = MediaCapture.FindAllVideoProfiles(device.Id);
+            //    }
+            //    else
+            //    {
+            //        profiles = MediaCapture.FindKnownVideoProfiles(device.Id, (KnownVideoProfile)(videoProfileKind - 1));
+            //    }
+            //    foreach (var profile in profiles)
+            //    {
+            //        VideoProfiles.Add(profile);
+            //    }
+            //    if (profiles.Any())
+            //    {
+            //        VideoProfileComboBox.SelectedIndex = 0;
+            //    }
+            //}
+            //else
+            //{
+            //    // Device doesn't support video profiles; fall back on flat list of capture formats.
+            //    List<VideoCaptureFormat> formatsList = await PeerConnection.GetVideoCaptureFormatsAsync(device.Id);
+            //    foreach (var format in formatsList)
+            //    {
+            //        VideoCaptureFormats.Add(format);
+            //    }
+
+            //    // Default to first format, so that user can start the video capture even without selecting
+            //    // explicitly a format in a different application tab.
+            //    if (formatsList.Count > 0)
+            //    {
+            //        VideoCaptureFormatList.SelectedIndex = 0;
+            //    }
+            //}
+        }
+
+        //private void VideoCaptureDeviceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        //{
+        //    // Get the video capture device selected by the user
+        //    var deviceIndex = VideoCaptureDeviceList.SelectedIndex;
+        //    if (deviceIndex < 0)
+        //    {
+        //        return;
+        //    }
+        //    var device = VideoCaptureDevices[deviceIndex];
+
+        //    // Select a default video profile kind
+        //    var values = Enum.GetValues(typeof(VideoProfileKind));
+        //    if (MediaCapture.IsVideoProfileSupported(device.Id))
+        //    {
+        //        var defaultProfile = VideoProfileKind.VideoConferencing;
+        //        var profiles = MediaCapture.FindKnownVideoProfiles(device.Id, (KnownVideoProfile)(defaultProfile - 1));
+        //        if (!profiles.Any())
+        //        {
+        //            // Fall back to VideoRecording if VideoConferencing has no profiles (e.g. HoloLens).
+        //            defaultProfile = VideoProfileKind.VideoRecording;
+        //        }
+        //        KnownVideoProfileKindComboBox.SelectedIndex = Array.IndexOf(values, defaultProfile);
+
+        //        KnownVideoProfileKindComboBox.IsEnabled = true; //< TODO - Use binding
+        //        VideoProfileComboBox.IsEnabled = true;
+        //        RecordMediaDescList.IsEnabled = true;
+        //        VideoCaptureFormatList.IsEnabled = false;
+        //    }
+        //    else
+        //    {
+        //        KnownVideoProfileKindComboBox.SelectedIndex = Array.IndexOf(values, VideoProfileKind.Unspecified);
+        //        KnownVideoProfileKindComboBox.IsEnabled = false;
+        //        VideoProfileComboBox.IsEnabled = false;
+        //        RecordMediaDescList.IsEnabled = false;
+        //        VideoCaptureFormatList.IsEnabled = true;
+        //    }
+
+        //    UpdateVideoProfiles();
+        //}
+
+        //private void KnownVideoProfileKindComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        //{
+        //    UpdateVideoProfiles();
+        //}
+
+        //private void VideoProfileComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        //{
+        //    RecordMediaDescs.Clear();
+
+        //    var profile = SelectedVideoProfile;
+        //    if (profile == null)
+        //    {
+        //        return;
+        //    }
+
+        //    foreach (var desc in profile.SupportedRecordMediaDescription)
+        //    {
+        //        RecordMediaDescs.Add(desc);
+        //    }
+        //}
+
+    }
+}

--- a/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
@@ -100,7 +100,7 @@ namespace TestAppUwp
             ErrorMessage = null;
             try
             {
-                await RequestMediaAccesssAsync(StreamingCaptureMode.Video);
+                await RequestMediaAccessAsync(StreamingCaptureMode.Video);
             }
             catch (UnauthorizedAccessException uae)
             {
@@ -153,7 +153,7 @@ namespace TestAppUwp
 
         public async Task AddVideoTrackFromDeviceAsync(string trackName)
         {
-            await RequestMediaAccesssAsync(StreamingCaptureMode.Video);
+            await RequestMediaAccessAsync(StreamingCaptureMode.Video);
 
             VideoCaptureDeviceInfo deviceInfo = VideoCaptureDevices.SelectedItem;
             if (deviceInfo == null)
@@ -184,7 +184,7 @@ namespace TestAppUwp
             SessionModel.Current.LocalTracks.Add(new TrackViewModel(Symbol.Video) { DisplayName = deviceInfo.DisplayName });
         }
 
-        private async Task RequestMediaAccesssAsync(StreamingCaptureMode mode)
+        private async Task RequestMediaAccessAsync(StreamingCaptureMode mode)
         {
             // Ensure that the UWP app was authorized to capture audio (cap:microphone)
             // or video (cap:webcam), otherwise the native plugin will fail.


### PR DESCRIPTION
Add support for multiple audio and video tracks to the TestAppUWP
sample. This change refactors the app to use MVVM in an attempt to
clarify usage of the C# API, and to separate the tracks from the
transceivers in the UI.