### PR TITLE
Delete unused components before CG scan

### DIFF
--- a/tools/build/libwebrtc/mrwebrtc.ps1
+++ b/tools/build/libwebrtc/mrwebrtc.ps1
@@ -95,6 +95,16 @@ function Install-GoogleRepository {
         throw
     }
 
+    # Delete sources not needed; this prevent security alerts on unused components,
+    # and makes the overall checkout size smaller.
+    $toolsFolder = Join-Path $libwebrtcFolder "tools" -Resolve
+    Rename-Item -Path $toolsFolder -NewName "_tools"
+    $oldToolsFolder = Join-Path $libwebrtcFolder "_tools" -Resolve
+    New-Item -Path $toolsFolder -ItemType Directory | Out-Null
+    Move-Item -Path $(Join-Path $oldToolsFolder "clang") -Destination $toolsFolder
+    Move-Item -Path $(Join-Path $oldToolsFolder "protoc_wrapper") -Destination $toolsFolder
+    Remove-Item -Path $oldToolsFolder -Recurse -Force | Out-Null
+
     # Apply patches
     $env:WEBRTCM80_ROOT = $libwebrtcFolder
     Write-TaskStart "Patching M80 for UWP..."

--- a/tools/build/libwebrtc/mrwebrtc.ps1
+++ b/tools/build/libwebrtc/mrwebrtc.ps1
@@ -75,6 +75,12 @@ function Clear-PostCheckout([string]$SourceFolder) {
 
     # Remove third_party/catapult
     Remove-Item -Path $(Join-Path $SourceFolder "third_party/catapult" -Resolve) -Force -Recurse | Out-Null
+
+    # Remove third_party/depot_tools
+    Remove-Item -Path $(Join-Path $SourceFolder "third_party/depot_tools" -Resolve) -Force -Recurse | Out-Null
+
+    # Remove third_party/node
+    Remove-Item -Path $(Join-Path $SourceFolder "third_party/node" -Resolve) -Force -Recurse | Out-Null
 }
 
 # Install the Google repository of libwebrtc into external/libwebrtc

--- a/tools/build/libwebrtc/mrwebrtc.ps1
+++ b/tools/build/libwebrtc/mrwebrtc.ps1
@@ -218,10 +218,27 @@ is_debug=$is_debug
 use_lld=false
 is_clang=false
 
+# Force-include mandatory components for clarity
+rtc_include_internal_audio_device=true
+rtc_include_builtin_audio_codecs=true
+rtc_include_builtin_video_codecs=true
+rtc_libvpx_build_vp9=true
+rtc_include_ilbc=true
+rtc_include_opus=true
+rtc_enable_sctp=true
+rtc_disable_logging=false
+rtc_disable_trace_events=false
+
+# Disable proprietary codecs (MP3,MP4,OpenH264,AAC,...)
+proprietary_codecs=false
+rtc_use_h264=false # OpenH264
+
 # Exclude unused modules to speed up build
 rtc_include_tests=false
 rtc_build_tools=false
 rtc_build_examples=false
+rtc_enable_protobuf=false
+rtc_enable_external_auth=false
 
 # Use WinRT video capturer for Windows Desktop and UWP
 rtc_win_video_capture_winrt=true

--- a/tools/build/libwebrtc/mrwebrtc.ps1
+++ b/tools/build/libwebrtc/mrwebrtc.ps1
@@ -123,6 +123,9 @@ function Install-GoogleRepository {
     # and makes the overall checkout size smaller.
     Clear-PostCheckout -SourceFolder $libwebrtcFolder
 
+    # Remove depot_tools/external_bin/gsutil
+    Remove-Item -Path $(Join-Path $externalFolder "depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
+
     # Apply patches
     $env:WEBRTCM80_ROOT = $libwebrtcFolder
     Write-TaskStart "Patching M80 for UWP..."

--- a/tools/build/libwebrtc/mrwebrtc.ps1
+++ b/tools/build/libwebrtc/mrwebrtc.ps1
@@ -122,8 +122,6 @@ function Install-GoogleRepository {
     # Delete sources not needed; this prevent security alerts on unused components,
     # and makes the overall checkout size smaller.
     Clear-PostCheckout -SourceFolder $libwebrtcFolder
-
-    # Remove depot_tools/external_bin/gsutil
     Remove-Item -Path $(Join-Path $externalFolder "depot_tools/external_bin/gsutil" -Resolve) -Force -Recurse | Out-Null
 
     # Apply patches

--- a/tools/build/libwebrtc/mrwebrtc.ps1
+++ b/tools/build/libwebrtc/mrwebrtc.ps1
@@ -59,6 +59,24 @@ function Initialize-BuildEnvironment {
     $env:GYP_MSVS_VERSION = "2019"
 }
 
+# Post-checkout clean-up
+function Clear-PostCheckout([string]$SourceFolder) {
+    # Remove tools/ (except tools/clang/ and tools/protoc_wrapper/)
+    $toolsFolder = Join-Path $SourceFolder "tools" -Resolve
+    Rename-Item -Path $toolsFolder -NewName "_tools"
+    $oldToolsFolder = Join-Path $SourceFolder "_tools" -Resolve
+    New-Item -Path $toolsFolder -ItemType Directory | Out-Null
+    Move-Item -Path $(Join-Path $oldToolsFolder "clang") -Destination $toolsFolder
+    Move-Item -Path $(Join-Path $oldToolsFolder "protoc_wrapper") -Destination $toolsFolder
+    Remove-Item -Path $oldToolsFolder -Recurse -Force | Out-Null
+
+    # Remove third_party/blink
+    Remove-Item -Path $(Join-Path $SourceFolder "third_party/blink" -Resolve) -Force -Recurse | Out-Null
+
+    # Remove third_party/catapult
+    Remove-Item -Path $(Join-Path $SourceFolder "third_party/catapult" -Resolve) -Force -Recurse | Out-Null
+}
+
 # Install the Google repository of libwebrtc into external/libwebrtc
 function Install-GoogleRepository {
     $externalFolder = Get-ExternalFolder
@@ -97,13 +115,7 @@ function Install-GoogleRepository {
 
     # Delete sources not needed; this prevent security alerts on unused components,
     # and makes the overall checkout size smaller.
-    $toolsFolder = Join-Path $libwebrtcFolder "tools" -Resolve
-    Rename-Item -Path $toolsFolder -NewName "_tools"
-    $oldToolsFolder = Join-Path $libwebrtcFolder "_tools" -Resolve
-    New-Item -Path $toolsFolder -ItemType Directory | Out-Null
-    Move-Item -Path $(Join-Path $oldToolsFolder "clang") -Destination $toolsFolder
-    Move-Item -Path $(Join-Path $oldToolsFolder "protoc_wrapper") -Destination $toolsFolder
-    Remove-Item -Path $oldToolsFolder -Recurse -Force | Out-Null
+    Clear-PostCheckout -SourceFolder $libwebrtcFolder
 
     # Apply patches
     $env:WEBRTCM80_ROOT = $libwebrtcFolder

--- a/tools/ci/mapVariables.ps1
+++ b/tools/ci/mapVariables.ps1
@@ -1,10 +1,9 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See LICENSE in the project root for license information.
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 # Map build* variables to script* variables
 #   build* variables are for MSVC and use uppercase : ARM(64), Debug|Release, Win32|UWP
 #   script* variables are for the Google Python scripts and use lowercase: arm(64), debug|release, win|winuwp
-# See https://github.com/webrtc-uwp/webrtc-scripts/blob/3f2eb87b1baa3f49c6341d144e0b3c3be11c78ae/defaults.py#L17
 
 param(
     [Parameter(Position=0)]
@@ -12,7 +11,7 @@ param(
     [string]$BuildPlatform,
 
     [Parameter(Position=1)]
-    [ValidateSet('x86','x64','ARM')]
+    [ValidateSet('x86','x64','ARM','ARM64')]
     [string]$BuildArch,
 
     [Parameter(Position=2)]
@@ -33,8 +32,8 @@ else {
     Write-Host "##vso[task.complete result=Failed;]Unknown build platform '$BuildPlatform'."
 }
 
-# buildArch = x86|x64|ARM
-# scriptArch = x86|x64|arm
+# buildArch = x86|x64|ARM|ARM64
+# scriptArch = x86|x64|arm|arm64
 Write-Host "buildArch = $BuildArch"
 if ($BuildArch -eq "x86") {
     Write-Host "##vso[task.setvariable variable=scriptArch; ]x86"
@@ -44,6 +43,9 @@ elseif ($BuildArch -eq "x64") {
 }
 elseif ($BuildArch -eq "ARM") {
     Write-Host "##vso[task.setvariable variable=scriptArch; ]arm"
+}
+elseif ($BuildArch -eq "ARM64") {
+    Write-Host "##vso[task.setvariable variable=scriptArch; ]arm64"
 }
 else {
     Write-Host "##vso[task.complete result=Failed; ]Unknown build architecture '$BuildArch'."


### PR DESCRIPTION
Before Component Governance scanning and `libwebrtc` building occur, delete components checked out on disk by Google's tools but unused, and which trigger some security vulnerability alerts. This makes sure those vulnerabilities cannot possibly make it into MixedReality-WebRTC, and makes the security checks pass.