### PR TITLE
Disable SceneVideoSender w/o async GPU readback

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/SceneVideoSender.cs
+++ b/libs/Microsoft.MixedReality.WebRTC.Unity/Assets/Microsoft.MixedReality.WebRTC.Unity/Scripts/Media/SceneVideoSender.cs
@@ -77,6 +77,13 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
         protected new void OnEnable()
         {
+            if (!SystemInfo.supportsAsyncGPUReadback)
+            {
+                Debug.LogError("This platform does not support async GPU readback. Cannot use the SceneVideoSender component.");
+                enabled = false;
+                return;
+            }
+
             // If no camera provided, attempt to fallback to main camera
             if (SourceCamera == null)
             {


### PR DESCRIPTION
Prevent the SceneVideoSender component from being enabled if
asynchronous GPU readback is not supported by the target device. This is
common on Android targets using the OpenGL graphics backend, which has
no support for this feature (and won't ever get it according to Unity).
More recent Android devices can use Vulkan instead, which supports
asynchronous GPU readback.