### PR TITLE
Use enum and message type for SDP messages

### DIFF
--- a/examples/TestAppUwp/NodeDssSignaler.cs
+++ b/examples/TestAppUwp/NodeDssSignaler.cs
@@ -77,6 +77,26 @@ namespace TestAppUwp
                 throw new ArgumentException($"Unkown signaler message type '{stringType}'");
             }
 
+            public static WireMessageType TypeFromSdpMessageType(SdpMessageType type)
+            {
+                switch (type)
+                {
+                case SdpMessageType.Offer: return WireMessageType.Offer;
+                case SdpMessageType.Answer: return WireMessageType.Answer;
+                }
+                throw new ArgumentException($"Invalid SDP message type '{type}'.");
+            }
+
+            public static Message FromSdpMessage(SdpMessage message)
+            {
+                return new Message
+                {
+                    MessageType = TypeFromSdpMessageType(message.Type),
+                    Data = message.Content,
+                    IceDataSeparator = "|"
+                };
+            }
+
             /// <summary>
             /// The message type
             /// </summary>

--- a/examples/TestNetCoreConsole/NamedPipeSignaler.cs
+++ b/examples/TestNetCoreConsole/NamedPipeSignaler.cs
@@ -221,7 +221,8 @@ namespace NamedPipeSignaler
                     }
 
                     Console.WriteLine($"[<-] SDP message: {type} {sdp}");
-                    SdpMessageReceived?.Invoke(type, sdp);
+                    var message = new SdpMessage { Type = SdpMessage.StringToType(type), Content = sdp };
+                    SdpMessageReceived?.Invoke(message);
                 }
             }
             Console.WriteLine("Finished processing messages");
@@ -270,10 +271,11 @@ namespace NamedPipeSignaler
             SendMessage($"ice\n{sdpMid}\n{sdpMlineindex}\n{candidate}\n\n");
         }
 
-        private void PeerConnection_LocalSdpReadytoSend(string type, string sdp)
+        private void PeerConnection_LocalSdpReadytoSend(SdpMessage message)
         {
             // See ProcessIncomingMessages() for the message format
-            SendMessage($"sdp\n{type}\n{sdp}\n\n");
+            string typeStr = SdpMessage.TypeToString(message.Type);
+            SendMessage($"sdp\n{typeStr}\n{message.Content}\n\n");
         }
     }
 }

--- a/examples/TestNetCoreConsole/Program.cs
+++ b/examples/TestNetCoreConsole/Program.cs
@@ -67,9 +67,9 @@ namespace TestNetCoreConsole
                 // Setup signaling
                 Console.WriteLine("Starting signaling...");
                 var signaler = new NamedPipeSignaler.NamedPipeSignaler(pc, "testpipe");
-                signaler.SdpMessageReceived += (string type, string sdp) => {
-                    pc.SetRemoteDescriptionAsync(type, sdp).Wait();
-                    if (type == "offer")
+                signaler.SdpMessageReceived += async (SdpMessage message) => {
+                    await pc.SetRemoteDescriptionAsync(message);
+                    if (message.Type == SdpMessageType.Offer)
                     {
                         pc.CreateAnswer();
                     }

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Examples/StandaloneDemo/LocalOnlySignaler.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Examples/StandaloneDemo/LocalOnlySignaler.cs
@@ -86,21 +86,21 @@ public class LocalOnlySignaler : MonoBehaviour
         Peer2.Peer.IceCandidateReadytoSend += Peer2_IceCandidateReadytoSend;
     }
 
-    private async void Peer1_LocalSdpReadytoSend(string type, string sdp)
+    private async void Peer1_LocalSdpReadytoSend(Microsoft.MixedReality.WebRTC.SdpMessage message)
     {
-        await Peer2.HandleConnectionMessageAsync(type, sdp);
+        await Peer2.HandleConnectionMessageAsync(message);
         _remoteApplied2.Set();
-        if (type == "offer")
+        if (message.Type == Microsoft.MixedReality.WebRTC.SdpMessageType.Offer)
         {
             Peer2.Peer.CreateAnswer();
         }
     }
 
-    private async void Peer2_LocalSdpReadytoSend(string type, string sdp)
+    private async void Peer2_LocalSdpReadytoSend(Microsoft.MixedReality.WebRTC.SdpMessage message)
     {
-        await Peer1.HandleConnectionMessageAsync(type, sdp);
+        await Peer1.HandleConnectionMessageAsync(message);
         _remoteApplied1.Set();
-        if (type == "offer")
+        if (message.Type == Microsoft.MixedReality.WebRTC.SdpMessageType.Offer)
         {
             Peer1.Peer.CreateAnswer();
         }

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Editor/EditorTests.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity.Tests.Editor/EditorTests.cs
@@ -57,18 +57,18 @@ namespace Microsoft.MixedReality.WebRTC.Tests
                     await pc2.InitializeAsync();
 
                     // Prepare SDP event handlers
-                    pc1.LocalSdpReadytoSend += async (string type, string sdp) =>
+                    pc1.LocalSdpReadytoSend += async (SdpMessage message) =>
                     {
-                        await pc2.SetRemoteDescriptionAsync(type, sdp);
-                        if (type == "offer")
+                        await pc2.SetRemoteDescriptionAsync(message);
+                        if (message.Type == SdpMessageType.Offer)
                         {
                             pc2.CreateAnswer();
                         }
                     };
-                    pc2.LocalSdpReadytoSend += async (string type, string sdp) =>
+                    pc2.LocalSdpReadytoSend += async (SdpMessage message) =>
                     {
-                        await pc1.SetRemoteDescriptionAsync(type, sdp);
-                        if (type == "offer")
+                        await pc1.SetRemoteDescriptionAsync(message);
+                        if (message.Type == SdpMessageType.Offer)
                         {
                             pc1.CreateAnswer();
                         }

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/PeerConnection.cs
@@ -871,15 +871,14 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// </p>
         /// </div>
         /// </summary>
-        /// <param name="type">The type of SDP message ("offer" or "answer")</param>
-        /// <param name="sdp">The content of the SDP message</param>
+        /// <param name="message">The SDP message to handle.</param>
         /// <returns>A task which completes once the remote description has been applied and transceivers
         /// have been updated.</returns>
         /// <exception xref="InvalidOperationException">The peer connection is not intialized.</exception>
-        public async Task HandleConnectionMessageAsync(string type, string sdp)
+        public async Task HandleConnectionMessageAsync(SdpMessage message)
         {
             // First apply the remote description
-            await Peer.SetRemoteDescriptionAsync(type, sdp);
+            await Peer.SetRemoteDescriptionAsync(message);
 
             // Sort associated transceiver by media line index. The media line index is not the index of
             // the transceiver, but they are both monotonically increasing, so sorting by one or the other
@@ -891,7 +890,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             int numMatching = Math.Min(numAssociatedTransceivers, _mediaLines.Count);
 
             // Once applied, try to pair transceivers and remote tracks with the Unity receiver components
-            if (type == "offer")
+            if (message.Type == SdpMessageType.Offer)
             {
                 // Match transceivers with media line, in order
                 for (int i = 0; i < numMatching; ++i)
@@ -940,7 +939,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                     });
                 }
             }
-            else if (type == "answer")
+            else if (message.Type == SdpMessageType.Answer)
             {
                 // Associate registered media senders/receivers with existing transceivers
                 for (int i = 0; i < numMatching; ++i)

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/NodeDssSignaler.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/NodeDssSignaler.cs
@@ -270,7 +270,8 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                     {
                     case NodeDssMessage.Type.Offer:
                         // Apply the offer coming from the remote peer to the local peer
-                        PeerConnection.HandleConnectionMessageAsync("offer", msg.Data).ContinueWith(_ =>
+                        var sdpOffer = new WebRTC.SdpMessage { Type = SdpMessageType.Offer, Content = msg.Data };
+                        PeerConnection.HandleConnectionMessageAsync(sdpOffer).ContinueWith(_ =>
                         {
                             // If the remote description was successfully applied then immediately send
                             // back an answer to the remote peer to acccept the offer.
@@ -280,7 +281,8 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
                     case NodeDssMessage.Type.Answer:
                         // No need to wait for completion; there is nothing interesting to do after it.
-                        _ = PeerConnection.HandleConnectionMessageAsync("answer", msg.Data);
+                        var sdpAnswer = new WebRTC.SdpMessage { Type = SdpMessageType.Answer, Content = msg.Data };
+                        _ = PeerConnection.HandleConnectionMessageAsync(sdpAnswer);
                         break;
 
                     case NodeDssMessage.Type.Ice:

--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/Signaler.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Signaling/Signaler.cs
@@ -176,17 +176,16 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// <summary>
         /// Helper to split SDP offer and answer messages and dispatch to the appropriate handler.
         /// </summary>
-        /// <param name="type"></param>
-        /// <param name="sdp"></param>
-        private void OnLocalSdpReadyToSend_Listener(string type, string sdp)
+        /// <param name="message">The SDP message ready to be sent to the remote peer.</param>
+        private void OnLocalSdpReadyToSend_Listener(WebRTC.SdpMessage message)
         {
-            if (string.Equals(type, "offer", StringComparison.OrdinalIgnoreCase))
+            if (message.Type == SdpMessageType.Offer)
             {
-                _mainThreadWorkQueue.Enqueue(() => OnSdpOfferReadyToSend(sdp));
+                _mainThreadWorkQueue.Enqueue(() => OnSdpOfferReadyToSend(message.Content));
             }
-            else if (string.Equals(type, "answer", StringComparison.OrdinalIgnoreCase))
+            else if (message.Type == SdpMessageType.Answer)
             {
-                _mainThreadWorkQueue.Enqueue(() => OnSdpAnswerReadyToSend(sdp));
+                _mainThreadWorkQueue.Enqueue(() => OnSdpAnswerReadyToSend(message.Content));
             }
         }
 

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/PeerConnectionInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/PeerConnectionInterop.cs
@@ -173,7 +173,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         }
 
         [MonoPInvokeCallback(typeof(LocalSdpReadytoSendDelegate))]
-        public static void LocalSdpReadytoSendCallback(IntPtr userData, string type, string sdp)
+        public static void LocalSdpReadytoSendCallback(IntPtr userData, SdpMessageType type, string sdp)
         {
             var peer = Utils.ToWrapper<PeerConnection>(userData);
             peer.OnLocalSdpReadytoSend(type, sdp);
@@ -626,7 +626,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         public delegate void PeerConnectionLocalSdpReadytoSendCallback(IntPtr userData,
-            string type, string sdp);
+            SdpMessageType type, string sdp);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         public delegate void PeerConnectionIceCandidateReadytoSendCallback(IntPtr userData,
@@ -803,7 +803,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsPeerConnectionSetRemoteDescriptionAsync")]
         public static extern uint PeerConnection_SetRemoteDescriptionAsync(PeerConnectionHandle peerHandle,
-            string type, string sdp, PeerConnectionRemoteDescriptionAppliedDelegate callback, IntPtr callbackArgs);
+            SdpMessageType type, string sdp, PeerConnectionRemoteDescriptionAppliedDelegate callback, IntPtr callbackArgs);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsPeerConnectionClose")]
@@ -831,7 +831,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             public TaskCompletionSource<bool> tcs;
         }
 
-        public static Task SetRemoteDescriptionAsync(PeerConnectionHandle peerHandle, string type, string sdp)
+        public static Task SetRemoteDescriptionAsync(PeerConnectionHandle peerHandle, SdpMessageType type, string sdp)
         {
             var args = new RemoteDescArgs
             {

--- a/libs/Microsoft.MixedReality.WebRTC/Tracing/MainEventSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Tracing/MainEventSource.cs
@@ -99,8 +99,9 @@ namespace Microsoft.MixedReality.WebRTC.Tracing
 
         #region SDP
 
-        [Event(0x2001, Level = EventLevel.Informational, Keywords = Keywords.Sdp)]
-        public void LocalSdpReady(string type, string sdp) { WriteEvent(0x2001, type, sdp); }
+        // DEPRECATED; see 0x2006
+        //[Event(0x2001, Level = EventLevel.Informational, Keywords = Keywords.Sdp)]
+        //public void LocalSdpReady(string type, string sdp) { WriteEvent(0x2001, type, sdp); }
 
         [Event(0x2002, Level = EventLevel.Informational, Keywords = Keywords.Sdp)]
         public void IceCandidateReady(string sdpMid, int sdpMlineindex, string candidate)
@@ -119,6 +120,9 @@ namespace Microsoft.MixedReality.WebRTC.Tracing
         {
             WriteEvent(0x2005, sdpMid, sdpMlineindex, candidate);
         }
+
+        [Event(0x2006, Level = EventLevel.Informational, Keywords = Keywords.Sdp)]
+        public void LocalSdpReady(SdpMessageType type, string sdp) { WriteEvent(0x2006, (int)type, sdp); }
 
         #endregion
 

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -156,6 +156,9 @@ MRS_API mrsResult MRS_CALL mrsEnumVideoCaptureFormatsAsync(
 // Peer connection
 //
 
+/// Type of SDP message.
+enum class mrsSdpMessageType : int32_t { kOffer = 1, kAnswer = 2 };
+
 /// Opaque handle to a native AudioTrackReadBuffer C++ object.
 using AudioTrackReadBufferHandle = void*;
 
@@ -165,8 +168,8 @@ using mrsPeerConnectionConnectedCallback = void(MRS_CALL*)(void* user_data);
 
 /// Callback fired when a local SDP message has been prepared and is ready to be
 /// sent by the user via the signaling service.
-using mrsPeerConnectionLocalSdpReadytoSendCallback =
-    void(MRS_CALL*)(void* user_data, const char* type, const char* sdp_data);
+using mrsPeerConnectionLocalSdpReadytoSendCallback = void(
+    MRS_CALL*)(void* user_data, mrsSdpMessageType type, const char* sdp_data);
 
 /// Callback fired when an ICE candidate has been prepared and is ready to be
 /// sent by the user via the signaling service.
@@ -718,7 +721,7 @@ using mrsRemoteDescriptionAppliedCallback = void(
 /// the negotiation, and in particular it is safe to call |CreateAnswer()|.
 MRS_API mrsResult MRS_CALL mrsPeerConnectionSetRemoteDescriptionAsync(
     mrsPeerConnectionHandle peer_handle,
-    const char* type,
+    mrsSdpMessageType type,
     const char* sdp,
     mrsRemoteDescriptionAppliedCallback callback,
     void* user_data) noexcept;

--- a/libs/mrwebrtc/src/peer_connection.cpp
+++ b/libs/mrwebrtc/src/peer_connection.cpp
@@ -665,12 +665,12 @@ ErrorOr<Transceiver*> PeerConnection::AddTransceiver(
   return transceiver.get();
 }
 
-bool PeerConnection::SetRemoteDescriptionAsync(
-    const char* type,
+Error PeerConnection::SetRemoteDescriptionAsync(
+    mrsSdpMessageType type,
     const char* sdp,
     RemoteDescriptionAppliedCallback callback) noexcept {
   if (!peer_) {
-    return false;
+    return Error(mrsResult::kInvalidOperation);
   }
   {
     auto lock = std::scoped_lock{data_channel_mutex_};
@@ -678,16 +678,14 @@ bool PeerConnection::SetRemoteDescriptionAsync(
       sctp_negotiated_ = false;
     }
   }
-  std::string sdp_type_str(type);
-  auto sdp_type = SdpTypeFromString(sdp_type_str);
-  if (!sdp_type.has_value())
-    return false;
+  const webrtc::SdpType sdp_type = SdpTypeFromApiType(type);
   std::string remote_desc(sdp);
   webrtc::SdpParseError error;
   std::unique_ptr<webrtc::SessionDescriptionInterface> session_description(
-      webrtc::CreateSessionDescription(sdp_type.value(), remote_desc, &error));
-  if (!session_description)
-    return false;
+      webrtc::CreateSessionDescription(sdp_type, remote_desc, &error));
+  if (!session_description) {
+    return Error(mrsResult::kInvalidParameter, error.description.c_str());
+  }
   rtc::scoped_refptr<webrtc::SetRemoteDescriptionObserverInterface> observer =
       new rtc::RefCountedObject<SetRemoteSessionDescObserver>(
           [this, callback](mrsResult result, const char* error_message) {
@@ -714,7 +712,7 @@ bool PeerConnection::SetRemoteDescriptionAsync(
           });
   peer_->SetRemoteDescription(std::move(session_description),
                               std::move(observer));
-  return true;
+  return Error(mrsResult::kSuccess);
 }
 
 void PeerConnection::OnSignalingChange(
@@ -980,10 +978,10 @@ void PeerConnection::OnLocalDescCreated(
           auto lock = std::scoped_lock{local_sdp_ready_to_send_callback_mutex_};
           if (auto cb = local_sdp_ready_to_send_callback_) {
             auto desc = peer_->local_description();
-            std::string type{SdpTypeToString(desc->GetType())};
+            const mrsSdpMessageType type = ApiTypeFromSdpType(desc->GetType());
             std::string sdp;
             desc->ToString(&sdp);
-            cb(type.c_str(), sdp.c_str());
+            cb(type, sdp.c_str());
           }
         }
       });

--- a/libs/mrwebrtc/src/peer_connection.h
+++ b/libs/mrwebrtc/src/peer_connection.h
@@ -121,7 +121,7 @@ class PeerConnection : public TrackedObject,
   /// - The null-terminated type of the SDP message. Valid values are "offer" or
   /// "answer".
   /// - The null-terminated SDP message content.
-  using LocalSdpReadytoSendCallback = Callback<const char*, const char*>;
+  using LocalSdpReadytoSendCallback = Callback<mrsSdpMessageType, const char*>;
 
   /// Register a custom LocalSdpReadytoSendCallback invoked when a local SDP
   /// message is ready to be sent by the user to the remote peer. Users MUST
@@ -219,8 +219,8 @@ class PeerConnection : public TrackedObject,
   /// remote peer. The parameters correspond to the SDP message data provided by
   /// the |LocalSdpReadytoSendCallback|, after being transmitted to the
   /// other peer.
-  bool SetRemoteDescriptionAsync(
-      const char* type,
+  Error SetRemoteDescriptionAsync(
+      mrsSdpMessageType type,
       const char* sdp,
       RemoteDescriptionAppliedCallback callback) noexcept;
 

--- a/libs/mrwebrtc/src/sdp_utils.cpp
+++ b/libs/mrwebrtc/src/sdp_utils.cpp
@@ -221,4 +221,28 @@ std::optional<webrtc::SdpType> SdpTypeFromString(const std::string& type_str) {
   }
 }
 
+webrtc::SdpType SdpTypeFromApiType(mrsSdpMessageType api_type) {
+  switch (api_type) {
+    case mrsSdpMessageType::kOffer:
+      return webrtc::SdpType::kOffer;
+    case mrsSdpMessageType::kAnswer:
+      return webrtc::SdpType::kAnswer;
+    default:
+      RTC_NOTREACHED();
+      return (webrtc::SdpType)-1;  // invalid
+  }
+}
+
+mrsSdpMessageType ApiTypeFromSdpType(webrtc::SdpType type) {
+  switch (type) {
+    case webrtc::SdpType::kOffer:
+      return mrsSdpMessageType::kOffer;
+    case webrtc::SdpType::kAnswer:
+      return mrsSdpMessageType::kAnswer;
+    default:
+      RTC_NOTREACHED();
+      return (mrsSdpMessageType)-1;  // invalid
+  }
+}
+
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/mrwebrtc/src/sdp_utils.h
+++ b/libs/mrwebrtc/src/sdp_utils.h
@@ -7,6 +7,7 @@
 #include <mutex>
 
 #include "callback.h"
+#include "interop_api.h"
 
 namespace Microsoft::MixedReality::WebRTC {
 
@@ -64,5 +65,11 @@ std::string EncodeIceServers(const std::string& url,
 // representation of absl::optional as per the Abseil Compatibility Guidelines:
 // https://abseil.io/about/compatibility
 std::optional<webrtc::SdpType> SdpTypeFromString(const std::string& type_str);
+
+/// Convert an API SDP message type to an internal implementation SDP type.
+webrtc::SdpType SdpTypeFromApiType(mrsSdpMessageType api_type);
+
+/// Convert an internal implementation SDP type to an API SDP message type.
+mrsSdpMessageType ApiTypeFromSdpType(webrtc::SdpType type);
 
 }  // namespace Microsoft::MixedReality::WebRTC

--- a/libs/mrwebrtc/test/data_channel_tests.cpp
+++ b/libs/mrwebrtc/test/data_channel_tests.cpp
@@ -62,25 +62,25 @@ TEST_P(DataChannelTests, InBand) {
   ASSERT_NE(nullptr, pc2.handle());
 
   // Setup signaling
-  SdpCallback sdp1_cb(pc1.handle(), [&pc2](const char* type,
+  SdpCallback sdp1_cb(pc1.handle(), [&pc2](mrsSdpMessageType type,
                                            const char* sdp_data) {
     Event ev;
     ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescriptionAsync(
                                     pc2.handle(), type, sdp_data,
                                     &TestUtils::SetEventOnCompleted, &ev));
     ev.Wait();
-    if (kOfferString == type) {
+    if (type == mrsSdpMessageType::kOffer) {
       ASSERT_EQ(Result::kSuccess, mrsPeerConnectionCreateAnswer(pc2.handle()));
     }
   });
-  SdpCallback sdp2_cb(pc2.handle(), [&pc1](const char* type,
+  SdpCallback sdp2_cb(pc2.handle(), [&pc1](mrsSdpMessageType type,
                                            const char* sdp_data) {
     Event ev;
     ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescriptionAsync(
                                     pc1.handle(), type, sdp_data,
                                     &TestUtils::SetEventOnCompleted, &ev));
     ev.Wait();
-    if (kOfferString == type) {
+    if (type == mrsSdpMessageType::kOffer) {
       ASSERT_EQ(Result::kSuccess, mrsPeerConnectionCreateAnswer(pc1.handle()));
     }
   });

--- a/libs/mrwebrtc/test/peer_connection_test_helpers.h
+++ b/libs/mrwebrtc/test/peer_connection_test_helpers.h
@@ -162,10 +162,10 @@ class PCRaii {
 };
 
 // OnLocalSdpReadyToSend
-class SdpCallback : public InteropCallback<const char*, const char*> {
+class SdpCallback : public InteropCallback<mrsSdpMessageType, const char*> {
  public:
-  using Base = InteropCallback<const char*, const char*>;
-  using callback_type = void(const char*, const char*);
+  using Base = InteropCallback<mrsSdpMessageType, const char*>;
+  using callback_type = void(mrsSdpMessageType, const char*);
   SdpCallback(mrsPeerConnectionHandle pc) : pc_(pc) {}
   SdpCallback(mrsPeerConnectionHandle pc, std::function<callback_type> func)
       : Base(std::move(func)), pc_(pc) {
@@ -276,13 +276,13 @@ class LocalPeerPairRaii {
   bool is_exchange_pending_{false};
   Event exchange_completed_;
   void setup() {
-    sdp1_cb_ = [this](const char* type, const char* sdp_data) {
+    sdp1_cb_ = [this](mrsSdpMessageType type, const char* sdp_data) {
       Event ev;
       ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescriptionAsync(
                                       pc2_.handle(), type, sdp_data,
                                       &TestUtils::SetEventOnCompleted, &ev));
       ev.Wait();
-      if (kOfferString == type) {
+      if (type == mrsSdpMessageType::kOffer) {
         ASSERT_EQ(Result::kSuccess,
                   mrsPeerConnectionCreateAnswer(pc2_.handle()));
       } else {
@@ -291,13 +291,13 @@ class LocalPeerPairRaii {
         exchange_completed_.Set();
       }
     };
-    sdp2_cb_ = [this](const char* type, const char* sdp_data) {
+    sdp2_cb_ = [this](mrsSdpMessageType type, const char* sdp_data) {
       Event ev;
       ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescriptionAsync(
                                       pc1_.handle(), type, sdp_data,
                                       &TestUtils::SetEventOnCompleted, &ev));
       ev.Wait();
-      if (kOfferString == type) {
+      if (type == mrsSdpMessageType::kOffer) {
         ASSERT_EQ(Result::kSuccess,
                   mrsPeerConnectionCreateAnswer(pc1_.handle()));
       } else {

--- a/libs/mrwebrtc/test/peer_connection_tests.cpp
+++ b/libs/mrwebrtc/test/peer_connection_tests.cpp
@@ -33,14 +33,14 @@ TEST_P(PeerConnectionTests, LocalNoIce) {
     // Setup signaling
     Event ev_completed;
     SdpCallback sdp1_cb(pc1.handle(), [&pc2, &ev_completed](
-                                          const char* type,
+                                          mrsSdpMessageType type,
                                           const char* sdp_data) {
       Event ev;
       ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescriptionAsync(
                                       pc2.handle(), type, sdp_data,
                                       &TestUtils::SetEventOnCompleted, &ev));
       ev.Wait();
-      if (kOfferString == type) {
+      if (type == mrsSdpMessageType::kOffer) {
         ASSERT_EQ(Result::kSuccess,
                   mrsPeerConnectionCreateAnswer(pc2.handle()));
       } else {
@@ -48,14 +48,14 @@ TEST_P(PeerConnectionTests, LocalNoIce) {
       }
     });
     SdpCallback sdp2_cb(pc2.handle(), [&pc1, &ev_completed](
-                                          const char* type,
+                                          mrsSdpMessageType type,
                                           const char* sdp_data) {
       Event ev;
       ASSERT_EQ(Result::kSuccess, mrsPeerConnectionSetRemoteDescriptionAsync(
                                       pc1.handle(), type, sdp_data,
                                       &TestUtils::SetEventOnCompleted, &ev));
       ev.Wait();
-      if (kOfferString == type) {
+      if (type == mrsSdpMessageType::kOffer) {
         ASSERT_EQ(Result::kSuccess,
                   mrsPeerConnectionCreateAnswer(pc1.handle()));
       } else {

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/PeerConnectionTestBase.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/PeerConnectionTestBase.cs
@@ -257,12 +257,12 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             connectedEvent2_.Set();
         }
 
-        private async void OnLocalSdpReady1(string type, string sdp)
+        private async void OnLocalSdpReady1(SdpMessage message)
         {
             Assert.IsTrue(exchangePending_);
-            await pc2_.SetRemoteDescriptionAsync(type, sdp);
+            await pc2_.SetRemoteDescriptionAsync(message);
             remoteDescAppliedEvent2_.Set();
-            if (type == "offer")
+            if (message.Type == SdpMessageType.Offer)
             {
                 pc2_.CreateAnswer();
             }
@@ -273,12 +273,12 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             }
         }
 
-        private async void OnLocalSdpReady2(string type, string sdp)
+        private async void OnLocalSdpReady2(SdpMessage message)
         {
             Assert.IsTrue(exchangePending_);
-            await pc1_.SetRemoteDescriptionAsync(type, sdp);
+            await pc1_.SetRemoteDescriptionAsync(message);
             remoteDescAppliedEvent1_.Set();
-            if (type == "offer")
+            if (message.Type == SdpMessageType.Offer)
             {
                 pc1_.CreateAnswer();
             }


### PR DESCRIPTION
Add an enum type for the SDP message type, and a C# SdpMessage class, to
pass the SDP messages around with additional type safety and without the
risks associated with string comparison (locale, misspelling, ...).

Bug: #188