### PR TITLE
Add warning for missing per-track preferred codec

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/AudioSender.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/AudioSender.cs
@@ -196,6 +196,8 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             // accounted for.
             //< FIXME - Multi-track override!!!
             Transceiver.PeerConnection.PreferredAudioCodec = PreferredAudioCodec;
+            Debug.LogWarning("PreferredAudioCodec is currently a per-PeerConnection setting; overriding the value for peer"
+                + $" connection '{Transceiver.PeerConnection.Name}' with track's value of '{PreferredAudioCodec}'.");
 
             // Ensure the local sender track exists
             if (Track == null)

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/VideoSender.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/VideoSender.cs
@@ -173,6 +173,14 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         {
             Debug.Assert(Transceiver != null);
 
+            // Force again PreferredVideoCodec right before starting the local capture,
+            // so that modifications to the property done after OnPeerInitialized() are
+            // accounted for.
+            //< FIXME - Multi-track override!!!
+            Transceiver.PeerConnection.PreferredVideoCodec = PreferredVideoCodec;
+            Debug.LogWarning("PreferredVideoCodec is currently a per-PeerConnection setting; overriding the value for peer"
+                + $" connection '{Transceiver.PeerConnection.Name}' with track's value of '{PreferredVideoCodec}'.");
+
             // Ensure the local sender track exists
             if (Track == null)
             {


### PR DESCRIPTION
Add a warning indicating that the per-track preferred media codec is not
yet implemented, and the track value will override the peer connection's
global value.

This shall eventually be fixed, and per-track support added, but the change
is not trivial, so adding at least a warning until then and fixing parity of
audio and video tracks.