### PR TITLE
Fix release pipeline with component detection

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4,7 +4,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://chromium.googlesource.com/external/webrtc", 
-         "commitHash": "baa89682df1ab891ae274a1cb2d9be3b1ee7e20b" 
+         "commitHash": "0680f27b996a4bc68c200a581ff12ba52669f2fa" 
          }
        }
     },
@@ -13,7 +13,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/webrtc-uwp-sdk", 
-         "commitHash": "c6fdf8c33637b7f1e07aa2b5b0fe375dbcbbb088" 
+         "commitHash": "13ebaf1c2cd33e026433d467593753cf8655722c" 
          }
        }
     },
@@ -31,16 +31,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/PeerCC", 
-         "commitHash": "693ec8637846ef23f3a26a397d20d1beffe2683b" 
-         }
-       }
-    },
-    {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/webrtc-uwp/webrtc-uwp.github.io", 
-         "commitHash": "1b0f4576f9c8896f25cd367298ef30b877ac910f" 
+         "commitHash": "2db07b2ddfa7e85d6ad250a1caa149537d3f3fbc" 
          }
        }
     },
@@ -49,7 +40,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/webrtc-scripts", 
-         "commitHash": "3f2eb87b1baa3f49c6341d144e0b3c3be11c78ae" 
+         "commitHash": "66c7bce1e6413c19c7c24a68848e14cad3a0d5af" 
          }
        }
     },
@@ -76,7 +67,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/webrtc-windows", 
-         "commitHash": "1bb3fea09316ac8d087fe7b009686ca374dde9c9" 
+         "commitHash": "33cd625d8aa57b88d2fb67ca34c1941dbaaaeee0" 
          }
        }
     },
@@ -112,7 +103,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/chromium-build", 
-         "commitHash": "ce61deb53143460c96b3ee2750f536114293dde5" 
+         "commitHash": "495bba670b418b77b2b58d0c14f15b34c5c58458" 
          }
        }
     },
@@ -247,7 +238,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/libvpx", 
-         "commitHash": "04ce135db1823c8eaf3491e65aa43df7b35b6b96" 
+         "commitHash": "c41a69ccf2e5812ed4ef78a1614e3670dcc8e573" 
          }
        }
     },
@@ -256,7 +247,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/libyuv", 
-         "commitHash": "f1e39df1a6ffc965a1743622632cc79e9f927286" 
+         "commitHash": "bdff617d430cfd05d857595a044ed00f9eeaa7eb" 
          }
        }
     },
@@ -319,7 +310,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/webrtc", 
-         "commitHash": "baa89682df1ab891ae274a1cb2d9be3b1ee7e20b" 
+         "commitHash": "0680f27b996a4bc68c200a581ff12ba52669f2fa" 
          }
        }
     },
@@ -328,7 +319,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/webrtc-apis", 
-         "commitHash": "0d303d62f7e6483cf4b57c24ef295c487b0c28dd" 
+         "commitHash": "659f09a61d8ba8885221379722b361c7eddf7be5" 
          }
        }
     },
@@ -364,7 +355,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/zsLib", 
-         "commitHash": "86ca02ff3effa26eaf4cbe3783fe79b00a5fd217" 
+         "commitHash": "f65d364639b3da032c392d5f4c7cdd4573e419e9" 
          }
        }
     },
@@ -373,7 +364,7 @@
        "type": "git", 
        "git": { 
          "repositoryUrl": "https://github.com/webrtc-uwp/zsLib-eventing", 
-         "commitHash": "9d4abb9779508aabdaf9867c938b82e9040abd0f" 
+         "commitHash": "308cbc319cfea35e9d91b4b3907e8805df5853ec" 
          }
        }
     }

--- a/tools/ci/release-core-nosign.yaml
+++ b/tools/ci/release-core-nosign.yaml
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See LICENSE in the project root for license information.
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 # MixedReality-WebRTC build pipeline for Release
 # Build the core WebRTC implementation and the UWP wrappers
@@ -21,64 +21,64 @@ stages:
 - stage: build
   displayName: Build Core WebRTC
   jobs:
-  # - template: templates/jobs-libwebrtc-win32.yaml
-  #   parameters:
-  #     buildAgent: $(BuildAgent)
-  #     buildArch: 'x86'
-  #     buildConfig: 'Debug'
-  # - template: templates/jobs-libwebrtc-win32.yaml
-  #   parameters:
-  #     buildAgent: $(BuildAgent)
-  #     buildArch: 'x64'
-  #     buildConfig: 'Debug'
-  # - template: templates/jobs-libwebrtc-uwp.yaml
-  #   parameters:
-  #     buildAgent: $(BuildAgent)
-  #     buildArch: 'x86'
-  #     buildConfig: 'Debug'
-  #     publishWinRtHeaders: true # Randomly selected, any UWP build will do
+  - template: templates/jobs-libwebrtc-win32.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'x86'
+      buildConfig: 'Debug'
+  - template: templates/jobs-libwebrtc-win32.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'x64'
+      buildConfig: 'Debug'
+  - template: templates/jobs-libwebrtc-uwp.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'x86'
+      buildConfig: 'Debug'
+      publishWinRtHeaders: true # Randomly selected, any UWP build will do
   - template: templates/jobs-libwebrtc-uwp.yaml
     parameters:
       buildAgent: $(BuildAgent)
       buildArch: 'x64'
       buildConfig: 'Debug'
+  - template: templates/jobs-libwebrtc-uwp.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'ARM'
+      buildConfig: 'Debug'
   # - template: templates/jobs-libwebrtc-uwp.yaml
   #   parameters:
   #     buildAgent: $(BuildAgent)
-  #     buildArch: 'ARM'
+  #     buildArch: 'ARM64'
   #     buildConfig: 'Debug'
-  # # - template: templates/jobs-libwebrtc-uwp.yaml
-  # #   parameters:
-  # #     buildAgent: $(BuildAgent)
-  # #     buildArch: 'ARM64'
-  # #     buildConfig: 'Debug'
-  # - template: templates/jobs-libwebrtc-win32.yaml
-  #   parameters:
-  #     buildAgent: $(BuildAgent)
-  #     buildArch: 'x86'
-  #     buildConfig: 'Release'
-  # - template: templates/jobs-libwebrtc-win32.yaml
-  #   parameters:
-  #     buildAgent: $(BuildAgent)
-  #     buildArch: 'x64'
-  #     buildConfig: 'Release'
+  - template: templates/jobs-libwebrtc-win32.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'x86'
+      buildConfig: 'Release'
+  - template: templates/jobs-libwebrtc-win32.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'x64'
+      buildConfig: 'Release'
+  - template: templates/jobs-libwebrtc-uwp.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'x86'
+      buildConfig: 'Release'
+  - template: templates/jobs-libwebrtc-uwp.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'x64'
+      buildConfig: 'Release'
+  - template: templates/jobs-libwebrtc-uwp.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'ARM'
+      buildConfig: 'Release'
   # - template: templates/jobs-libwebrtc-uwp.yaml
   #   parameters:
   #     buildAgent: $(BuildAgent)
-  #     buildArch: 'x86'
+  #     buildArch: 'ARM64'
   #     buildConfig: 'Release'
-  # - template: templates/jobs-libwebrtc-uwp.yaml
-  #   parameters:
-  #     buildAgent: $(BuildAgent)
-  #     buildArch: 'x64'
-  #     buildConfig: 'Release'
-  # - template: templates/jobs-libwebrtc-uwp.yaml
-  #   parameters:
-  #     buildAgent: $(BuildAgent)
-  #     buildArch: 'ARM'
-  #     buildConfig: 'Release'
-  # # - template: templates/jobs-libwebrtc-uwp.yaml
-  # #   parameters:
-  # #     buildAgent: $(BuildAgent)
-  # #     buildArch: 'ARM64'
-  # #     buildConfig: 'Release'

--- a/tools/ci/release-core-nosign.yaml
+++ b/tools/ci/release-core-nosign.yaml
@@ -21,64 +21,64 @@ stages:
 - stage: build
   displayName: Build Core WebRTC
   jobs:
-  - template: templates/jobs-libwebrtc-win32.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'x86'
-      buildConfig: 'Debug'
-  - template: templates/jobs-libwebrtc-win32.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'x64'
-      buildConfig: 'Debug'
-  - template: templates/jobs-libwebrtc-uwp.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'x86'
-      buildConfig: 'Debug'
-      publishWinRtHeaders: true # Randomly selected, any UWP build will do
-  - template: templates/jobs-libwebrtc-uwp.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'x64'
-      buildConfig: 'Debug'
-  - template: templates/jobs-libwebrtc-uwp.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'ARM'
-      buildConfig: 'Debug'
-  # - template: templates/jobs-libwebrtc-uwp.yaml
+  # - template: templates/jobs-libwebrtc-win32.yaml
   #   parameters:
   #     buildAgent: $(BuildAgent)
-  #     buildArch: 'ARM64'
+  #     buildArch: 'x86'
   #     buildConfig: 'Debug'
-  - template: templates/jobs-libwebrtc-win32.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'x86'
-      buildConfig: 'Release'
+  # - template: templates/jobs-libwebrtc-win32.yaml
+  #   parameters:
+  #     buildAgent: $(BuildAgent)
+  #     buildArch: 'x64'
+  #     buildConfig: 'Debug'
+  # - template: templates/jobs-libwebrtc-uwp.yaml
+  #   parameters:
+  #     buildAgent: $(BuildAgent)
+  #     buildArch: 'x86'
+  #     buildConfig: 'Debug'
+  #     publishWinRtHeaders: true # Randomly selected, any UWP build will do
+  # - template: templates/jobs-libwebrtc-uwp.yaml
+  #   parameters:
+  #     buildAgent: $(BuildAgent)
+  #     buildArch: 'x64'
+  #     buildConfig: 'Debug'
+  # - template: templates/jobs-libwebrtc-uwp.yaml
+  #   parameters:
+  #     buildAgent: $(BuildAgent)
+  #     buildArch: 'ARM'
+  #     buildConfig: 'Debug'
+  # # - template: templates/jobs-libwebrtc-uwp.yaml
+  # #   parameters:
+  # #     buildAgent: $(BuildAgent)
+  # #     buildArch: 'ARM64'
+  # #     buildConfig: 'Debug'
+  # - template: templates/jobs-libwebrtc-win32.yaml
+  #   parameters:
+  #     buildAgent: $(BuildAgent)
+  #     buildArch: 'x86'
+  #     buildConfig: 'Release'
   - template: templates/jobs-libwebrtc-win32.yaml
     parameters:
       buildAgent: $(BuildAgent)
       buildArch: 'x64'
-      buildConfig: 'Release'
-  - template: templates/jobs-libwebrtc-uwp.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'x86'
-      buildConfig: 'Release'
-  - template: templates/jobs-libwebrtc-uwp.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'x64'
-      buildConfig: 'Release'
-  - template: templates/jobs-libwebrtc-uwp.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'ARM'
       buildConfig: 'Release'
   # - template: templates/jobs-libwebrtc-uwp.yaml
   #   parameters:
   #     buildAgent: $(BuildAgent)
-  #     buildArch: 'ARM64'
+  #     buildArch: 'x86'
   #     buildConfig: 'Release'
+  # - template: templates/jobs-libwebrtc-uwp.yaml
+  #   parameters:
+  #     buildAgent: $(BuildAgent)
+  #     buildArch: 'x64'
+  #     buildConfig: 'Release'
+  # - template: templates/jobs-libwebrtc-uwp.yaml
+  #   parameters:
+  #     buildAgent: $(BuildAgent)
+  #     buildArch: 'ARM'
+  #     buildConfig: 'Release'
+  # # - template: templates/jobs-libwebrtc-uwp.yaml
+  # #   parameters:
+  # #     buildAgent: $(BuildAgent)
+  # #     buildArch: 'ARM64'
+  # #     buildConfig: 'Release'

--- a/tools/ci/release-core-nosign.yaml
+++ b/tools/ci/release-core-nosign.yaml
@@ -37,11 +37,11 @@ stages:
   #     buildArch: 'x86'
   #     buildConfig: 'Debug'
   #     publishWinRtHeaders: true # Randomly selected, any UWP build will do
-  # - template: templates/jobs-libwebrtc-uwp.yaml
-  #   parameters:
-  #     buildAgent: $(BuildAgent)
-  #     buildArch: 'x64'
-  #     buildConfig: 'Debug'
+  - template: templates/jobs-libwebrtc-uwp.yaml
+    parameters:
+      buildAgent: $(BuildAgent)
+      buildArch: 'x64'
+      buildConfig: 'Debug'
   # - template: templates/jobs-libwebrtc-uwp.yaml
   #   parameters:
   #     buildAgent: $(BuildAgent)
@@ -57,11 +57,11 @@ stages:
   #     buildAgent: $(BuildAgent)
   #     buildArch: 'x86'
   #     buildConfig: 'Release'
-  - template: templates/jobs-libwebrtc-win32.yaml
-    parameters:
-      buildAgent: $(BuildAgent)
-      buildArch: 'x64'
-      buildConfig: 'Release'
+  # - template: templates/jobs-libwebrtc-win32.yaml
+  #   parameters:
+  #     buildAgent: $(BuildAgent)
+  #     buildArch: 'x64'
+  #     buildConfig: 'Release'
   # - template: templates/jobs-libwebrtc-uwp.yaml
   #   parameters:
   #     buildAgent: $(BuildAgent)

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -23,9 +23,16 @@ jobs:
     buildTriple: UWP-${{parameters.buildArch}}-${{parameters.buildConfig}}
     projectRoot: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/'
   steps:
+
+  # Checkout
   - checkout: self
     submodules: recursive
     clean: $(clean.git)
+  - powershell: |
+      Write-Host "Deleting gsutil from depot_tools before building"
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
+    env:
+      SDK_ROOT: 'external/webrtc-uwp-sdk'
 
   # Compute the PDB package variables
   - task: PowerShell@2

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -84,13 +84,13 @@ jobs:
   # Clean-up unused files
   - powershell: |
       Write-Host "Deleting gsutil from depot_tools"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse -ErrorAction Ignore | Out-Null
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil") -Force -Recurse -ErrorAction Ignore | Out-Null
       Write-Host "Deleting chromium/third_party/protobuf"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/third_party/protobuf" -Resolve) -Force -Recurse -ErrorAction Ignore | Out-Null
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/third_party/protobuf") -Force -Recurse -ErrorAction Ignore | Out-Null
       Write-Host "Deleting chromium/tools/android"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/android" -Resolve) -Force -Recurse -ErrorAction Ignore | Out-Null
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/android") -Force -Recurse -ErrorAction Ignore | Out-Null
       Write-Host "Deleting chromium/tools/code_coverage"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/code_coverage" -Resolve) -Force -Recurse -ErrorAction Ignore | Out-Null
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/code_coverage") -Force -Recurse -ErrorAction Ignore | Out-Null
     displayName: 'Clean-up unused files'
     env:
       SDK_ROOT: 'external/webrtc-uwp-sdk'

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -84,7 +84,7 @@ jobs:
   # Clean-up unused files
   - script: |
       del /F /S /Q "depot_tools/external_bin/gsutil"
-      del /F /S /Q "chromium/third_party/protobuf"
+      del /F /S /Q "chromium/third_party/protobuf/java"
       del /F /S /Q "chromium/tools/android"
       del /F /S /Q "chromium/tools/code_coverage"
     workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -18,7 +18,7 @@ jobs:
     name: ${{parameters.buildAgent}}
     demands:
     - msbuild
-    - mr_webrtc_core
+    #- mr_webrtc_core
   variables:
     buildTriple: UWP-${{parameters.buildArch}}-${{parameters.buildConfig}}
     projectRoot: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/'

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -83,8 +83,14 @@ jobs:
 
   # Clean-up unused files
   - powershell: |
-      Write-Host "Deleting gsutil from depot_tools before building"
+      Write-Host "Deleting gsutil from depot_tools"
       Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
+      Write-Host "Deleting chromium/third_party/protobuf"
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/third_party/protobuf" -Resolve) -Force -Recurse | Out-Null
+      Write-Host "Deleting chromium/tools/android"
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/android" -Resolve) -Force -Recurse | Out-Null
+      Write-Host "Deleting chromium/tools/code_coverage"
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/code_coverage" -Resolve) -Force -Recurse | Out-Null
     displayName: 'Clean-up unused files'
     env:
       SDK_ROOT: 'external/webrtc-uwp-sdk'

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -117,73 +117,73 @@ jobs:
       configuration: ${{parameters.buildConfig}}
     timeoutInMinutes: 180
 
-  # Publish webrtc.lib as pipeline artifacts (limited retention)
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish webrtc.lib ($(buildTriple))'
-    inputs:
-      artifactName: 'libwebrtc_$(buildTriple)'
-      targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/webrtc.lib'
-    timeoutInMinutes: 15
-
-  # # Publish PDBs for webrtc.lib as pipeline artifacts (limited retention)
+  # # Publish webrtc.lib as pipeline artifacts (limited retention)
   # - task: PublishPipelineArtifact@0
-  #   displayName: 'Publish PDBs for webrtc.lib ($(buildTriple))'
+  #   displayName: 'Publish webrtc.lib ($(buildTriple))'
   #   inputs:
-  #     artifactName: 'libwebrtc_pdbs_$(buildTriple)'
-  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/pdbs'
+  #     artifactName: 'libwebrtc_$(buildTriple)'
+  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/webrtc.lib'
   #   timeoutInMinutes: 15
 
-  # Publish Org.WebRtc.dll and associated (PDB, ...)
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish WinRT wrappers ($(buildTriple))'
-    inputs:
-      artifactName: 'orgwebrtc_$(buildTriple)'
-      targetPath: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.Universal/Build/Output/Org.WebRtc/${{parameters.buildConfig}}/${{parameters.buildArch}}'
-    timeoutInMinutes: 15
+  # # # Publish PDBs for webrtc.lib as pipeline artifacts (limited retention)
+  # # - task: PublishPipelineArtifact@0
+  # #   displayName: 'Publish PDBs for webrtc.lib ($(buildTriple))'
+  # #   inputs:
+  # #     artifactName: 'libwebrtc_pdbs_$(buildTriple)'
+  # #     targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/pdbs'
+  # #   timeoutInMinutes: 15
 
-  # Publish Org.WebRtc generated headers
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish WinRT generated headers ($(buildTriple))'
-    condition: eq('${{parameters.publishWinRtHeaders}}', 'true')
-    inputs:
-      artifactName: 'orgwebrtc_headers'
-      targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/sdk/windows/wrapper'
-    timeoutInMinutes: 15
+  # # Publish Org.WebRtc.dll and associated (PDB, ...)
+  # - task: PublishPipelineArtifact@0
+  #   displayName: 'Publish WinRT wrappers ($(buildTriple))'
+  #   inputs:
+  #     artifactName: 'orgwebrtc_$(buildTriple)'
+  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.Universal/Build/Output/Org.WebRtc/${{parameters.buildConfig}}/${{parameters.buildArch}}'
+  #   timeoutInMinutes: 15
 
-  # Publish Org.WebRtc.WrapperGlue.lib and associated (PDB, ...)
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish WinRT glue wrappers ($(buildTriple))'
-    inputs:
-      artifactName: 'orgwebrtc_glue_$(buildTriple)'
-      targetPath: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Build/Output/Org.WebRtc.WrapperGlue/${{parameters.buildConfig}}/${{parameters.buildArch}}'
-    timeoutInMinutes: 15
+  # # Publish Org.WebRtc generated headers
+  # - task: PublishPipelineArtifact@0
+  #   displayName: 'Publish WinRT generated headers ($(buildTriple))'
+  #   condition: eq('${{parameters.publishWinRtHeaders}}', 'true')
+  #   inputs:
+  #     artifactName: 'orgwebrtc_headers'
+  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/sdk/windows/wrapper'
+  #   timeoutInMinutes: 15
 
-  # Copy all PDBs to a single directory for package publishing
-  - task: PowerShell@2
-    displayName: Copy PDBs for packaging
-    inputs:
-      targetType: filePath
-      filePath: tools/ci/copyPdbsForPackaging.ps1
-      arguments: '-WithUwpWrapper -CorePath "external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/pdbs" -WrapperPath "external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.Universal/Build/Output/Org.WebRtc/${{parameters.buildConfig}}/${{parameters.buildArch}}" -WrapperGluePath "external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Build/Output/Org.WebRtc.WrapperGlue/${{parameters.buildConfig}}/${{parameters.buildArch}}" -OutputPath $(Build.ArtifactStagingDirectory)/pdbs -BuildConfig ${{parameters.buildConfig}}'
+  # # Publish Org.WebRtc.WrapperGlue.lib and associated (PDB, ...)
+  # - task: PublishPipelineArtifact@0
+  #   displayName: 'Publish WinRT glue wrappers ($(buildTriple))'
+  #   inputs:
+  #     artifactName: 'orgwebrtc_glue_$(buildTriple)'
+  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Build/Output/Org.WebRtc.WrapperGlue/${{parameters.buildConfig}}/${{parameters.buildArch}}'
+  #   timeoutInMinutes: 15
 
-  # List content of PDB packaging folder
-  - powershell: |
-        foreach ($f in $(Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/pdbs -Recurse))
-        {
-          Write-Host $f.FullName
-        }
-    displayName: 'List PDBs to package'
-    timeoutInMinutes: 5
+  # # Copy all PDBs to a single directory for package publishing
+  # - task: PowerShell@2
+  #   displayName: Copy PDBs for packaging
+  #   inputs:
+  #     targetType: filePath
+  #     filePath: tools/ci/copyPdbsForPackaging.ps1
+  #     arguments: '-WithUwpWrapper -CorePath "external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/pdbs" -WrapperPath "external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.Universal/Build/Output/Org.WebRtc/${{parameters.buildConfig}}/${{parameters.buildArch}}" -WrapperGluePath "external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Build/Output/Org.WebRtc.WrapperGlue/${{parameters.buildConfig}}/${{parameters.buildArch}}" -OutputPath $(Build.ArtifactStagingDirectory)/pdbs -BuildConfig ${{parameters.buildConfig}}'
 
-  # Publish PDBs for webrtc.lib as Universal Package (unlimited retention)
-  - task: UniversalPackages@0
-    displayName: 'Publish PDBs for webrtc.lib ($(buildTriple))'
-    inputs:
-      command: publish
-      publishDirectory: '$(Build.ArtifactStagingDirectory)/pdbs'
-      vstsFeedPublish: $(MRWebRTC_PdbFeed)
-      vstsFeedPackagePublish: $(MRWebRTC_PdbPackageName)
-      versionOption: custom
-      versionPublish: $(MRWebRTC_PdbPackageVersion)
-      packagePublishDescription: 'PDBs for MixedReality-WebRTC core (webrtc.lib) $(buildTriple)'
-    timeoutInMinutes: 30
+  # # List content of PDB packaging folder
+  # - powershell: |
+  #       foreach ($f in $(Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/pdbs -Recurse))
+  #       {
+  #         Write-Host $f.FullName
+  #       }
+  #   displayName: 'List PDBs to package'
+  #   timeoutInMinutes: 5
+
+  # # Publish PDBs for webrtc.lib as Universal Package (unlimited retention)
+  # - task: UniversalPackages@0
+  #   displayName: 'Publish PDBs for webrtc.lib ($(buildTriple))'
+  #   inputs:
+  #     command: publish
+  #     publishDirectory: '$(Build.ArtifactStagingDirectory)/pdbs'
+  #     vstsFeedPublish: $(MRWebRTC_PdbFeed)
+  #     vstsFeedPackagePublish: $(MRWebRTC_PdbPackageName)
+  #     versionOption: custom
+  #     versionPublish: $(MRWebRTC_PdbPackageVersion)
+  #     packagePublishDescription: 'PDBs for MixedReality-WebRTC core (webrtc.lib) $(buildTriple)'
+  #   timeoutInMinutes: 30

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -82,18 +82,25 @@ jobs:
       failOnStderr: false
 
   # Clean-up unused files
-  - powershell: |
-      Write-Host "Deleting gsutil from depot_tools"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil") -Force -Recurse -ErrorAction Ignore | Out-Null
-      Write-Host "Deleting chromium/third_party/protobuf"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/third_party/protobuf") -Force -Recurse -ErrorAction Ignore | Out-Null
-      Write-Host "Deleting chromium/tools/android"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/android") -Force -Recurse -ErrorAction Ignore | Out-Null
-      Write-Host "Deleting chromium/tools/code_coverage"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/code_coverage") -Force -Recurse -ErrorAction Ignore | Out-Null
+  - script: |
+      del /F /S /Q "depot_tools/external_bin/gsutil"
+      del /F /S /Q "chromium/third_party/protobuf"
+      del /F /S /Q "chromium/tools/android"
+      del /F /S /Q "chromium/tools/code_coverage"
+    workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'
     displayName: 'Clean-up unused files'
-    env:
-      SDK_ROOT: 'external/webrtc-uwp-sdk'
+  # - powershell: |
+  #     Write-Host "Deleting gsutil from depot_tools"
+  #     Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil") -Force -Recurse -ErrorAction Ignore | Out-Null
+  #     Write-Host "Deleting chromium/third_party/protobuf"
+  #     Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/third_party/protobuf") -Force -Recurse -ErrorAction Ignore | Out-Null
+  #     Write-Host "Deleting chromium/tools/android"
+  #     Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/android") -Force -Recurse -ErrorAction Ignore | Out-Null
+  #     Write-Host "Deleting chromium/tools/code_coverage"
+  #     Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/code_coverage") -Force -Recurse -ErrorAction Ignore | Out-Null
+  #   displayName: 'Clean-up unused files'
+  #   env:
+  #     SDK_ROOT: 'external/webrtc-uwp-sdk'
 
   # Run component detection
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -84,13 +84,13 @@ jobs:
   # Clean-up unused files
   - powershell: |
       Write-Host "Deleting gsutil from depot_tools"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse -ErrorAction Ignore | Out-Null
       Write-Host "Deleting chromium/third_party/protobuf"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/third_party/protobuf" -Resolve) -Force -Recurse | Out-Null
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/third_party/protobuf" -Resolve) -Force -Recurse -ErrorAction Ignore | Out-Null
       Write-Host "Deleting chromium/tools/android"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/android" -Resolve) -Force -Recurse | Out-Null
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/android" -Resolve) -Force -Recurse -ErrorAction Ignore | Out-Null
       Write-Host "Deleting chromium/tools/code_coverage"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/code_coverage" -Resolve) -Force -Recurse | Out-Null
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/code_coverage" -Resolve) -Force -Recurse -ErrorAction Ignore | Out-Null
     displayName: 'Clean-up unused files'
     env:
       SDK_ROOT: 'external/webrtc-uwp-sdk'

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -84,23 +84,10 @@ jobs:
   # Clean-up unused files
   - script: |
       del /F /S /Q "depot_tools/external_bin/gsutil"
-      del /F /S /Q "chromium/third_party/protobuf"
       del /F /S /Q "chromium/tools/android"
       del /F /S /Q "chromium/tools/code_coverage"
     workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'
     displayName: 'Clean-up unused files'
-  # - powershell: |
-  #     Write-Host "Deleting gsutil from depot_tools"
-  #     Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil") -Force -Recurse -ErrorAction Ignore | Out-Null
-  #     Write-Host "Deleting chromium/third_party/protobuf"
-  #     Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/third_party/protobuf") -Force -Recurse -ErrorAction Ignore | Out-Null
-  #     Write-Host "Deleting chromium/tools/android"
-  #     Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/android") -Force -Recurse -ErrorAction Ignore | Out-Null
-  #     Write-Host "Deleting chromium/tools/code_coverage"
-  #     Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/chromium/tools/code_coverage") -Force -Recurse -ErrorAction Ignore | Out-Null
-  #   displayName: 'Clean-up unused files'
-  #   env:
-  #     SDK_ROOT: 'external/webrtc-uwp-sdk'
 
   # Run component detection
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -86,7 +86,7 @@ jobs:
   # Run component detection
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
-    inputs:
+    #inputs:
       #scanType: 'LogOnly'
       #sourceScanPath: '$(sourcesRoot)'
 

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -84,6 +84,7 @@ jobs:
   # Clean-up unused files
   - script: |
       del /F /S /Q "depot_tools/external_bin/gsutil"
+      del /F /S /Q "chromium/third_party/protobuf"
       del /F /S /Q "chromium/tools/android"
       del /F /S /Q "chromium/tools/code_coverage"
     workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -24,6 +24,12 @@ jobs:
     projectRoot: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/'
   steps:
 
+  # Install Python 2.7.17 and select as default
+  - template: 'steps-install-python2x.yaml'
+    parameters:
+      tempFolder: '$(Build.BinariesDirectory)\py27'
+      pythonVersion: '2.7.17'
+
   # Checkout
   - checkout: self
     submodules: recursive

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See LICENSE in the project root for license information.
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 # [TEMPLATE] Compile WebRTC Core and UWP wrappers for UWP platform
 
@@ -18,7 +18,6 @@ jobs:
     name: ${{parameters.buildAgent}}
     demands:
     - msbuild
-    #- mr_webrtc_core
   variables:
     buildTriple: UWP-${{parameters.buildArch}}-${{parameters.buildConfig}}
     projectRoot: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/'
@@ -118,73 +117,72 @@ jobs:
       configuration: ${{parameters.buildConfig}}
     timeoutInMinutes: 180
 
-  # # Publish webrtc.lib as pipeline artifacts (limited retention)
+  # Publish webrtc.lib as pipeline artifacts (limited retention)
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish webrtc.lib ($(buildTriple))'
+    inputs:
+      artifactName: 'libwebrtc_$(buildTriple)'
+      targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/webrtc.lib'
+    timeoutInMinutes: 15
+
+  # # Publish PDBs for webrtc.lib as pipeline artifacts (limited retention)
   # - task: PublishPipelineArtifact@0
-  #   displayName: 'Publish webrtc.lib ($(buildTriple))'
-  #   inputs:
-  #     artifactName: 'libwebrtc_$(buildTriple)'
-  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/webrtc.lib'
-  #   timeoutInMinutes: 15
-
-  # # # Publish PDBs for webrtc.lib as pipeline artifacts (limited retention)
-  # # - task: PublishPipelineArtifact@0
-  # #   displayName: 'Publish PDBs for webrtc.lib ($(buildTriple))'
-  # #   inputs:
-  # #     artifactName: 'libwebrtc_pdbs_$(buildTriple)'
-  # #     targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/pdbs'
-  # #   timeoutInMinutes: 15
-
-  # # Publish Org.WebRtc.dll and associated (PDB, ...)
-  # - task: PublishPipelineArtifact@0
-  #   displayName: 'Publish WinRT wrappers ($(buildTriple))'
-  #   inputs:
-  #     artifactName: 'orgwebrtc_$(buildTriple)'
-  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.Universal/Build/Output/Org.WebRtc/${{parameters.buildConfig}}/${{parameters.buildArch}}'
-  #   timeoutInMinutes: 15
-
-  # # Publish Org.WebRtc generated headers
-  # - task: PublishPipelineArtifact@0
-  #   displayName: 'Publish WinRT generated headers ($(buildTriple))'
-  #   condition: eq('${{parameters.publishWinRtHeaders}}', 'true')
-  #   inputs:
-  #     artifactName: 'orgwebrtc_headers'
-  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/sdk/windows/wrapper'
-  #   timeoutInMinutes: 15
-
-  # # Publish Org.WebRtc.WrapperGlue.lib and associated (PDB, ...)
-  # - task: PublishPipelineArtifact@0
-  #   displayName: 'Publish WinRT glue wrappers ($(buildTriple))'
-  #   inputs:
-  #     artifactName: 'orgwebrtc_glue_$(buildTriple)'
-  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Build/Output/Org.WebRtc.WrapperGlue/${{parameters.buildConfig}}/${{parameters.buildArch}}'
-  #   timeoutInMinutes: 15
-
-  # # Copy all PDBs to a single directory for package publishing
-  # - task: PowerShell@2
-  #   displayName: Copy PDBs for packaging
-  #   inputs:
-  #     targetType: filePath
-  #     filePath: tools/ci/copyPdbsForPackaging.ps1
-  #     arguments: '-WithUwpWrapper -CorePath "external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/pdbs" -WrapperPath "external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.Universal/Build/Output/Org.WebRtc/${{parameters.buildConfig}}/${{parameters.buildArch}}" -WrapperGluePath "external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Build/Output/Org.WebRtc.WrapperGlue/${{parameters.buildConfig}}/${{parameters.buildArch}}" -OutputPath $(Build.ArtifactStagingDirectory)/pdbs -BuildConfig ${{parameters.buildConfig}}'
-
-  # # List content of PDB packaging folder
-  # - powershell: |
-  #       foreach ($f in $(Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/pdbs -Recurse))
-  #       {
-  #         Write-Host $f.FullName
-  #       }
-  #   displayName: 'List PDBs to package'
-  #   timeoutInMinutes: 5
-
-  # # Publish PDBs for webrtc.lib as Universal Package (unlimited retention)
-  # - task: UniversalPackages@0
   #   displayName: 'Publish PDBs for webrtc.lib ($(buildTriple))'
   #   inputs:
-  #     command: publish
-  #     publishDirectory: '$(Build.ArtifactStagingDirectory)/pdbs'
-  #     vstsFeedPublish: $(MRWebRTC_PdbFeed)
-  #     vstsFeedPackagePublish: $(MRWebRTC_PdbPackageName)
-  #     versionOption: custom
-  #     versionPublish: $(MRWebRTC_PdbPackageVersion)
-  #     packagePublishDescription: 'PDBs for MixedReality-WebRTC core (webrtc.lib) $(buildTriple)'
-  #   timeoutInMinutes: 30
+  #     artifactName: 'libwebrtc_pdbs_$(buildTriple)'
+  #     targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/pdbs'
+  #   timeoutInMinutes: 15
+
+  # Publish Org.WebRtc.dll and associated (PDB, ...)
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish WinRT wrappers ($(buildTriple))'
+    inputs:
+      artifactName: 'orgwebrtc_$(buildTriple)'
+      targetPath: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.Universal/Build/Output/Org.WebRtc/${{parameters.buildConfig}}/${{parameters.buildArch}}'
+    timeoutInMinutes: 15
+
+  # Publish Org.WebRtc generated headers
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish WinRT generated headers ($(buildTriple))'
+    condition: eq('${{parameters.publishWinRtHeaders}}', 'true')
+    inputs:
+      artifactName: 'orgwebrtc_headers'
+      targetPath: 'external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/sdk/windows/wrapper'
+    timeoutInMinutes: 15
+
+  # Publish Org.WebRtc.WrapperGlue.lib and associated (PDB, ...)
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish WinRT glue wrappers ($(buildTriple))'
+    inputs:
+      artifactName: 'orgwebrtc_glue_$(buildTriple)'
+      targetPath: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Build/Output/Org.WebRtc.WrapperGlue/${{parameters.buildConfig}}/${{parameters.buildArch}}'
+    timeoutInMinutes: 15
+
+  # Copy all PDBs to a single directory for package publishing
+  - task: PowerShell@2
+    displayName: Copy PDBs for packaging
+    inputs:
+      targetType: filePath
+      filePath: tools/ci/copyPdbsForPackaging.ps1
+      arguments: '-WithUwpWrapper -CorePath "external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT/webrtc/$(scriptPlatform)/${{parameters.buildArch}}/${{parameters.buildConfig}}/pdbs" -WrapperPath "external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.Universal/Build/Output/Org.WebRtc/${{parameters.buildConfig}}/${{parameters.buildArch}}" -WrapperGluePath "external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Build/Output/Org.WebRtc.WrapperGlue/${{parameters.buildConfig}}/${{parameters.buildArch}}" -OutputPath $(Build.ArtifactStagingDirectory)/pdbs -BuildConfig ${{parameters.buildConfig}}'
+
+  # List content of PDB packaging folder
+  - powershell: |
+      foreach ($f in $(Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/pdbs -Recurse)) {
+        Write-Host $f.FullName
+      }
+    displayName: 'List PDBs to package'
+    timeoutInMinutes: 5
+
+  # Publish PDBs for webrtc.lib as Universal Package (unlimited retention)
+  - task: UniversalPackages@0
+    displayName: 'Publish PDBs for webrtc.lib ($(buildTriple))'
+    inputs:
+      command: publish
+      publishDirectory: '$(Build.ArtifactStagingDirectory)/pdbs'
+      vstsFeedPublish: $(MRWebRTC_PdbFeed)
+      vstsFeedPackagePublish: $(MRWebRTC_PdbPackageName)
+      versionOption: custom
+      versionPublish: $(MRWebRTC_PdbPackageVersion)
+      packagePublishDescription: 'PDBs for MixedReality-WebRTC core (webrtc.lib) $(buildTriple)'
+    timeoutInMinutes: 30

--- a/tools/ci/templates/jobs-libwebrtc-uwp.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-uwp.yaml
@@ -28,11 +28,6 @@ jobs:
   - checkout: self
     submodules: recursive
     clean: $(clean.git)
-  - powershell: |
-      Write-Host "Deleting gsutil from depot_tools before building"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
-    env:
-      SDK_ROOT: 'external/webrtc-uwp-sdk'
 
   # Compute the PDB package variables
   - task: PowerShell@2
@@ -71,15 +66,38 @@ jobs:
       restoreDirectory: ../../../solutions/packages
     timeoutInMinutes: 10
 
+  # Prepare build
+  - task: PythonScript@0
+    displayName: 'Prepare build'
+    inputs:
+      scriptSource: 'filePath'
+      scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
+      arguments: '-a prepare -t webrtc -p winuwp --cpus $(scriptArch) -c $(scriptConfig) --noColor --noWrapper'
+      failOnStderr: false
+
+  # Clean-up unused files
+  - powershell: |
+      Write-Host "Deleting gsutil from depot_tools before building"
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
+    displayName: 'Clean-up unused files'
+    env:
+      SDK_ROOT: 'external/webrtc-uwp-sdk'
+
+  # Run component detection
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    inputs:
+      #scanType: 'LogOnly'
+      #sourceScanPath: '$(sourcesRoot)'
+
   # Build webrtc.lib
-  - task: MSBuild@1
+  - task: PythonScript@0
     displayName: 'Build webrtc.lib ($(buildTriple))'
     inputs:
-      solution: '$(projectRoot)WebRtc.UWP.Native.Builder/WebRtc.UWP.Native.Builder.vcxproj'
-      msbuildVersion: '15.0'
-      msbuildArchitecture: x64
-      platform: ${{parameters.buildArch}}
-      configuration: ${{parameters.buildConfig}}
+      scriptSource: 'filePath'
+      scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
+      arguments: '-a build -t webrtc -p winuwp --cpus $(scriptArch) -c $(scriptConfig) --noColor --noWrapper'
+      failOnStderr: false
     timeoutInMinutes: 120
 
   # Build the UWP wrapper

--- a/tools/ci/templates/jobs-libwebrtc-win32.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-win32.yaml
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See LICENSE in the project root for license information.
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 # [TEMPLATE] Compile WebRTC Core for Desktop (Win32) platform
 
@@ -17,20 +17,20 @@ jobs:
     name: ${{parameters.buildAgent}}
     demands:
     - msbuild
-    #- mr_webrtc_core
   variables:
     buildTriple: Win32-${{parameters.buildArch}}-${{parameters.buildConfig}}
     projectRoot: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/'
   steps:
 
+  # Install Python 2.7.17 and select as default
+  - template: 'steps-install-python2x.yaml'
+    parameters:
+      tempFolder: '$(Build.BinariesDirectory)\py27'
+      pythonVersion: '2.7.17'
+
   # Checkout
   - checkout: self
     submodules: recursive
-  - powershell: |
-      Write-Host "Deleting gsutil from depot_tools before building"
-      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
-    env:
-      SDK_ROOT: 'external/webrtc-uwp-sdk'
 
   # Compute the PDB package variables
   - task: PowerShell@2
@@ -50,15 +50,39 @@ jobs:
       filePath: tools/ci/mapVariables.ps1
       arguments: 'Win32 ${{parameters.buildArch}} ${{parameters.buildConfig}}'
 
-  # Compile webrtc.lib
-  - task: MSBuild@1
+  # Prepare build
+  - task: PythonScript@0
+    displayName: 'Prepare build'
+    inputs:
+      scriptSource: 'filePath'
+      scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
+      arguments: '-a prepare -t webrtc -p win --cpus $(scriptArch) -c $(scriptConfig) --noColor --noWrapper'
+      failOnStderr: false
+
+  # Clean-up unused files
+  - script: |
+      del /F /S /Q "depot_tools/external_bin/gsutil"
+      del /F /S /Q "chromium/third_party/protobuf/java"
+      del /F /S /Q "chromium/tools/android"
+      del /F /S /Q "chromium/tools/code_coverage"
+    workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'
+    displayName: 'Clean-up unused files'
+
+  # Run component detection
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    #inputs:
+      #scanType: 'LogOnly'
+      #sourceScanPath: '$(sourcesRoot)'
+
+  # Build webrtc.lib
+  - task: PythonScript@0
     displayName: 'Build webrtc.lib ($(buildTriple))'
     inputs:
-      solution: '$(projectRoot)WebRtc.Win32.Native.Builder/WebRtc.Win32.Native.Builder.vcxproj'
-      msbuildVersion: '15.0'
-      msbuildArchitecture: x64
-      platform: ${{parameters.buildArch}}
-      configuration: ${{parameters.buildConfig}}
+      scriptSource: 'filePath'
+      scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
+      arguments: '-a build -t webrtc -p win --cpus $(scriptArch) -c $(scriptConfig) --noColor --noWrapper'
+      failOnStderr: false
     timeoutInMinutes: 120
 
   # Publish webrtc.lib as pipeline artifacts (limited retention)

--- a/tools/ci/templates/jobs-libwebrtc-win32.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-win32.yaml
@@ -17,7 +17,7 @@ jobs:
     name: ${{parameters.buildAgent}}
     demands:
     - msbuild
-    - mr_webrtc_core
+    #- mr_webrtc_core
   variables:
     buildTriple: Win32-${{parameters.buildArch}}-${{parameters.buildConfig}}
     projectRoot: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/'

--- a/tools/ci/templates/jobs-libwebrtc-win32.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-win32.yaml
@@ -22,8 +22,15 @@ jobs:
     buildTriple: Win32-${{parameters.buildArch}}-${{parameters.buildConfig}}
     projectRoot: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/'
   steps:
+
+  # Checkout
   - checkout: self
     submodules: recursive
+  - powershell: |
+      Write-Host "Deleting gsutil from depot_tools before building"
+      Remove-Item -Path $(Join-Path $env:SDK_ROOT "webrtc/xplatform/depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
+    env:
+      SDK_ROOT: 'external/webrtc-uwp-sdk'
 
   # Compute the PDB package variables
   - task: PowerShell@2

--- a/tools/ci/templates/jobs-libwebrtc-win32.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-win32.yaml
@@ -31,6 +31,7 @@ jobs:
   # Checkout
   - checkout: self
     submodules: recursive
+    clean: $(clean.git)
 
   # Compute the PDB package variables
   - task: PowerShell@2

--- a/tools/ci/templates/steps-install-python2x.yaml
+++ b/tools/ci/templates/steps-install-python2x.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# [TEMPLATE] Steps to install Python 2.x on the build agent
+
+parameters:
+# Temporary folder where to download the Python 2.x NuGet package before moving
+# it to the agent's tools folder. This folder will be completely cleared.
+- name: 'tempFolder'
+  type: string
+  default: ''
+# Python version (e.g. 2.7.17)
+- name: 'pythonVersion'
+  type: string
+  default: ''
+
+steps:
+
+# Clean-up the temporary folder
+- powershell: 'Remove-Item "${{parameters.tempFolder}}\*" -Force -Recurse -ErrorAction Ignore'
+  displayName: 'Clean-up temp install folder'
+
+# Install Python from NuGet
+- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand@2
+  displayName: 'Install Python ${{parameters.pythonVersion}}'
+  inputs:
+    command: 'custom'
+    arguments: 'install python2 -Version ${{parameters.pythonVersion}} -OutputDirectory ${{parameters.tempFolder}}'
+
+# Move downloaded version to the agent's tools folder
+- powershell: |
+    Write-Host "Content of downloaded NuGet package ${{parameters.tempFolder}}:"
+    foreach ($f in $(Get-ChildItem -Path ${{parameters.tempFolder}} -Recurse)) {
+        Write-Host $f.FullName
+    }
+    Remove-Item "$(Agent.ToolsDirectory)\Python\${{parameters.pythonVersion}}\*" -Force -Recurse -ErrorAction Ignore
+    New-Item -Path "$(Agent.ToolsDirectory)\Python\${{parameters.pythonVersion}}" -ItemType 'Directory' -ErrorAction Ignore
+    Move-Item -Path "${{parameters.tempFolder}}\python2.${{parameters.pythonVersion}}\tools" -Destination "$(Agent.ToolsDirectory)\Python\${{parameters.pythonVersion}}"
+    Rename-Item -Path "$(Agent.ToolsDirectory)\Python\${{parameters.pythonVersion}}\tools" -NewName "x64"
+    Write-Host "Content of agent tools folder $(Agent.ToolsDirectory)\Python\${{parameters.pythonVersion}}:"
+    foreach ($f in $(Get-ChildItem -Path $(Agent.ToolsDirectory)\Python\${{parameters.pythonVersion}} -Recurse)) {
+        Write-Host $f.FullName
+    }
+  displayName: 'Move Python ${{parameters.pythonVersion}}'
+
+# Register the new tool with the agent
+- powershell: |
+    Write-Host "Creating '.complete' file for build tool registration..."
+    New-Item "$(Agent.ToolsDirectory)\Python\${{parameters.pythonVersion}}\x64.complete" -Force
+  displayName: 'Register Python ${{parameters.pythonVersion}} with build agent'
+
+# Select the new tool to be used by subsequent steps
+- task: UsePythonVersion@0
+  displayName: 'Use Python ${{parameters.pythonVersion}}'
+  inputs:
+    versionSpec: ${{parameters.pythonVersion}}
+
+# Print the current Python version for validation
+- task: PythonScript@0
+  displayName: 'Print Python version'
+  inputs:
+    scriptSource: inline
+    script: |
+      import sys;
+      print(sys.version_info);
+
+# Install pywin32 via pip
+- script: 'python -m pip install pywin32'
+  displayName: 'Install pywin32'


### PR DESCRIPTION
- Fix the release pipeline building the Google's implementation library `libwebrtc` to build on on-prem agents.
- Add a Component Governance task before the build to detect components in use by the project.
- Ensure the security report for those components is clean by deleting unused code before detection and building to make sure potentially vulnerable code present in Google's build tools _etc._ is not used in the build and not shipped.
- Update `cgmanifest.json` with the correct commits for all used git repositories.