### PR TITLE
Earlier and more consistent DataChannelAdded event

### DIFF
--- a/libs/mrwebrtc/src/data_channel.cpp
+++ b/libs/mrwebrtc/src/data_channel.cpp
@@ -81,31 +81,12 @@ bool DataChannel::Send(const void* data, size_t size) noexcept {
 }
 
 void DataChannel::OnStateChange() noexcept {
-  const webrtc::DataChannelInterface::DataState state = data_channel_->state();
-  switch (state) {
-    case webrtc::DataChannelInterface::DataState::kOpen:
-      // Negotiated (out-of-band) data channels never generate an
-      // OnDataChannel() message, so simulate it for the DataChannelAdded event
-      // to be consistent.
-      if (data_channel_->negotiated()) {
-        owner_->OnDataChannelAdded(*this);
-      }
-      break;
-    case webrtc::DataChannelInterface::DataState::kClosed:
-      break;
-    case webrtc::DataChannelInterface::DataState::kClosing:
-      break;
-    case webrtc::DataChannelInterface::DataState::kConnecting:
-      break;
-  }
-
-  // Invoke the StateChanged event
-  {
-    const std::lock_guard<std::mutex> lock{mutex_};
-    if (state_callback_) {
-      auto apiState = apiStateFromRtcState(state);
-      state_callback_((int)apiState, data_channel_->id());
-    }
+  const std::lock_guard<std::mutex> lock{mutex_};
+  if (state_callback_) {
+    const webrtc::DataChannelInterface::DataState state =
+        data_channel_->state();
+    auto apiState = apiStateFromRtcState(state);
+    state_callback_((int)apiState, data_channel_->id());
   }
 }
 

--- a/libs/mrwebrtc/src/peer_connection.cpp
+++ b/libs/mrwebrtc/src/peer_connection.cpp
@@ -311,9 +311,9 @@ ErrorOr<std::shared_ptr<DataChannel>> PeerConnection::AddDataChannel(
 
     // For in-band channels, the creating side (here) doesn't receive an
     // OnDataChannel() message, so invoke the DataChannelAdded event right now.
-    if (!data_channel->impl()->negotiated()) {
-      OnDataChannelAdded(*data_channel.get());
-    }
+    // For out-of-band channels, the standard doesn't ask to raise that event,
+    // but we do it anyway for convenience and for consistency.
+    OnDataChannelAdded(*data_channel.get());
 
     return data_channel;
   }


### PR DESCRIPTION
Raise the data channel added event earlier and more consistently for
out-of-band data channels when the data channel is created and added to
the peer connnection, instead of waiting for its state to change to
open, as the latter happens asynchronously much latter. This simplifies
interop wrapper creation, and makes the codepath consistent with in-band
data channels which already raise that event inline during the call to
AddDataChannel().