### PR TITLE
Maintain tools/generate-stubs

### DIFF
--- a/tools/build/libwebrtc/mrwebrtc.ps1
+++ b/tools/build/libwebrtc/mrwebrtc.ps1
@@ -61,13 +61,19 @@ function Initialize-BuildEnvironment {
 
 # Post-checkout clean-up
 function Clear-PostCheckout([string]$SourceFolder) {
-    # Remove tools/ (except tools/clang/ and tools/protoc_wrapper/)
+    # Cleanup temp _tools folder if left over.
+    if (Test-Path "_tools") {
+        Write-Host "Removing temporary _tools directory"
+        Remove-Item -Path "_tools" -Recurse -Force
+    }
+    # Remove tools/* (except tools/clang/ and tools/protoc_wrapper/)
     $toolsFolder = Join-Path $SourceFolder "tools" -Resolve
     Rename-Item -Path $toolsFolder -NewName "_tools"
     $oldToolsFolder = Join-Path $SourceFolder "_tools" -Resolve
     New-Item -Path $toolsFolder -ItemType Directory | Out-Null
     Move-Item -Path $(Join-Path $oldToolsFolder "clang") -Destination $toolsFolder
     Move-Item -Path $(Join-Path $oldToolsFolder "protoc_wrapper") -Destination $toolsFolder
+    Move-Item -Path $(Join-Path $oldToolsFolder "generate_stubs") -Destination $toolsFolder
     Remove-Item -Path $oldToolsFolder -Recurse -Force | Out-Null
 
     # Remove third_party/blink


### PR DESCRIPTION
Dependency of the desktop_capture module, deleting it prevents building win32.