### PR TITLE
Fix C# transceiver test

### DIFF
--- a/tests/Microsoft.MixedReality.WebRTC.Tests/TransceiverTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/TransceiverTests.cs
@@ -29,13 +29,15 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             suspendOffer1_ = true;
 
             // Create video transceiver on #1. This triggers a renegotiation needed event.
+            const Transceiver.Direction InitialDesiredDirection = Transceiver.Direction.SendReceive;
             var transceiver_settings = new TransceiverInitSettings
             {
                 Name = "transceiver1",
+                InitialDesiredDirection = InitialDesiredDirection
             };
             var transceiver1 = pc1_.AddTransceiver(MediaKind, transceiver_settings);
             Assert.NotNull(transceiver1);
-            Assert.AreEqual(transceiver1.DesiredDirection, Transceiver.Direction.SendReceive); // from implementation
+            Assert.AreEqual(transceiver1.DesiredDirection, InitialDesiredDirection);
             Assert.AreEqual(transceiver1.NegotiatedDirection, null);
             Assert.AreEqual(pc1_, transceiver1.PeerConnection);
             Assert.IsTrue(pc1_.Transceivers.Contains(transceiver1));
@@ -47,15 +49,17 @@ namespace Microsoft.MixedReality.WebRTC.Tests
 
             // Connect
             await DoNegotiationStartFrom(pc1_);
+            Assert.IsTrue(transceiver1.NegotiatedDirection.HasValue);
+            Assert.AreEqual(transceiver1.NegotiatedDirection.Value, Transceiver.Direction.SendOnly);
 
-            // Note: use manual list instead of Enum.GetValues() to control order, and not
-            // get Inactive first (which is the current value, so wouldn't make any change).
+            // Note: use manual list instead of Enum.GetValues() to control order and for Unified Plan
+            // control the expected negotiated direction changes or not.
             var desired = new List<Transceiver.Direction> {
-                Transceiver.Direction.SendOnly, Transceiver.Direction.SendReceive,
-                Transceiver.Direction.ReceiveOnly, Transceiver.Direction.Inactive };
+                Transceiver.Direction.SendOnly, Transceiver.Direction.ReceiveOnly,
+                Transceiver.Direction.Inactive, Transceiver.Direction.SendReceive };
             var negotiated = new List<Transceiver.Direction> {
-                Transceiver.Direction.SendOnly, Transceiver.Direction.SendOnly,
-                Transceiver.Direction.Inactive, Transceiver.Direction.Inactive };
+                Transceiver.Direction.SendOnly, Transceiver.Direction.Inactive,
+                Transceiver.Direction.Inactive, Transceiver.Direction.SendOnly };
             for (int i = 0; i < desired.Count; ++i)
             {
                 var direction = desired[i];
@@ -65,12 +69,43 @@ namespace Microsoft.MixedReality.WebRTC.Tests
                 transceiver1.DesiredDirection = direction;
                 Assert.AreEqual(transceiver1.DesiredDirection, direction);
 
-                // Wait for local SDP re-negotiation event on #1.
-                Assert.True(renegotiationEvent1_.Wait(TimeSpan.FromSeconds(10.0)));
-                renegotiationEvent1_.Reset();
+                // Check SDP semantic
+                if (sdpSemantic_ == SdpSemantic.PlanB)
+                {
+                    // Plan B always raises the event
 
-                // Renegotiate
-                await DoNegotiationStartFrom(pc1_);
+                    // Wait for local SDP re-negotiation event on #1.
+                    Assert.IsTrue(renegotiationEvent1_.Wait(TimeSpan.FromSeconds(10.0)));
+                    renegotiationEvent1_.Reset();
+
+                    // Renegotiate
+                    await DoNegotiationStartFrom(pc1_);
+                }
+                else if (sdpSemantic_ == SdpSemantic.UnifiedPlan)
+                {
+                    // Unified Plan only raises the event if this is actually useful,
+                    // that is if a renegotiation would effectively produce some change.
+
+                    // Actual expected direction is "intersection" of the desired direction with
+                    // the one the remote is actually capable of delivering. Because the remote peer
+                    // does not send, the local peer cannot expect to receive. So clear the receive
+                    // part of the desired direction to get the expected negotiated direction.
+                    Transceiver.Direction expectedDirection = Transceiver.DirectionFromSendRecv(
+                        hasSend: Transceiver.HasSend(direction), hasRecv: false);
+                    if (transceiver1.NegotiatedDirection.Value != expectedDirection)
+                    {
+                        // Wait for local SDP re-negotiation event on #1.
+                        Assert.IsTrue(renegotiationEvent1_.Wait(TimeSpan.FromSeconds(10.0)));
+                        renegotiationEvent1_.Reset();
+
+                        // Renegotiate
+                        await DoNegotiationStartFrom(pc1_);
+                    }
+                    else
+                    {
+                        Assert.IsFalse(renegotiationEvent1_.IsSet);
+                    }
+                }
 
                 // Observe the new negotiated direction
                 Assert.AreEqual(transceiver1.DesiredDirection, direction);


### PR DESCRIPTION
Fix C# transceiver test for SetDirection to match the actual cases the renegotiation needed event is raised, as described in the standard.