### PR TITLE
Only create local tracks if component is active

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime.asmdef
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime.asmdef
@@ -9,7 +9,7 @@
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [
         "Microsoft.MixedReality.WebRTC.dll"

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/PeerConnectionTests.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/PeerConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Collections;
@@ -47,12 +47,6 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             // Check the event was raised
             Assert.IsTrue(initializedEvent.Wait(millisecondsTimeout: 50000));
             Assert.IsNotNull(pc.Peer);
-        }
-
-        [UnityTest]
-        public IEnumerator RuntimeTestsWithEnumeratorPasses()
-        {
-            yield return null;
         }
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/VideoSenderTests.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/VideoSenderTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Assert.IsTrue(sender.IsCapturing);
         }
 
-        [Test(Description = "Capture can be manyally started even if not active.")]
+        [Test(Description = "Capture can be manually started even if not active.")]
         public async void CaptureStartManualInactive()
         {
             // Create the peer connections

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/VideoSenderTests.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/VideoSenderTests.cs
@@ -1,0 +1,380 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Threading;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
+{
+    public class MockVideoSender : CustomVideoSender<Argb32VideoFrameStorage>
+    {
+        protected override void OnFrameRequested(in FrameRequest request)
+        {
+            var data = new uint[16 * 16];
+            for (int k = 0; k < 256; ++k)
+            {
+                data[k] = 0xFF0000FFu;
+            }
+            unsafe
+            {
+                fixed (uint* ptr = data)
+                {
+                    var frame = new Argb32VideoFrame
+                    {
+                        data = new IntPtr(ptr),
+                        width = 16,
+                        height = 16,
+                        stride = 64
+                    };
+                    request.CompleteRequest(frame);
+                }
+            }
+        }
+    }
+
+    public class VideoSenderTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [TearDown]
+        public void Shutdown()
+        {
+            // Note - this runs before OnDisabled/OnDestroy, so will always report false positives
+            Library.ReportLiveObjects();
+        }
+
+        [Test(Description = "Capture starts automatically if AutoStartOnEnabled=true.")]
+        public void CaptureStartAuto()
+        {
+            // Create the peer connections
+            var pc_go = new GameObject("pc1");
+            pc_go.SetActive(false); // prevent auto-activation of components
+            var pc = pc_go.AddComponent<PeerConnection>();
+            pc.AutoInitializeOnStart = false;
+
+            // Batch changes manually
+            pc.AutoCreateOfferOnRenegotiationNeeded = false;
+
+            // Create the video source
+            VideoSender sender = pc_go.AddComponent<MockVideoSender>();
+            sender.AutoStartOnEnabled = true;
+            sender.TrackName = "track_name";
+            MediaLine ml = pc.AddMediaLine(MediaKind.Video);
+            ml.Sender = sender;
+
+            // Confirm the sender has no track yet because it is inactive
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+
+            // Activate the game object and the video sender component on it
+            pc_go.SetActive(true);
+
+            // Confirm the sender now has a track because it became active and AutoStartOnEnabled
+            // is true to capture started automatically.
+            Assert.IsNotNull(sender.Track);
+            Assert.IsTrue(sender.IsCapturing);
+        }
+
+        [Test(Description = "Capture doesn't start automatically if AutoStartOnEnabled=false.")]
+        public async void CaptureStartManualActive()
+        {
+            // Create the peer connections
+            var pc_go = new GameObject("pc1");
+            pc_go.SetActive(false); // prevent auto-activation of components
+            var pc = pc_go.AddComponent<PeerConnection>();
+            pc.AutoInitializeOnStart = false;
+
+            // Batch changes manually
+            pc.AutoCreateOfferOnRenegotiationNeeded = false;
+
+            // Create the video source
+            VideoSender sender = pc_go.AddComponent<MockVideoSender>();
+            sender.AutoStartOnEnabled = false;
+            sender.TrackName = "track_name";
+            MediaLine ml = pc.AddMediaLine(MediaKind.Video);
+            ml.Sender = sender;
+
+            // Confirm the sender has no track yet because it is inactive
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+
+            // Activate the game object and the video sender component on it
+            pc_go.SetActive(true);
+
+            // Confirm the sender still has no track because AutoStartOnEnabled = false
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+
+            // Manually start capture
+            await sender.StartCaptureAsync();
+            Assert.IsNotNull(sender.Track);
+            Assert.IsTrue(sender.IsCapturing);
+        }
+
+        [Test(Description = "Capture can be manyally started even if not active.")]
+        public async void CaptureStartManualInactive()
+        {
+            // Create the peer connections
+            var pc_go = new GameObject("pc1");
+            pc_go.SetActive(false); // prevent auto-activation of components
+            var pc = pc_go.AddComponent<PeerConnection>();
+            pc.AutoInitializeOnStart = false;
+
+            // Batch changes manually
+            pc.AutoCreateOfferOnRenegotiationNeeded = false;
+
+            // Create the video source
+            VideoSender sender = pc_go.AddComponent<MockVideoSender>();
+            sender.enabled = false;
+            sender.AutoStartOnEnabled = false;
+            sender.TrackName = "track_name";
+            MediaLine ml = pc.AddMediaLine(MediaKind.Video);
+            ml.Sender = sender;
+
+            // Confirm the sender has no track yet because it is inactive
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+
+            // Manually start capture even if not enabled/active
+            await sender.StartCaptureAsync();
+            Assert.IsNotNull(sender.Track);
+            Assert.IsTrue(sender.IsCapturing);
+
+            // Because the component is inactive, don't forget to manually stop capture,
+            // because the Unity lifecycle handlers like OnDestroy() are not called.
+            sender.StopCapture();
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+        }
+
+        [Test(Description = "Capture can start and stop multiple times.")]
+        public async void CaptureStartStop()
+        {
+            // Create the peer connections
+            var pc_go = new GameObject("pc1");
+            pc_go.SetActive(false); // prevent auto-activation of components
+            var pc = pc_go.AddComponent<PeerConnection>();
+            pc.AutoInitializeOnStart = false;
+
+            // Batch changes manually
+            pc.AutoCreateOfferOnRenegotiationNeeded = false;
+
+            // Create the video source
+            VideoSender sender = pc_go.AddComponent<MockVideoSender>();
+            sender.enabled = false;
+            sender.AutoStartOnEnabled = false;
+            sender.TrackName = "track_name";
+            MediaLine ml = pc.AddMediaLine(MediaKind.Video);
+            ml.Sender = sender;
+
+            // Confirm the sender has no track yet because it is inactive
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+
+            // Manually start capture
+            await sender.StartCaptureAsync();
+            Assert.IsNotNull(sender.Track);
+            Assert.IsTrue(sender.IsCapturing);
+
+            // Start capture is no-op if called twice
+            await sender.StartCaptureAsync();
+            Assert.IsNotNull(sender.Track);
+            Assert.IsTrue(sender.IsCapturing);
+
+            // Stop capture
+            sender.StopCapture();
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+
+            // Stop capture is no-op if called twice
+            sender.StopCapture();
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+
+            // Capture can restart after being stopped
+            await sender.StartCaptureAsync();
+            Assert.IsNotNull(sender.Track);
+            Assert.IsTrue(sender.IsCapturing);
+
+            // Clean-up
+            sender.StopCapture();
+            Assert.IsNull(sender.Track);
+            Assert.IsFalse(sender.IsCapturing);
+        }
+
+        // Capture starts automatically on attach if active.
+        [UnityTest]
+        public IEnumerator CaptureOnAttachStartIfActive()
+        {
+            // Create the peer connections
+            var pc1_go = new GameObject("pc1");
+            pc1_go.SetActive(false); // prevent auto-activation of components
+            var pc1 = pc1_go.AddComponent<PeerConnection>();
+            pc1.AutoInitializeOnStart = false;
+            var pc2_go = new GameObject("pc2");
+            pc2_go.SetActive(false); // prevent auto-activation of components
+            var pc2 = pc2_go.AddComponent<PeerConnection>();
+            pc2.AutoInitializeOnStart = false;
+
+            // Batch changes manually
+            pc1.AutoCreateOfferOnRenegotiationNeeded = false;
+            pc2.AutoCreateOfferOnRenegotiationNeeded = false;
+
+            // Create the signaler
+            var sig_go = new GameObject("signaler");
+            var sig = sig_go.AddComponent<LocalOnlySignaler>();
+            sig.Peer1 = pc1;
+            sig.Peer2 = pc2;
+
+            // Create the video sources on peer #1
+            VideoSender sender1 = pc1_go.AddComponent<MockVideoSender>();
+            sender1.enabled = true;
+            sender1.AutoStartOnEnabled = false;
+            sender1.TrackName = "track_name";
+            MediaLine tr1 = pc1.AddMediaLine(MediaKind.Video);
+            tr1.Sender = sender1;
+
+            // Create the video sources on peer #2
+            VideoReceiver receiver2 = pc1_go.AddComponent<VideoReceiver>();
+            MediaLine tr2 = pc2.AddMediaLine(MediaKind.Video);
+            tr2.Receiver = receiver2;
+
+            // Activate
+            pc1_go.SetActive(true);
+            pc2_go.SetActive(true);
+
+            // Initialize
+            var initializedEvent1 = new ManualResetEventSlim(initialState: false);
+            pc1.OnInitialized.AddListener(() => initializedEvent1.Set());
+            Assert.IsNull(pc1.Peer);
+            pc1.InitializeAsync().Wait(millisecondsTimeout: 50000);
+            var initializedEvent2 = new ManualResetEventSlim(initialState: false);
+            pc2.OnInitialized.AddListener(() => initializedEvent2.Set());
+            Assert.IsNull(pc2.Peer);
+            pc2.InitializeAsync().Wait(millisecondsTimeout: 50000);
+
+            // Wait a frame so that the Unity event OnInitialized can propagate
+            yield return null;
+
+            // Check the event was raised
+            Assert.IsTrue(initializedEvent1.Wait(millisecondsTimeout: 50000));
+            Assert.IsNotNull(pc1.Peer);
+            Assert.IsTrue(initializedEvent2.Wait(millisecondsTimeout: 50000));
+            Assert.IsNotNull(pc2.Peer);
+
+            // AutoStartOnEnabled = false
+            Assert.IsNull(sender1.Track);
+
+            // Confirm the receiver track is not added yet, since remote tracks are only instantiated
+            // as the result of a session negotiation.
+            Assert.IsNull(receiver2.Track);
+
+            // Connect
+            Assert.IsTrue(sig.Connect(millisecondsTimeout: 60000));
+
+            // Wait a frame so that the Unity events for streams started can propagate
+            yield return null;
+
+            // Check attached and that attaching forced the track creation on active sender
+            Assert.IsNotNull(sender1.Track);
+            Assert.IsTrue(sender1.IsCapturing);
+            Assert.IsTrue(sender1.IsStreaming);
+            Assert.IsNotNull(sender1.Transceiver);
+            Assert.IsNotNull(receiver2.Track);
+            Assert.IsTrue(receiver2.IsLive);
+            Assert.IsTrue(receiver2.IsStreaming);
+            Assert.IsNotNull(receiver2.Transceiver);
+        }
+
+        // Capture doesn't start automatically on attach if inactive.
+        [UnityTest]
+        public IEnumerator CaptureOnAttachDoNotStartIfInactive()
+        {
+            // Create the peer connections
+            var pc1_go = new GameObject("pc1");
+            pc1_go.SetActive(false); // prevent auto-activation of components
+            var pc1 = pc1_go.AddComponent<PeerConnection>();
+            pc1.AutoInitializeOnStart = false;
+            var pc2_go = new GameObject("pc2");
+            pc2_go.SetActive(false); // prevent auto-activation of components
+            var pc2 = pc2_go.AddComponent<PeerConnection>();
+            pc2.AutoInitializeOnStart = false;
+
+            // Batch changes manually
+            pc1.AutoCreateOfferOnRenegotiationNeeded = false;
+            pc2.AutoCreateOfferOnRenegotiationNeeded = false;
+
+            // Create the signaler
+            var sig_go = new GameObject("signaler");
+            var sig = sig_go.AddComponent<LocalOnlySignaler>();
+            sig.Peer1 = pc1;
+            sig.Peer2 = pc2;
+
+            // Create the video sources on peer #1
+            VideoSender sender1 = pc1_go.AddComponent<MockVideoSender>();
+            sender1.enabled = false;
+            sender1.AutoStartOnEnabled = false;
+            sender1.TrackName = "track_name";
+            MediaLine tr1 = pc1.AddMediaLine(MediaKind.Video);
+            tr1.Sender = sender1;
+
+            // Create the video sources on peer #2
+            VideoReceiver receiver2 = pc1_go.AddComponent<VideoReceiver>();
+            MediaLine tr2 = pc2.AddMediaLine(MediaKind.Video);
+            tr2.Receiver = receiver2;
+
+            // Activate
+            pc1_go.SetActive(true);
+            pc2_go.SetActive(true);
+
+            // Initialize
+            var initializedEvent1 = new ManualResetEventSlim(initialState: false);
+            pc1.OnInitialized.AddListener(() => initializedEvent1.Set());
+            Assert.IsNull(pc1.Peer);
+            pc1.InitializeAsync().Wait(millisecondsTimeout: 50000);
+            var initializedEvent2 = new ManualResetEventSlim(initialState: false);
+            pc2.OnInitialized.AddListener(() => initializedEvent2.Set());
+            Assert.IsNull(pc2.Peer);
+            pc2.InitializeAsync().Wait(millisecondsTimeout: 50000);
+
+            // Wait a frame so that the Unity event OnInitialized can propagate
+            yield return null;
+
+            // Check the event was raised
+            Assert.IsTrue(initializedEvent1.Wait(millisecondsTimeout: 50000));
+            Assert.IsNotNull(pc1.Peer);
+            Assert.IsTrue(initializedEvent2.Wait(millisecondsTimeout: 50000));
+            Assert.IsNotNull(pc2.Peer);
+
+            // AutoStartOnEnabled = false
+            Assert.IsNull(sender1.Track);
+
+            // Confirm the receiver track is not added yet, since remote tracks are only instantiated
+            // as the result of a session negotiation.
+            Assert.IsNull(receiver2.Track);
+
+            // Connect
+            Assert.IsTrue(sig.Connect(millisecondsTimeout: 60000));
+
+            // Wait a frame so that the Unity events for streams started can propagate
+            yield return null;
+
+            // Check attached but attaching did not start track because sender was inactive (disabled)
+            Assert.IsNull(sender1.Track);
+            Assert.IsFalse(sender1.IsCapturing);
+            Assert.IsFalse(sender1.IsStreaming);
+            Assert.IsNotNull(sender1.Transceiver);
+            Assert.IsNotNull(receiver2.Track);
+            Assert.IsTrue(receiver2.IsLive);
+            Assert.IsTrue(receiver2.IsStreaming);
+            Assert.IsNotNull(receiver2.Transceiver);
+        }
+    }
+}

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/VideoSenderTests.cs.meta
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/VideoSenderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d296c693cc9b4db4285f4ae8bd7b5d38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/VideoSourceTests.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime/VideoSourceTests.cs
@@ -163,11 +163,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
 
                 // Transceivers are consistent with pairing
                 Assert.IsTrue(tr1.Transceiver.NegotiatedDirection.HasValue);
-                Assert.AreEqual(hasSend1, HasSend(tr1.Transceiver.NegotiatedDirection.Value));
-                Assert.AreEqual(hasRecv1, HasRecv(tr1.Transceiver.NegotiatedDirection.Value));
+                Assert.AreEqual(hasSend1, Transceiver.HasSend(tr1.Transceiver.NegotiatedDirection.Value));
+                Assert.AreEqual(hasRecv1, Transceiver.HasRecv(tr1.Transceiver.NegotiatedDirection.Value));
                 Assert.IsTrue(tr2.Transceiver.NegotiatedDirection.HasValue);
-                Assert.AreEqual(hasSend2, HasSend(tr2.Transceiver.NegotiatedDirection.Value));
-                Assert.AreEqual(hasRecv2, HasRecv(tr2.Transceiver.NegotiatedDirection.Value));
+                Assert.AreEqual(hasSend2, Transceiver.HasSend(tr2.Transceiver.NegotiatedDirection.Value));
+                Assert.AreEqual(hasRecv2, Transceiver.HasRecv(tr2.Transceiver.NegotiatedDirection.Value));
             }
         }
 
@@ -243,16 +243,6 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             public PeerConfig peer1;
             public PeerConfig peer2;
         };
-
-        private bool HasSend(Transceiver.Direction dir)
-        {
-            return ((dir == Transceiver.Direction.SendOnly) || (dir == Transceiver.Direction.SendReceive));
-        }
-
-        private bool HasRecv(Transceiver.Direction dir)
-        {
-            return ((dir == Transceiver.Direction.ReceiveOnly) || (dir == Transceiver.Direction.SendReceive));
-        }
 
         [UnityTest]
         public IEnumerator Multi()
@@ -370,7 +360,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
                     MediaLine tr1 = pc1.AddMediaLine(MediaKind.Video);
                     var peer = cfg.peer1;
                     peer.mediaLine = tr1;
-                    if (HasSend(peer.desiredDirection))
+                    if (Transceiver.HasSend(peer.desiredDirection))
                     {
                         var sender1 = pc1_go.AddComponent<UniformColorVideoSource>();
                         sender1.AutoStartOnEnabled = true;
@@ -378,7 +368,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
                         peer.sender = sender1;
                         tr1.Sender = sender1;
                     }
-                    if (HasRecv(peer.desiredDirection))
+                    if (Transceiver.HasRecv(peer.desiredDirection))
                     {
                         var receiver1 = pc1_go.AddComponent<VideoReceiver>();
                         peer.receiver = receiver1;
@@ -390,7 +380,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
                     MediaLine tr2 = pc2.AddMediaLine(MediaKind.Video);
                     var peer = cfg.peer2;
                     peer.mediaLine = tr2;
-                    if (HasSend(peer.desiredDirection))
+                    if (Transceiver.HasSend(peer.desiredDirection))
                     {
                         var sender2 = pc2_go.AddComponent<UniformColorVideoSource>();
                         sender2.AutoStartOnEnabled = true;
@@ -398,7 +388,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
                         peer.sender = sender2;
                         tr2.Sender = sender2;
                     }
-                    if (HasRecv(peer.desiredDirection))
+                    if (Transceiver.HasRecv(peer.desiredDirection))
                     {
                         var receiver2 = pc2_go.AddComponent<VideoReceiver>();
                         peer.receiver = receiver2;

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/MediaSender.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/MediaSender.cs
@@ -33,12 +33,25 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         public string TrackName;
 
         /// <summary>
-        /// Automatically start media capture when the component is enabled.
+        /// Automatically start media capture when the component is enabled, and stop capture
+        /// when the component is disabled.
         /// 
         /// If <c>true</c>, then <see cref="StartCaptureAsync"/> is automatically called
         /// when the <see xref="UnityEngine.MonoBehaviour.OnEnabled"/> callback is invoked
-        /// by Unity.
+        /// by Unity, and conversely <see cref="StopCapture"/> is automatically called when
+        /// the <see xref="UnityEngine.MonoBehaviour.OnEnabled"/> callback is invoked by Unity.
+        /// 
+        /// If <c>false</c>, then the user has to manually call <see cref="StartCaptureAsync"/>
+        /// to start capture before the media sender is attached to a transceiver, and call
+        /// <see cref="StopCapture"/> to stop capture.
         /// </summary>
+        /// <remarks>
+        /// When the media sender is attached to a transceiver, media capture starts automatically
+        /// if the component is active and enabled, even if <see cref="AutoStartOnEnabled"/> is false.
+        /// 
+        /// To have complete manual control on capture, set both <see cref="AutoStartOnEnabled"/> and
+        /// <see xref="UnityEngine.MonoBehaviour.enabled"/> to <c>false</c>.
+        /// </remarks>
         [Tooltip("Automatically start media capture when the component is enabled")]
         [Editor.ToggleLeft]
         public bool AutoStartOnEnabled = true;
@@ -122,6 +135,18 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// <inheritdoc/>
         protected void OnDisable()
         {
+            if (AutoStartOnEnabled)
+            {
+                StopCapture();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected void OnDestroy()
+        {
+            // Note that capture can be started manually even if inactive,
+            // so force destruction when the component is destroyed to release
+            // native resources.
             StopCapture();
         }
 

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/VideoSender.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/VideoSender.cs
@@ -126,12 +126,24 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                     IsStreaming = true;
                 });
             }
+
+            // Attach the local track to the transceiver
+            if (Transceiver != null)
+            {
+                Transceiver.LocalVideoTrack = Track;
+            }
         }
 
         protected override void DestroyLocalTrack()
         {
             if (Track != null)
             {
+                // Detach the local track from the transceiver
+                if ((Transceiver != null) && (Transceiver.LocalVideoTrack == Track))
+                {
+                    Transceiver.LocalVideoTrack = null;
+                }
+
                 // Defer track destruction to derived classes.
                 DestroyLocalVideoTrack();
                 Debug.Assert(Track == null, "Implementation did not destroy the existing Track property yet did not throw any exception.", this);
@@ -177,17 +189,21 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             // so that modifications to the property done after OnPeerInitialized() are
             // accounted for.
             //< FIXME - Multi-track override!!!
-            Transceiver.PeerConnection.PreferredVideoCodec = PreferredVideoCodec;
-            Debug.LogWarning("PreferredVideoCodec is currently a per-PeerConnection setting; overriding the value for peer"
-                + $" connection '{Transceiver.PeerConnection.Name}' with track's value of '{PreferredVideoCodec}'.");
-
-            // Ensure the local sender track exists
-            if (Track == null)
+            if (!string.IsNullOrWhiteSpace(PreferredVideoCodec))
             {
-                await CreateLocalTrackAsync();
+                Transceiver.PeerConnection.PreferredVideoCodec = PreferredVideoCodec;
+                Debug.LogWarning("PreferredVideoCodec is currently a per-PeerConnection setting; overriding the value for peer"
+                    + $" connection '{Transceiver.PeerConnection.Name}' with track's value of '{PreferredVideoCodec}'.");
             }
 
-            // Attach the local track to the transceiver
+            // Ensure the local sender track exists and is ready, but do not create it
+            // if the component is not active.
+            if (isActiveAndEnabled)
+            {
+                await StartCaptureAsync();
+            }
+
+            // Attach the local track to the transceiver if any
             if (Track != null)
             {
                 Transceiver.LocalVideoTrack = Track;
@@ -197,8 +213,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         internal override void DetachTrack()
         {
             Debug.Assert(Transceiver != null);
-            Debug.Assert(Transceiver.LocalTrack == Track);
-            Transceiver.LocalVideoTrack = null;
+            if (Track != null)
+            {
+                Debug.Assert(Transceiver.LocalVideoTrack == Track);
+                Transceiver.LocalVideoTrack = null;
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Avoid creating a local audio or video track (webcam/microphone) if the
component is not active. Instead leave the Track property as NULL.