### PR TITLE
Downgrade mrwebrtc on Android to C++14

### DIFF
--- a/libs/mrwebrtc/include/audio_frame.h
+++ b/libs/mrwebrtc/include/audio_frame.h
@@ -5,7 +5,9 @@
 
 #include <cstdint>
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// View over an existing buffer representing an audio frame, in the sense
 /// of a single group of contiguous audio data.
@@ -29,4 +31,6 @@ struct AudioFrame {
   std::uint32_t sample_count_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/include/data_channel_interop.h
+++ b/libs/mrwebrtc/include/data_channel_interop.h
@@ -23,7 +23,7 @@ mrsDataChannelGetUserData(mrsDataChannelHandle handle) noexcept;
 /// Callback fired when a message |data| of byte size |size| is received on a
 /// data channel.
 using mrsDataChannelMessageCallback = void(
-    MRS_CALL*)(void* user_data, const void* data, const uint64_t size) noexcept;
+    MRS_CALL*)(void* user_data, const void* data, const uint64_t size);
 
 /// Callback invoked when a data channel internal buffering changes.
 /// The |previous| and |current| values are the old and new sizes in bytes of
@@ -34,12 +34,12 @@ using mrsDataChannelBufferingCallback =
     void(MRS_CALL*)(void* user_data,
                     const uint64_t previous,
                     const uint64_t current,
-                    const uint64_t limit) noexcept;
+                    const uint64_t limit);
 
 /// Callback fired when the state of a data channel changed.
 using mrsDataChannelStateCallback = void(MRS_CALL*)(void* user_data,
                                                     int32_t state,
-                                                    int32_t id) noexcept;
+                                                    int32_t id);
 
 /// Helper to register a group of data channel callbacks.
 struct mrsDataChannelCallbacks {

--- a/libs/mrwebrtc/include/export.h
+++ b/libs/mrwebrtc/include/export.h
@@ -15,3 +15,9 @@
 #else
 #error Unknown platform, see export.h
 #endif
+
+#if (__cplusplus >= 201703L)
+#define MRS_NODISCARD [[nodiscard]]
+#else
+#define MRS_NODISCARD
+#endif

--- a/libs/mrwebrtc/include/result.h
+++ b/libs/mrwebrtc/include/result.h
@@ -5,7 +5,9 @@
 
 #include "export.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// Result code from an operation, typically used through the interop layer
 /// instead of a full-featured Error object.
@@ -85,6 +87,8 @@ enum class Result : std::uint32_t {
   kInvalidMediaKind = 0x80000401,
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft
 
 using mrsResult = Microsoft::MixedReality::WebRTC::Result;

--- a/libs/mrwebrtc/include/video_frame.h
+++ b/libs/mrwebrtc/include/video_frame.h
@@ -5,7 +5,9 @@
 
 #include <cstdint>
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// View over an existing buffer representing a video frame encoded in I420
 /// format with an extra Alpha plane for opacity.
@@ -72,4 +74,6 @@ struct Argb32VideoFrame {
   std::int32_t stride_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/audio_frame_observer.cpp
+++ b/libs/mrwebrtc/src/audio_frame_observer.cpp
@@ -6,7 +6,9 @@
 
 #include "audio_frame_observer.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 void AudioFrameObserver::SetCallback(
     AudioFrameReadyCallback callback) noexcept {
@@ -32,4 +34,6 @@ void AudioFrameObserver::OnData(const void* audio_data,
   callback_(frame);
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/audio_frame_observer.cpp
+++ b/libs/mrwebrtc/src/audio_frame_observer.cpp
@@ -12,7 +12,7 @@ namespace WebRTC {
 
 void AudioFrameObserver::SetCallback(
     AudioFrameReadyCallback callback) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   callback_ = std::move(callback);
 }
 
@@ -21,7 +21,7 @@ void AudioFrameObserver::OnData(const void* audio_data,
                                 int sample_rate,
                                 size_t number_of_channels,
                                 size_t number_of_frames) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   if (!callback_) {
     return;
   }

--- a/libs/mrwebrtc/src/audio_frame_observer.h
+++ b/libs/mrwebrtc/src/audio_frame_observer.h
@@ -10,7 +10,9 @@
 #include "audio_frame.h"
 #include "callback.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// Callback fired on newly available audio frame.
 using AudioFrameReadyCallback = Callback<const AudioFrame&>;
@@ -33,4 +35,6 @@ class AudioFrameObserver : public webrtc::AudioTrackSinkInterface {
   std::mutex mutex_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/callback.h
+++ b/libs/mrwebrtc/src/callback.h
@@ -6,7 +6,9 @@
 
 #include "export.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// Wrapper for a static callback with user data.
 /// Usage:
@@ -70,4 +72,6 @@ struct RetCallback {
   }
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/data_channel.cpp
+++ b/libs/mrwebrtc/src/data_channel.cpp
@@ -50,17 +50,17 @@ str DataChannel::label() const {
 }
 
 void DataChannel::SetMessageCallback(MessageCallback callback) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   message_callback_ = callback;
 }
 
 void DataChannel::SetBufferingCallback(BufferingCallback callback) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   buffering_callback_ = callback;
 }
 
 void DataChannel::SetStateCallback(StateCallback callback) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   state_callback_ = callback;
 }
 
@@ -101,7 +101,7 @@ void DataChannel::OnStateChange() noexcept {
 
   // Invoke the StateChanged event
   {
-    auto lock = std::scoped_lock{mutex_};
+    std::lock_guard<std::mutex> lock(mutex_);
     if (state_callback_) {
       auto apiState = apiStateFromRtcState(state);
       state_callback_((int)apiState, data_channel_->id());
@@ -110,14 +110,14 @@ void DataChannel::OnStateChange() noexcept {
 }
 
 void DataChannel::OnMessage(const webrtc::DataBuffer& buffer) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   if (message_callback_) {
     message_callback_(buffer.data.data(), buffer.data.size());
   }
 }
 
 void DataChannel::OnBufferedAmountChange(uint64_t previous_amount) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   if (buffering_callback_) {
     uint64_t current_amount = data_channel_->buffered_amount();
     constexpr uint64_t max_capacity =

--- a/libs/mrwebrtc/src/data_channel.cpp
+++ b/libs/mrwebrtc/src/data_channel.cpp
@@ -15,11 +15,10 @@ using ApiDataState = Microsoft::MixedReality::WebRTC::DataChannel::State;
 inline ApiDataState apiStateFromRtcState(RtcDataState rtcState) {
   // API values have been chosen to match the current WebRTC values. If the
   // later change, this helper must be updated, as API values cannot change.
-  static_assert((int)RtcDataState::kOpen == (int)ApiDataState::kOpen);
-  static_assert((int)RtcDataState::kConnecting ==
-                (int)ApiDataState::kConnecting);
-  static_assert((int)RtcDataState::kClosing == (int)ApiDataState::kClosing);
-  static_assert((int)RtcDataState::kClosed == (int)ApiDataState::kClosed);
+  static_assert((int)RtcDataState::kOpen == (int)ApiDataState::kOpen, "");
+  static_assert((int)RtcDataState::kConnecting == (int)ApiDataState::kConnecting, "");
+  static_assert((int)RtcDataState::kClosing == (int)ApiDataState::kClosing, "");
+  static_assert((int)RtcDataState::kClosed == (int)ApiDataState::kClosed, "");
   return (ApiDataState)rtcState;
 }
 

--- a/libs/mrwebrtc/src/data_channel.cpp
+++ b/libs/mrwebrtc/src/data_channel.cpp
@@ -25,7 +25,9 @@ inline ApiDataState apiStateFromRtcState(RtcDataState rtcState) {
 
 }  // namespace
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 DataChannel::DataChannel(
     PeerConnection* owner,
@@ -124,4 +126,6 @@ void DataChannel::OnBufferedAmountChange(uint64_t previous_amount) noexcept {
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/data_channel.h
+++ b/libs/mrwebrtc/src/data_channel.h
@@ -15,7 +15,9 @@
 // Internal
 #include "interop_api.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class PeerConnection;
 
@@ -148,4 +150,6 @@ class DataChannel : public webrtc::DataChannelObserver {
   void* user_data_{nullptr};
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/data_channel.h
+++ b/libs/mrwebrtc/src/data_channel.h
@@ -85,6 +85,7 @@ class DataChannel : public webrtc::DataChannelObserver {
   MRS_NODISCARD int id() const { return data_channel_->id(); }
 
   MRS_NODISCARD mrsDataChannelConfigFlags flags() const noexcept {
+    mrsDataChannelConfigFlags flags{mrsDataChannelConfigFlags::kNone};
     if (data_channel_->ordered()) {
       flags = flags | mrsDataChannelConfigFlags::kOrdered;
     }

--- a/libs/mrwebrtc/src/data_channel.h
+++ b/libs/mrwebrtc/src/data_channel.h
@@ -73,7 +73,7 @@ class DataChannel : public webrtc::DataChannelObserver {
   /// Remove the data channel from its parent PeerConnection and close it.
   ~DataChannel() override;
 
-  [[nodiscard]] constexpr void* GetUserData() const noexcept {
+  MRS_NODISCARD constexpr void* GetUserData() const noexcept {
     return user_data_;
   }
 
@@ -82,10 +82,9 @@ class DataChannel : public webrtc::DataChannelObserver {
   }
 
   /// Get the unique channel identifier.
-  [[nodiscard]] int id() const { return data_channel_->id(); }
+  MRS_NODISCARD int id() const { return data_channel_->id(); }
 
-  [[nodiscard]] mrsDataChannelConfigFlags flags() const noexcept {
-    mrsDataChannelConfigFlags flags{0};
+  MRS_NODISCARD mrsDataChannelConfigFlags flags() const noexcept {
     if (data_channel_->ordered()) {
       flags = flags | mrsDataChannelConfigFlags::kOrdered;
     }
@@ -96,7 +95,7 @@ class DataChannel : public webrtc::DataChannelObserver {
   }
 
   /// Get the friendly channel name.
-  [[nodiscard]] str label() const;
+  MRS_NODISCARD str label() const;
 
   void SetMessageCallback(MessageCallback callback) noexcept;
   void SetBufferingCallback(BufferingCallback callback) noexcept;
@@ -104,7 +103,7 @@ class DataChannel : public webrtc::DataChannelObserver {
 
   /// Get the maximum buffering size, in bytes, before |Send()| stops accepting
   /// data.
-  [[nodiscard]] size_t GetMaxBufferingSize() const noexcept;
+  MRS_NODISCARD size_t GetMaxBufferingSize() const noexcept;
 
   /// Send a blob of data through the data channel.
   bool Send(const void* data, size_t size) noexcept;
@@ -113,7 +112,7 @@ class DataChannel : public webrtc::DataChannelObserver {
   // Advanced use
   //
 
-  [[nodiscard]] webrtc::DataChannelInterface* impl() const {
+  MRS_NODISCARD webrtc::DataChannelInterface* impl() const {
     return data_channel_.get();
   }
 

--- a/libs/mrwebrtc/src/interop/external_video_track_source_interop.cpp
+++ b/libs/mrwebrtc/src/interop/external_video_track_source_interop.cpp
@@ -166,7 +166,10 @@ struct Argb32InteropVideoSource : Argb32ExternalVideoSource {
 
 }  // namespace
 
-namespace Microsoft::MixedReality::WebRTC::detail {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
+namespace detail {
 
 RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromI420A(
     RefPtr<GlobalFactory> global_factory,
@@ -206,4 +209,7 @@ RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromArgb32(
   return track_source;
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC::detail
+}  // namespace detail
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/interop/global_factory.cpp
+++ b/libs/mrwebrtc/src/interop/global_factory.cpp
@@ -20,7 +20,7 @@ using namespace Microsoft::MixedReality::WebRTC;
 /// Utility to convert an ObjectType to a string, for debugging purpose. This
 /// returns a view over a global constant buffer (static storage), which is
 /// always valid, never deallocated.
-std::string_view ObjectTypeToString(ObjectType type) {
+absl::string_view ObjectTypeToString(ObjectType type) {
   switch (type) {
     case ObjectType::kPeerConnection:
       return "PeerConnection";
@@ -56,7 +56,7 @@ std::string ObjectToString(TrackedObject* obj) {
   rtc::SimpleStringBuilder builder(buffer);
   if (obj) {
     builder << "(";
-    std::string_view sv = ObjectTypeToString(obj->GetObjectType());
+    absl::string_view sv = ObjectTypeToString(obj->GetObjectType());
     builder.Append(sv.data(), sv.length());
     builder << ") " << obj->GetName();
   } else {

--- a/libs/mrwebrtc/src/interop/global_factory.cpp
+++ b/libs/mrwebrtc/src/interop/global_factory.cpp
@@ -67,7 +67,9 @@ std::string ObjectToString(TrackedObject* obj) {
 
 }  // namespace
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 uint32_t GlobalFactory::StaticReportLiveObjects() noexcept {
   // Lock the instance to prevent shutdown if it already exists, while
@@ -374,4 +376,6 @@ void GlobalFactory::ReportLiveObjectsNoLock() {
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/interop/global_factory.h
+++ b/libs/mrwebrtc/src/interop/global_factory.h
@@ -7,7 +7,9 @@
 #include "peer_connection.h"
 #include "utils.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// The global factory is a helper class used to initialize and shutdown the
 /// internal WebRTC library, which adds extra functionalities over a classical
@@ -228,4 +230,6 @@ class GlobalFactory {
   rtc::scoped_refptr<ToggleAudioMixer> custom_audio_mixer_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/interop/global_factory.h
+++ b/libs/mrwebrtc/src/interop/global_factory.h
@@ -91,7 +91,7 @@ class GlobalFactory {
     // pointer to the GlobalFactory (so this reference would never be the last
     // one) or calling |GetLockImpl()| to get a new pointer, which will only
     // call |AddRef()| under the lock too so will block.
-    std::scoped_lock lock(init_mutex_);
+    std::lock_guard<std::mutex> lock(init_mutex_);
     RTC_DCHECK(peer_factory_);
     // Usually this is memory_order_acq_rel, but here the |init_mutex_| forces
     // the necessary memory barrier, so only the atomicity is relevant.

--- a/libs/mrwebrtc/src/interop/interop_api.cpp
+++ b/libs/mrwebrtc/src/interop/interop_api.cpp
@@ -1018,7 +1018,8 @@ T& FindOrInsert(std::vector<std::pair<std::string, T>>& vec,
   if (it != vec.end()) {
     return it->second;
   }
-  return vec.emplace_back(id, T{}).second;
+  vec.emplace_back(id, T{});
+  return vec.back().second;
 }
 
 }  // namespace

--- a/libs/mrwebrtc/src/interop/interop_api.cpp
+++ b/libs/mrwebrtc/src/interop/interop_api.cpp
@@ -820,7 +820,7 @@ mrsResult MRS_CALL mrsPeerConnectionAddDataChannel(
   }
   const bool ordered = (config->flags & mrsDataChannelConfigFlags::kOrdered);
   const bool reliable = (config->flags & mrsDataChannelConfigFlags::kReliable);
-  const std::string_view label = (config->label ? config->label : "");
+  const absl::string_view label = (config->label ? config->label : "");
   ErrorOr<std::shared_ptr<DataChannel>> data_channel =
       peer->AddDataChannel(config->id, label, ordered, reliable);
   if (data_channel.ok()) {
@@ -1012,7 +1012,7 @@ void MRS_CALL mrsMemCpyStride(void* dst,
 namespace {
 template <class T>
 T& FindOrInsert(std::vector<std::pair<std::string, T>>& vec,
-                std::string_view id) {
+                absl::string_view id) {
   auto it = std::find_if(vec.begin(), vec.end(),
                          [&](auto&& pair) { return pair.first == id; });
   if (it != vec.end()) {

--- a/libs/mrwebrtc/src/media/audio_track_read_buffer.cpp
+++ b/libs/mrwebrtc/src/media/audio_track_read_buffer.cpp
@@ -32,7 +32,7 @@ void AudioTrackReadBuffer::audioFrameCallback(const void* audio_data,
   frame.number_of_frames = number_of_frames;
   size_t size =
       (size_t)(bits_per_sample / 8) * number_of_channels * number_of_frames;
-  auto src_bytes = static_cast<const std::byte*>(audio_data);
+  auto src_bytes = static_cast<const std::uint8_t*>(audio_data);
   frame.audio_data.insert(frame.audio_data.begin(), src_bytes,
                           src_bytes + size);
 }

--- a/libs/mrwebrtc/src/media/audio_track_read_buffer.cpp
+++ b/libs/mrwebrtc/src/media/audio_track_read_buffer.cpp
@@ -24,7 +24,8 @@ void AudioTrackReadBuffer::audioFrameCallback(const void* audio_data,
     frames_.pop_front();
   }
   // add the new frame
-  auto& frame = frames_.emplace_back();
+  frames_.emplace_back();
+  auto& frame = frames_.back();
   frame.bits_per_sample = bits_per_sample;
   frame.sample_rate = sample_rate;
   frame.number_of_channels = number_of_channels;

--- a/libs/mrwebrtc/src/media/audio_track_read_buffer.h
+++ b/libs/mrwebrtc/src/media/audio_track_read_buffer.h
@@ -48,7 +48,7 @@ class AudioTrackReadBuffer {
 
   PeerConnection* peer_ = nullptr;
   struct Frame {
-    std::vector<std::byte> audio_data;
+    std::vector<std::uint8_t> audio_data;
     uint32_t bits_per_sample;
     uint32_t sample_rate;
     uint32_t number_of_channels;

--- a/libs/mrwebrtc/src/media/external_video_track_source.cpp
+++ b/libs/mrwebrtc/src/media/external_video_track_source.cpp
@@ -110,7 +110,9 @@ class Argb32BufferAdapter : public detail::BufferAdapter {
 
 }  // namespace
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 namespace detail {
 
 constexpr const size_t kMaxPendingRequestCount = 64;
@@ -317,4 +319,6 @@ Result Argb32VideoFrameRequest::CompleteRequest(
   return impl->CompleteRequest(request_id_, timestamp_ms_, frame_view);
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/external_video_track_source.h
+++ b/libs/mrwebrtc/src/media/external_video_track_source.h
@@ -9,7 +9,9 @@
 #include "tracked_object.h"
 #include "video_frame.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class ExternalVideoTrackSource;
 
@@ -144,4 +146,6 @@ RefPtr<ExternalVideoTrackSource> ExternalVideoTrackSourceCreateFromArgb32(
 
 }  // namespace detail
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/external_video_track_source_impl.h
+++ b/libs/mrwebrtc/src/media/external_video_track_source_impl.h
@@ -9,7 +9,10 @@
 #include "external_video_track_source.h"
 #include "interop_api.h"
 
-namespace Microsoft::MixedReality::WebRTC::detail {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
+namespace detail {
 
 /// Adapater for the frame buffer of an external video track source,
 /// to support various frame encodings in a unified way.
@@ -115,4 +118,7 @@ class ExternalVideoTrackSourceImpl : public ExternalVideoTrackSource,
   std::string name_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC::detail
+}  // namespace detail
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/local_audio_track.cpp
+++ b/libs/mrwebrtc/src/media/local_audio_track.cpp
@@ -7,7 +7,9 @@
 #include "local_audio_track.h"
 #include "peer_connection.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 LocalAudioTrack::LocalAudioTrack(
     RefPtr<GlobalFactory> global_factory,
@@ -122,4 +124,6 @@ void LocalAudioTrack::RemoveFromPeerConnection(
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/local_audio_track.h
+++ b/libs/mrwebrtc/src/media/local_audio_track.h
@@ -66,9 +66,9 @@ class LocalAudioTrack : public AudioFrameObserver, public MediaTrack {
 
   /// Check if the track is enabled.
   /// See |SetEnabled(bool)|.
-  [[nodiscard]] bool IsEnabled() const noexcept;
+  MRS_NODISCARD bool IsEnabled() const noexcept;
 
-  [[nodiscard]] Transceiver* GetTransceiver() const noexcept {
+  MRS_NODISCARD Transceiver* GetTransceiver() const noexcept {
     return transceiver_;
   }
 
@@ -76,10 +76,10 @@ class LocalAudioTrack : public AudioFrameObserver, public MediaTrack {
   // Advanced use
   //
 
-  [[nodiscard]] webrtc::AudioTrackInterface* impl() const;
-  [[nodiscard]] webrtc::RtpSenderInterface* sender() const;
+  MRS_NODISCARD webrtc::AudioTrackInterface* impl() const;
+  MRS_NODISCARD webrtc::RtpSenderInterface* sender() const;
 
-  [[nodiscard]] webrtc::MediaStreamTrackInterface* GetMediaImpl()
+  MRS_NODISCARD webrtc::MediaStreamTrackInterface* GetMediaImpl()
       const override {
     return impl();
   }

--- a/libs/mrwebrtc/src/media/local_audio_track.h
+++ b/libs/mrwebrtc/src/media/local_audio_track.h
@@ -20,7 +20,9 @@ class RtpSenderInterface;
 class AudioTrackInterface;
 }  // namespace webrtc
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class PeerConnection;
 class Transceiver;
@@ -113,4 +115,6 @@ class LocalAudioTrack : public AudioFrameObserver, public MediaTrack {
   const std::string track_name_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/local_video_track.cpp
+++ b/libs/mrwebrtc/src/media/local_video_track.cpp
@@ -7,7 +7,9 @@
 #include "local_video_track.h"
 #include "peer_connection.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 LocalVideoTrack::LocalVideoTrack(
     RefPtr<GlobalFactory> global_factory,
@@ -126,4 +128,6 @@ void LocalVideoTrack::RemoveFromPeerConnection(
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/local_video_track.h
+++ b/libs/mrwebrtc/src/media/local_video_track.h
@@ -20,7 +20,9 @@ class RtpSenderInterface;
 class VideoTrackInterface;
 }  // namespace webrtc
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class PeerConnection;
 class Transceiver;
@@ -111,4 +113,6 @@ class LocalVideoTrack : public VideoFrameObserver, public MediaTrack {
   const std::string track_name_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/local_video_track.h
+++ b/libs/mrwebrtc/src/media/local_video_track.h
@@ -64,9 +64,9 @@ class LocalVideoTrack : public VideoFrameObserver, public MediaTrack {
 
   /// Check if the track is enabled.
   /// See |SetEnabled(bool)|.
-  [[nodiscard]] bool IsEnabled() const noexcept;
+  MRS_NODISCARD bool IsEnabled() const noexcept;
 
-  [[nodiscard]] Transceiver* GetTransceiver() const noexcept {
+  MRS_NODISCARD Transceiver* GetTransceiver() const noexcept {
     return transceiver_;
   }
 
@@ -74,10 +74,10 @@ class LocalVideoTrack : public VideoFrameObserver, public MediaTrack {
   // Advanced use
   //
 
-  [[nodiscard]] webrtc::VideoTrackInterface* impl() const;
-  [[nodiscard]] webrtc::RtpSenderInterface* sender() const;
+  MRS_NODISCARD webrtc::VideoTrackInterface* impl() const;
+  MRS_NODISCARD webrtc::RtpSenderInterface* sender() const;
 
-  [[nodiscard]] webrtc::MediaStreamTrackInterface* GetMediaImpl()
+  MRS_NODISCARD webrtc::MediaStreamTrackInterface* GetMediaImpl()
       const override {
     return impl();
   }

--- a/libs/mrwebrtc/src/media/media_track.cpp
+++ b/libs/mrwebrtc/src/media/media_track.cpp
@@ -7,7 +7,9 @@
 #include "media_track.h"
 #include "peer_connection.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 MediaTrack::MediaTrack(RefPtr<GlobalFactory> global_factory,
                        ObjectType object_type) noexcept
@@ -24,4 +26,6 @@ MediaTrack::~MediaTrack() {
   RTC_CHECK(!owner_);
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/media_track.h
+++ b/libs/mrwebrtc/src/media/media_track.h
@@ -36,9 +36,9 @@ class MediaTrack : public TrackedObject {
   ~MediaTrack() override;
 
   /// Get the kind of track.
-  [[nodiscard]] mrsTrackKind GetKind() const noexcept { return kind_; }
+  MRS_NODISCARD mrsTrackKind GetKind() const noexcept { return kind_; }
 
-  [[nodiscard]] virtual webrtc::MediaStreamTrackInterface* GetMediaImpl()
+  MRS_NODISCARD virtual webrtc::MediaStreamTrackInterface* GetMediaImpl()
       const = 0;
 
  protected:

--- a/libs/mrwebrtc/src/media/media_track.h
+++ b/libs/mrwebrtc/src/media/media_track.h
@@ -19,7 +19,9 @@ class RtpSenderInterface;
 class VideoTrackInterface;
 }  // namespace webrtc
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class PeerConnection;
 
@@ -47,4 +49,6 @@ class MediaTrack : public TrackedObject {
   mrsTrackKind kind_ = mrsTrackKind::kUnknownTrack;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/remote_audio_track.cpp
+++ b/libs/mrwebrtc/src/media/remote_audio_track.cpp
@@ -7,7 +7,9 @@
 #include "media/remote_audio_track.h"
 #include "peer_connection.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 RemoteAudioTrack::RemoteAudioTrack(
     RefPtr<GlobalFactory> global_factory,
@@ -74,4 +76,6 @@ void RemoteAudioTrack::InitSsrc(int ssrc) {
   global_factory_->audio_mixer()->OutputSource(ssrc, output_to_device_);
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/remote_audio_track.h
+++ b/libs/mrwebrtc/src/media/remote_audio_track.h
@@ -21,7 +21,9 @@ class RtpReceiverInterface;
 class AudioTrackInterface;
 }  // namespace webrtc
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class PeerConnection;
 class Transceiver;
@@ -115,4 +117,6 @@ class RemoteAudioTrack : public AudioFrameObserver, public MediaTrack {
   bool output_to_device_{true};
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/remote_audio_track.h
+++ b/libs/mrwebrtc/src/media/remote_audio_track.h
@@ -54,13 +54,13 @@ class RemoteAudioTrack : public AudioFrameObserver, public MediaTrack {
 
   /// Check if the track is enabled.
   /// See |SetEnabled(bool)|.
-  [[nodiscard]] bool IsEnabled() const noexcept { return track_->enabled(); }
+  MRS_NODISCARD bool IsEnabled() const noexcept { return track_->enabled(); }
 
   /// See |mrsRemoteAudioOutputToDevice|.
   void OutputToDevice(bool output) noexcept;
 
   /// See |mrsRemoteAudioTrackIsOutputToDevice|.
-  [[nodiscard]] bool IsOutputToDevice() const noexcept {
+  MRS_NODISCARD bool IsOutputToDevice() const noexcept {
     return output_to_device_;
   }
 
@@ -71,18 +71,18 @@ class RemoteAudioTrack : public AudioFrameObserver, public MediaTrack {
   /// Get a handle to the remote audio track. This handle is valid until the
   /// remote track is removed from the peer connection and destroyed, which is
   /// signaled by the |TrackRemoved| event on the peer connection.
-  [[nodiscard]] constexpr mrsRemoteAudioTrackHandle GetHandle() const noexcept {
+  MRS_NODISCARD constexpr mrsRemoteAudioTrackHandle GetHandle() const noexcept {
     return (mrsRemoteAudioTrackHandle)this;
   }
 
-  [[nodiscard]] webrtc::AudioTrackInterface* impl() const;
-  [[nodiscard]] webrtc::RtpReceiverInterface* receiver() const;
+  MRS_NODISCARD webrtc::AudioTrackInterface* impl() const;
+  MRS_NODISCARD webrtc::RtpReceiverInterface* receiver() const;
 
-  [[nodiscard]] constexpr Transceiver* GetTransceiver() const {
+  MRS_NODISCARD constexpr Transceiver* GetTransceiver() const {
     return transceiver_;
   }
 
-  [[nodiscard]] webrtc::MediaStreamTrackInterface* GetMediaImpl()
+  MRS_NODISCARD webrtc::MediaStreamTrackInterface* GetMediaImpl()
       const override {
     return impl();
   }

--- a/libs/mrwebrtc/src/media/remote_video_track.cpp
+++ b/libs/mrwebrtc/src/media/remote_video_track.cpp
@@ -7,7 +7,9 @@
 #include "peer_connection.h"
 #include "remote_video_track.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 RemoteVideoTrack::RemoteVideoTrack(
     RefPtr<GlobalFactory> global_factory,
@@ -65,4 +67,6 @@ void RemoteVideoTrack::OnTrackRemoved(PeerConnection& owner) {
   transceiver_ = nullptr;
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/remote_video_track.h
+++ b/libs/mrwebrtc/src/media/remote_video_track.h
@@ -20,7 +20,9 @@ class RtpReceiverInterface;
 class VideoTrackInterface;
 }  // namespace webrtc
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class PeerConnection;
 class Transceiver;
@@ -96,4 +98,6 @@ class RemoteVideoTrack : public VideoFrameObserver, public MediaTrack {
   const std::string track_name_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/remote_video_track.h
+++ b/libs/mrwebrtc/src/media/remote_video_track.h
@@ -53,7 +53,7 @@ class RemoteVideoTrack : public VideoFrameObserver, public MediaTrack {
 
   /// Check if the track is enabled.
   /// See |SetEnabled(bool)|.
-  [[nodiscard]] bool IsEnabled() const noexcept;
+  MRS_NODISCARD bool IsEnabled() const noexcept;
 
   //
   // Advanced use
@@ -62,18 +62,18 @@ class RemoteVideoTrack : public VideoFrameObserver, public MediaTrack {
   /// Get a handle to the remote video track. This handle is valid until the
   /// remote track is removed from the peer connection and destroyed, which is
   /// signaled by the |TrackRemoved| event on the peer connection.
-  [[nodiscard]] constexpr mrsRemoteVideoTrackHandle GetHandle() const noexcept {
+  MRS_NODISCARD constexpr mrsRemoteVideoTrackHandle GetHandle() const noexcept {
     return (mrsRemoteVideoTrackHandle)this;
   }
 
-  [[nodiscard]] webrtc::VideoTrackInterface* impl() const;
-  [[nodiscard]] webrtc::RtpReceiverInterface* receiver() const;
+  MRS_NODISCARD webrtc::VideoTrackInterface* impl() const;
+  MRS_NODISCARD webrtc::RtpReceiverInterface* receiver() const;
 
-  [[nodiscard]] constexpr Transceiver* GetTransceiver() const {
+  MRS_NODISCARD constexpr Transceiver* GetTransceiver() const {
     return transceiver_;
   }
 
-  [[nodiscard]] webrtc::MediaStreamTrackInterface* GetMediaImpl()
+  MRS_NODISCARD webrtc::MediaStreamTrackInterface* GetMediaImpl()
       const override {
     return impl();
   }

--- a/libs/mrwebrtc/src/media/transceiver.cpp
+++ b/libs/mrwebrtc/src/media/transceiver.cpp
@@ -320,7 +320,7 @@ Transceiver::Direction Transceiver::FromRtp(
 }
 
 Transceiver::OptDirection Transceiver::FromRtp(
-    std::optional<webrtc::RtpTransceiverDirection> rtp_direction) {
+    absl::optional<webrtc::RtpTransceiverDirection> rtp_direction) {
   using RtpDir = webrtc::RtpTransceiverDirection;
   static_assert((int)OptDirection::kSendRecv == (int)RtpDir::kSendRecv, "");
   static_assert((int)OptDirection::kSendOnly == (int)RtpDir::kSendOnly, "");

--- a/libs/mrwebrtc/src/media/transceiver.cpp
+++ b/libs/mrwebrtc/src/media/transceiver.cpp
@@ -8,7 +8,9 @@
 #include "transceiver.h"
 #include "utils.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 struct Transceiver::PlanBEmulation {
   /// RTP sender, indicating that the transceiver wants to send and/or is
@@ -524,4 +526,6 @@ void Transceiver::FireStateUpdatedEvent(
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/transceiver.cpp
+++ b/libs/mrwebrtc/src/media/transceiver.cpp
@@ -467,7 +467,7 @@ void Transceiver::OnAssociated(int mline_index) {
   // once, from their initial non-associated state.
   assert(mline_index_ < 0);
   mline_index_ = mline_index;
-  auto lock = std::scoped_lock{cb_mutex_};
+  std::lock_guard<std::mutex> lock(cb_mutex_);
   if (auto cb = associated_callback_) {
     cb(mline_index);
   }
@@ -520,7 +520,7 @@ void Transceiver::OnSessionDescUpdated(bool remote, bool forced) {
 
 void Transceiver::FireStateUpdatedEvent(
     mrsTransceiverStateUpdatedReason reason) {
-  auto lock = std::scoped_lock{cb_mutex_};
+  std::lock_guard<std::mutex> lock(cb_mutex_);
   if (auto cb = state_updated_callback_) {
     cb(reason, direction_, desired_direction_);
   }

--- a/libs/mrwebrtc/src/media/transceiver.h
+++ b/libs/mrwebrtc/src/media/transceiver.h
@@ -20,7 +20,9 @@ namespace webrtc {
 class RtpTransceiverInterface;
 }
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class PeerConnection;
 
@@ -346,4 +348,6 @@ class Transceiver : public TrackedObject {
   std::mutex cb_mutex_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/transceiver.h
+++ b/libs/mrwebrtc/src/media/transceiver.h
@@ -60,9 +60,9 @@ class Transceiver : public TrackedObject {
   ~Transceiver() override;
 
   /// Get the transceiver name, for debugging and logging purpose only.
-  [[nodiscard]] std::string GetName() const override { return name_; }
+  MRS_NODISCARD std::string GetName() const override { return name_; }
 
-  [[nodiscard]] constexpr int GetMlineIndex() const noexcept {
+  MRS_NODISCARD constexpr int GetMlineIndex() const noexcept {
     return mline_index_;
   }
 
@@ -70,15 +70,15 @@ class Transceiver : public TrackedObject {
   /// type to static_cast<> a |Transceiver| pointer to. If this is |kAudio| then
   /// the object is an |AudioTransceiver| instance, and if this is |kVideo| then
   /// the object is a |VideoTransceiver| instance.
-  [[nodiscard]] MediaKind GetMediaKind() const noexcept { return kind_; }
+  MRS_NODISCARD MediaKind GetMediaKind() const noexcept { return kind_; }
 
   /// Get the desired transceiver direction.
-  [[nodiscard]] Direction GetDesiredDirection() const noexcept {
+  MRS_NODISCARD Direction GetDesiredDirection() const noexcept {
     return desired_direction_;
   }
 
   /// Get the current transceiver direction.
-  [[nodiscard]] OptDirection GetDirection() const noexcept {
+  MRS_NODISCARD OptDirection GetDirection() const noexcept {
     return direction_;
   }
 
@@ -86,15 +86,15 @@ class Transceiver : public TrackedObject {
   /// offers/answers.
   Result SetDirection(Direction new_direction) noexcept;
 
-  [[nodiscard]] bool IsUnifiedPlan() const {
+  MRS_NODISCARD bool IsUnifiedPlan() const {
     RTC_DCHECK(!plan_b_ != !transceiver_);
     return (transceiver_ != nullptr);
   }
 
-  [[nodiscard]] bool IsPlanB() const { return !IsUnifiedPlan(); }
+  MRS_NODISCARD bool IsPlanB() const { return !IsUnifiedPlan(); }
 
-  [[nodiscard]] bool HasSender(webrtc::RtpSenderInterface* sender) const;
-  [[nodiscard]] bool HasReceiver(webrtc::RtpReceiverInterface* receiver) const;
+  MRS_NODISCARD bool HasSender(webrtc::RtpSenderInterface* sender) const;
+  MRS_NODISCARD bool HasReceiver(webrtc::RtpReceiverInterface* receiver) const;
 
   Result SetLocalTrack(std::nullptr_t) noexcept {
     return SetLocalTrackImpl(nullptr);
@@ -122,7 +122,7 @@ class Transceiver : public TrackedObject {
     return static_cast<LocalVideoTrack*>(local_track_.get());
   }
 
-  [[nodiscard]] MediaTrack* GetRemoteTrack() const {
+  MRS_NODISCARD MediaTrack* GetRemoteTrack() const {
     return remote_track_.get();
   }
 
@@ -182,11 +182,11 @@ class Transceiver : public TrackedObject {
   /// handle is valid until the transceiver is removed from the peer
   /// connection and destroyed, which happens during
   /// |PeerConnection::Close()|.
-  [[nodiscard]] constexpr mrsTransceiverHandle GetHandle() const noexcept {
+  MRS_NODISCARD constexpr mrsTransceiverHandle GetHandle() const noexcept {
     return (mrsTransceiverHandle)this;
   }
 
-  [[nodiscard]] rtc::scoped_refptr<webrtc::RtpTransceiverInterface> impl()
+  MRS_NODISCARD rtc::scoped_refptr<webrtc::RtpTransceiverInterface> impl()
       const;
 
   /// Synchronize the RTP sender with the desired direction when using Plan B.
@@ -223,35 +223,34 @@ class Transceiver : public TrackedObject {
   /// any is registered.
   void FireStateUpdatedEvent(mrsTransceiverStateUpdatedReason reason);
 
-  [[nodiscard]] static webrtc::RtpTransceiverDirection ToRtp(
+  MRS_NODISCARD static webrtc::RtpTransceiverDirection ToRtp(
       Direction direction);
-  [[nodiscard]] static Direction FromRtp(
+  MRS_NODISCARD static Direction FromRtp(
       webrtc::RtpTransceiverDirection rtp_direction);
-  [[nodiscard]] static OptDirection FromRtp(
-      std::optional<webrtc::RtpTransceiverDirection> rtp_direction);
-  [[nodiscard]] static Direction FromSendRecv(bool send, bool recv);
-  [[nodiscard]] static OptDirection OptFromSendRecv(bool send, bool recv);
+  MRS_NODISCARD static OptDirection FromRtp(
+  MRS_NODISCARD static Direction FromSendRecv(bool send, bool recv);
+  MRS_NODISCARD static OptDirection OptFromSendRecv(bool send, bool recv);
 
   /// Decode an encode stream ID string into the individual stream IDs.
   /// This is conceptually equivalent to a split(str, ';').
-  [[nodiscard]] static std::vector<std::string> DecodeStreamIDs(
+  MRS_NODISCARD static std::vector<std::string> DecodeStreamIDs(
       const char* encoded_stream_ids);
 
   /// Encode a list of stream IDs into a semi-colon separated string.
   /// This is conceptually equivalent to a join(str, ';').
-  [[nodiscard]] static std::string EncodeStreamIDs(
+  MRS_NODISCARD static std::string EncodeStreamIDs(
       const std::vector<std::string>& stream_ids);
 
   /// Build the encoded string used as the (single) stream ID of a Plan B
   /// track, which contains the media line index of the emulated transceiver
   /// as well as a list of stream IDs, to emulate the properties of Unified
   /// Plan.
-  [[nodiscard]] std::string BuildEncodedStreamIDForPlanB(int mline_index) const;
+  MRS_NODISCARD std::string BuildEncodedStreamIDForPlanB(int mline_index) const;
 
   /// Decode the string encoded by |BuildEncodedStreamIDForPlanB()|, and
   /// return in addition the encoded media line index string into |name| to be
   /// used as the transceiver name.
-  [[nodiscard]] static bool DecodedStreamIDForPlanB(
+  MRS_NODISCARD static bool DecodedStreamIDForPlanB(
       const std::string& encoded_string,
       int& mline_index_out,
       std::string& name,

--- a/libs/mrwebrtc/src/media/transceiver.h
+++ b/libs/mrwebrtc/src/media/transceiver.h
@@ -228,6 +228,7 @@ class Transceiver : public TrackedObject {
   MRS_NODISCARD static Direction FromRtp(
       webrtc::RtpTransceiverDirection rtp_direction);
   MRS_NODISCARD static OptDirection FromRtp(
+      absl::optional<webrtc::RtpTransceiverDirection> rtp_direction);
   MRS_NODISCARD static Direction FromSendRecv(bool send, bool recv);
   MRS_NODISCARD static OptDirection OptFromSendRecv(bool send, bool recv);
 

--- a/libs/mrwebrtc/src/media/transceiver.h
+++ b/libs/mrwebrtc/src/media/transceiver.h
@@ -158,7 +158,7 @@ class Transceiver : public TrackedObject {
   using AssociatedCallback = Callback<int>;
 
   void RegisterAssociatedCallback(AssociatedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{cb_mutex_};
+    std::lock_guard<std::mutex> lock(cb_mutex_);
     associated_callback_ = std::move(callback);
   }
 
@@ -168,7 +168,7 @@ class Transceiver : public TrackedObject {
       Callback<mrsTransceiverStateUpdatedReason, OptDirection, Direction>;
 
   void RegisterStateUpdatedCallback(StateUpdatedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{cb_mutex_};
+    std::lock_guard<std::mutex> lock(cb_mutex_);
     state_updated_callback_ = std::move(callback);
   }
 

--- a/libs/mrwebrtc/src/mrs_errors.cpp
+++ b/libs/mrwebrtc/src/mrs_errors.cpp
@@ -6,7 +6,9 @@
 #include "interop_api.h"
 #include "mrs_errors.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 Error::Error(Error&& other) = default;
 Error& Error::operator=(Error&& other) = default;
@@ -49,4 +51,6 @@ std::string_view ToString(Result code) {
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/mrs_errors.cpp
+++ b/libs/mrwebrtc/src/mrs_errors.cpp
@@ -25,7 +25,7 @@ void Error::set_message(std::string message) {
   message_ = std::move(message);
 }
 
-std::string_view ToString(Result code) {
+absl::string_view ToString(Result code) {
   switch (code) {
     case Result::kSuccess:
       return "Success";

--- a/libs/mrwebrtc/src/mrs_errors.h
+++ b/libs/mrwebrtc/src/mrs_errors.h
@@ -8,7 +8,9 @@
 #include "export.h"
 #include "result.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// Full-featured error object, containing an error code and a message.
 ///
@@ -133,4 +135,6 @@ class ErrorOr {
   T value_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/pch.h
+++ b/libs/mrwebrtc/src/pch.h
@@ -31,6 +31,10 @@
 #define WEBRTC_POSIX 1
 #define WEBRTC_ANDROID 1
 
+#else
+
+#error Unknown platform
+
 #endif
 
 #if (__cplusplus >= 201703L)

--- a/libs/mrwebrtc/src/pch.h
+++ b/libs/mrwebrtc/src/pch.h
@@ -8,7 +8,6 @@
 #include <functional>
 #include <mutex>
 #include <string>
-#include <string_view>
 #include <unordered_set>
 
 #if defined(MR_SHARING_WIN)

--- a/libs/mrwebrtc/src/pch.h
+++ b/libs/mrwebrtc/src/pch.h
@@ -37,12 +37,6 @@
 
 #endif
 
-#if (__cplusplus >= 201703L)
-#define MRS_NODISCARD [[nodiscard]]
-#else
-#define MRS_NODISCARD
-#endif
-
 // Prevent external headers from triggering warnings that would break compiling
 // due to warning-as-error.
 #pragma warning(push, 2)

--- a/libs/mrwebrtc/src/pch.h
+++ b/libs/mrwebrtc/src/pch.h
@@ -33,6 +33,12 @@
 
 #endif
 
+#if (__cplusplus >= 201703L)
+#define MRS_NODISCARD [[nodiscard]]
+#else
+#define MRS_NODISCARD
+#endif
+
 // Prevent external headers from triggering warnings that would break compiling
 // due to warning-as-error.
 #pragma warning(push, 2)

--- a/libs/mrwebrtc/src/peer_connection.cpp
+++ b/libs/mrwebrtc/src/peer_connection.cpp
@@ -1093,7 +1093,7 @@ ErrorOr<Transceiver*> PeerConnection::GetOrCreateTransceiverForNewRemoteTrack(
     rtc::scoped_refptr<webrtc::RtpTransceiverInterface> impl = *it_impl;
     const int mline_index = ExtractMlineIndexFromRtpTransceiver(impl);
     RTC_DCHECK(mline_index >= 0);  // should be always associated here
-    std::optional<std::string> mid = impl->mid();
+    absl::optional<std::string> mid = impl->mid();
     RTC_CHECK(mid.has_value());  // should be always true here
     std::string name = mid.value();
     std::vector<std::string> stream_ids =

--- a/libs/mrwebrtc/src/peer_connection.cpp
+++ b/libs/mrwebrtc/src/peer_connection.cpp
@@ -275,7 +275,7 @@ namespace WebRTC {
 
 ErrorOr<std::shared_ptr<DataChannel>> PeerConnection::AddDataChannel(
     int id,
-    std::string_view label,
+    absl::string_view label,
     bool ordered,
     bool reliable) noexcept {
   if (IsClosed()) {

--- a/libs/mrwebrtc/src/peer_connection.cpp
+++ b/libs/mrwebrtc/src/peer_connection.cpp
@@ -104,19 +104,27 @@ bool IsHololens() {
 
 }  // namespace
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 void PeerConnection::SetFrameHeightRoundMode(FrameHeightRoundMode value) {
   if (IsHololens()) {
     webrtc__WinUWPH264EncoderImpl__frame_height_round_mode = (int)value;
   }
 }
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft
 
 #else
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 void PeerConnection::SetFrameHeightRoundMode(FrameHeightRoundMode /*value*/) {}
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft
 
 #endif
 
@@ -261,7 +269,9 @@ webrtc::PeerConnectionInterface::BundlePolicy BundlePolicyToNative(
 
 }  // namespace
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 ErrorOr<std::shared_ptr<DataChannel>> PeerConnection::AddDataChannel(
     int id,
@@ -1340,4 +1350,6 @@ PeerConnection::PeerConnection(RefPtr<GlobalFactory> global_factory)
     : TrackedObject(std::move(global_factory), ObjectType::kPeerConnection),
       audio_mixer_(global_factory_->audio_mixer()) {}
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/peer_connection.cpp
+++ b/libs/mrwebrtc/src/peer_connection.cpp
@@ -222,14 +222,16 @@ mrsIceConnectionState IceStateFromImpl(
     webrtc::PeerConnectionInterface::IceConnectionState impl_state) {
   using Native = mrsIceConnectionState;
   using Impl = webrtc::PeerConnectionInterface::IceConnectionState;
-  static_assert((int)Native::kNew == (int)Impl::kIceConnectionNew);
-  static_assert((int)Native::kChecking == (int)Impl::kIceConnectionChecking);
-  static_assert((int)Native::kConnected == (int)Impl::kIceConnectionConnected);
-  static_assert((int)Native::kCompleted == (int)Impl::kIceConnectionCompleted);
-  static_assert((int)Native::kFailed == (int)Impl::kIceConnectionFailed);
-  static_assert((int)Native::kDisconnected ==
-                (int)Impl::kIceConnectionDisconnected);
-  static_assert((int)Native::kClosed == (int)Impl::kIceConnectionClosed);
+  static_assert((int)Native::kNew == (int)Impl::kIceConnectionNew, "");
+  static_assert((int)Native::kChecking == (int)Impl::kIceConnectionChecking,
+                "");
+  static_assert((int)Native::kConnected == (int)Impl::kIceConnectionConnected,
+                "");
+  static_assert((int)Native::kCompleted == (int)Impl::kIceConnectionCompleted,
+                "");
+  static_assert((int)Native::kFailed == (int)Impl::kIceConnectionFailed, "");
+  static_assert((int)Native::kDisconnected == (int)Impl::kIceConnectionDisconnected, "");
+  static_assert((int)Native::kClosed == (int)Impl::kIceConnectionClosed, "");
   return (mrsIceConnectionState)impl_state;
 }
 
@@ -240,9 +242,10 @@ mrsIceGatheringState IceGatheringStateFromImpl(
     webrtc::PeerConnectionInterface::IceGatheringState impl_state) {
   using Native = mrsIceGatheringState;
   using Impl = webrtc::PeerConnectionInterface::IceGatheringState;
-  static_assert((int)Native::kNew == (int)Impl::kIceGatheringNew);
-  static_assert((int)Native::kGathering == (int)Impl::kIceGatheringGathering);
-  static_assert((int)Native::kComplete == (int)Impl::kIceGatheringComplete);
+  static_assert((int)Native::kNew == (int)Impl::kIceGatheringNew, "");
+  static_assert((int)Native::kGathering == (int)Impl::kIceGatheringGathering,
+                "");
+  static_assert((int)Native::kComplete == (int)Impl::kIceGatheringComplete, "");
   return (mrsIceGatheringState)impl_state;
 }
 
@@ -250,10 +253,10 @@ webrtc::PeerConnectionInterface::IceTransportsType ICETransportTypeToNative(
     mrsIceTransportType value) {
   using Native = webrtc::PeerConnectionInterface::IceTransportsType;
   using Impl = mrsIceTransportType;
-  static_assert((int)Native::kNone == (int)Impl::kNone);
-  static_assert((int)Native::kNoHost == (int)Impl::kNoHost);
-  static_assert((int)Native::kRelay == (int)Impl::kRelay);
-  static_assert((int)Native::kAll == (int)Impl::kAll);
+  static_assert((int)Native::kNone == (int)Impl::kNone, "");
+  static_assert((int)Native::kNoHost == (int)Impl::kNoHost, "");
+  static_assert((int)Native::kRelay == (int)Impl::kRelay, "");
+  static_assert((int)Native::kAll == (int)Impl::kAll, "");
   return static_cast<Native>(value);
 }
 
@@ -261,9 +264,11 @@ webrtc::PeerConnectionInterface::BundlePolicy BundlePolicyToNative(
     mrsBundlePolicy value) {
   using Native = webrtc::PeerConnectionInterface::BundlePolicy;
   using Impl = mrsBundlePolicy;
-  static_assert((int)Native::kBundlePolicyBalanced == (int)Impl::kBalanced);
-  static_assert((int)Native::kBundlePolicyMaxBundle == (int)Impl::kMaxBundle);
-  static_assert((int)Native::kBundlePolicyMaxCompat == (int)Impl::kMaxCompat);
+  static_assert((int)Native::kBundlePolicyBalanced == (int)Impl::kBalanced, "");
+  static_assert((int)Native::kBundlePolicyMaxBundle == (int)Impl::kMaxBundle,
+                "");
+  static_assert((int)Native::kBundlePolicyMaxCompat == (int)Impl::kMaxCompat,
+                "");
   return static_cast<Native>(value);
 }
 

--- a/libs/mrwebrtc/src/peer_connection.cpp
+++ b/libs/mrwebrtc/src/peer_connection.cpp
@@ -316,7 +316,7 @@ ErrorOr<std::shared_ptr<DataChannel>> PeerConnection::AddDataChannel(
         data_channel_from_label_.emplace(std::move(labelString), data_channel);
       }
       if (config.id >= 0) {
-        data_channel_from_id_.try_emplace(config.id, data_channel);
+        data_channel_from_id_.emplace(config.id, data_channel);
       }
     }
 
@@ -829,7 +829,7 @@ void PeerConnection::OnDataChannel(
       config.label = it->first.c_str();
     }
     if (data_channel->id() >= 0) {
-      data_channel_from_id_.try_emplace(data_channel->id(), data_channel);
+      data_channel_from_id_.emplace(data_channel->id(), data_channel);
     }
   }
 

--- a/libs/mrwebrtc/src/peer_connection.h
+++ b/libs/mrwebrtc/src/peer_connection.h
@@ -106,7 +106,7 @@ class PeerConnection : public TrackedObject,
   /// Only one callback can be registered at a time.
   void RegisterLocalSdpReadytoSendCallback(
       LocalSdpReadytoSendCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{local_sdp_ready_to_send_callback_mutex_};
+    std::lock_guard<std::mutex> lock(local_sdp_ready_to_send_callback_mutex_);
     local_sdp_ready_to_send_callback_ = std::move(callback);
   }
 
@@ -122,7 +122,8 @@ class PeerConnection : public TrackedObject,
   /// registered at a time.
   void RegisterIceCandidateReadytoSendCallback(
       IceCandidateReadytoSendCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{ice_candidate_ready_to_send_callback_mutex_};
+    std::lock_guard<std::mutex> lock(
+        ice_candidate_ready_to_send_callback_mutex_);
     ice_candidate_ready_to_send_callback_ = std::move(callback);
   }
 
@@ -136,7 +137,7 @@ class PeerConnection : public TrackedObject,
   /// ICE connection changed. Only one callback can be registered at a time.
   void RegisterIceStateChangedCallback(
       IceStateChangedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{ice_state_changed_callback_mutex_};
+    std::lock_guard<std::mutex> lock(ice_state_changed_callback_mutex_);
     ice_state_changed_callback_ = std::move(callback);
   }
 
@@ -148,7 +149,8 @@ class PeerConnection : public TrackedObject,
   /// time.
   void RegisterIceGatheringStateChangedCallback(
       IceGatheringStateChangedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{ice_gathering_state_changed_callback_mutex_};
+    std::lock_guard<std::mutex> lock(
+        ice_gathering_state_changed_callback_mutex_);
     ice_gathering_state_changed_callback_ = std::move(callback);
   }
 
@@ -167,7 +169,7 @@ class PeerConnection : public TrackedObject,
   /// renegotiation is needed. Only one callback can be registered at a time.
   void RegisterRenegotiationNeededCallback(
       RenegotiationNeededCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{renegotiation_needed_callback_mutex_};
+    std::lock_guard<std::mutex> lock(renegotiation_needed_callback_mutex_);
     renegotiation_needed_callback_ = std::move(callback);
   }
 
@@ -204,7 +206,7 @@ class PeerConnection : public TrackedObject,
   /// Register a custom |ConnectedCallback| invoked when the connection is
   /// established. Only one callback can be registered at a time.
   void RegisterConnectedCallback(ConnectedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{connected_callback_mutex_};
+    std::lock_guard<std::mutex> lock(connected_callback_mutex_);
     connected_callback_ = std::move(callback);
   }
 
@@ -249,7 +251,7 @@ class PeerConnection : public TrackedObject,
   /// time.
   void RegisterTransceiverAddedCallback(
       TransceiverAddedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{callbacks_mutex_};
+    std::lock_guard<std::mutex> lock(callbacks_mutex_);
     transceiver_added_callback_ = std::move(callback);
   }
 
@@ -272,7 +274,7 @@ class PeerConnection : public TrackedObject,
   /// at a time.
   void RegisterVideoTrackAddedCallback(
       VideoTrackAddedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{media_track_callback_mutex_};
+    std::lock_guard<std::mutex> lock(media_track_callback_mutex_);
     video_track_added_callback_ = std::move(callback);
   }
 
@@ -286,7 +288,7 @@ class PeerConnection : public TrackedObject,
   /// registered at a time.
   void RegisterVideoTrackRemovedCallback(
       VideoTrackRemovedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{media_track_callback_mutex_};
+    std::lock_guard<std::mutex> lock(media_track_callback_mutex_);
     video_track_removed_callback_ = std::move(callback);
   }
 
@@ -331,7 +333,7 @@ class PeerConnection : public TrackedObject,
   /// registered at a time.
   void RegisterAudioTrackAddedCallback(
       AudioTrackAddedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{media_track_callback_mutex_};
+    std::lock_guard<std::mutex> lock(media_track_callback_mutex_);
     audio_track_added_callback_ = std::move(callback);
   }
 
@@ -345,7 +347,7 @@ class PeerConnection : public TrackedObject,
   /// registered at a time.
   void RegisterAudioTrackRemovedCallback(
       AudioTrackRemovedCallback&& callback) noexcept {
-    auto lock = std::scoped_lock{media_track_callback_mutex_};
+    std::lock_guard<std::mutex> lock(media_track_callback_mutex_);
     audio_track_removed_callback_ = std::move(callback);
   }
 
@@ -366,7 +368,7 @@ class PeerConnection : public TrackedObject,
   /// registered at a time.
   void RegisterDataChannelAddedCallback(
       DataChannelAddedCallback callback) noexcept {
-    auto lock = std::scoped_lock{data_channel_added_callback_mutex_};
+    std::lock_guard<std::mutex> lock(data_channel_added_callback_mutex_);
     data_channel_added_callback_ = std::move(callback);
   }
 
@@ -375,7 +377,7 @@ class PeerConnection : public TrackedObject,
   /// time.
   void RegisterDataChannelRemovedCallback(
       DataChannelRemovedCallback callback) noexcept {
-    auto lock = std::scoped_lock{data_channel_removed_callback_mutex_};
+    std::lock_guard<std::mutex> lock(data_channel_removed_callback_mutex_);
     data_channel_removed_callback_ = std::move(callback);
   }
 
@@ -762,7 +764,7 @@ class PeerConnection : public TrackedObject,
     // Invoke the TrackAdded callback, which will set the native handle on the
     // interop wrapper (if created above)
     {
-      auto lock = std::scoped_lock{media_track_callback_mutex_};
+      std::lock_guard<std::mutex> lock(media_track_callback_mutex_);
       // Read the function pointer inside the lock to avoid race condition
       auto cb = *track_added_cb;
       if (cb) {
@@ -804,7 +806,7 @@ class PeerConnection : public TrackedObject,
 
     // Invoke the TrackRemoved callback
     {
-      auto lock = std::scoped_lock{media_track_callback_mutex_};
+      std::lock_guard<std::mutex> lock(media_track_callback_mutex_);
       // Read the function pointer inside the lock to avoid race condition
       auto cb = *track_removed_cb;
       if (cb) {

--- a/libs/mrwebrtc/src/peer_connection.h
+++ b/libs/mrwebrtc/src/peer_connection.h
@@ -81,7 +81,9 @@ class PeerConnection : public TrackedObject,
 
   /// Set the name of the peer connection. This is a friendly name opaque to the
   /// implementation, used mainly for debugging and logging.
-  void SetName(std::string_view name) { name_ = name; }
+  void SetName(absl::string_view name) {
+    name_.assign(name.data(), name.size());
+  }
 
   std::string GetName() const override { return name_; }
 
@@ -384,7 +386,7 @@ class PeerConnection : public TrackedObject,
   /// Create a new data channel and add it to the peer connection.
   /// This invokes the DataChannelAdded callback.
   ErrorOr<std::shared_ptr<DataChannel>> AddDataChannel(int id,
-                                                       std::string_view label,
+                                                       absl::string_view label,
                                                        bool ordered,
                                                        bool reliable) noexcept;
 

--- a/libs/mrwebrtc/src/peer_connection.h
+++ b/libs/mrwebrtc/src/peer_connection.h
@@ -30,13 +30,13 @@ struct BitrateSettings {
   /// Start bitrate in bits per seconds when the connection is established.
   /// After that the connection will monitor the network bandwidth and media
   /// quality, and automatically adjust the bitrate.
-  std::optional<int> start_bitrate_bps;
+  absl::optional<int> start_bitrate_bps;
 
   /// Minimum bitrate in bits per seconds.
-  std::optional<int> min_bitrate_bps;
+  absl::optional<int> min_bitrate_bps;
 
   /// Maximum bitrate in bits per seconds.
-  std::optional<int> max_bitrate_bps;
+  absl::optional<int> max_bitrate_bps;
 };
 
 /// The PeerConnection class is the entry point to most of WebRTC.

--- a/libs/mrwebrtc/src/peer_connection.h
+++ b/libs/mrwebrtc/src/peer_connection.h
@@ -15,7 +15,9 @@
 #include "utils.h"
 #include "video_frame_observer.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class PeerConnection;
 class LocalAudioTrack;
@@ -813,4 +815,6 @@ class PeerConnection : public TrackedObject,
   }
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/ref_counted_base.h
+++ b/libs/mrwebrtc/src/ref_counted_base.h
@@ -5,7 +5,9 @@
 
 #include <atomic>
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// Base class for ref-counted objects.
 class RefCountedBase {
@@ -38,4 +40,6 @@ class RefCountedBase {
   mutable std::atomic_uint32_t ref_count_{0};
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/refptr.h
+++ b/libs/mrwebrtc/src/refptr.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 enum class DontAddRef {};
 
@@ -126,4 +128,6 @@ inline bool operator>=(const RefPtr<T>& a, const RefPtr<U>& b) noexcept {
   return a.get() >= b.get();
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/sdp_utils.cpp
+++ b/libs/mrwebrtc/src/sdp_utils.cpp
@@ -62,7 +62,9 @@ bool TryExtractSuffix(const std::string& str,
 
 }  // namespace
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 bool SdpIsValidToken(std::string_view token) noexcept {
   if (token.empty()) {
@@ -245,4 +247,6 @@ mrsSdpMessageType ApiTypeFromSdpType(webrtc::SdpType type) {
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/sdp_utils.cpp
+++ b/libs/mrwebrtc/src/sdp_utils.cpp
@@ -66,7 +66,7 @@ namespace Microsoft {
 namespace MixedReality {
 namespace WebRTC {
 
-bool SdpIsValidToken(std::string_view token) noexcept {
+bool SdpIsValidToken(absl::string_view token) noexcept {
   if (token.empty()) {
     return false;
   }

--- a/libs/mrwebrtc/src/sdp_utils.cpp
+++ b/libs/mrwebrtc/src/sdp_utils.cpp
@@ -211,7 +211,7 @@ std::string EncodeIceServers(const std::string& url,
   return url + "\nusername:" + username + "\npassword:" + password;
 }
 
-std::optional<webrtc::SdpType> SdpTypeFromString(const std::string& type_str) {
+absl::optional<webrtc::SdpType> SdpTypeFromString(const std::string& type_str) {
   if (type_str == webrtc::SessionDescriptionInterface::kOffer) {
     return webrtc::SdpType::kOffer;
   } else if (type_str == webrtc::SessionDescriptionInterface::kPrAnswer) {
@@ -219,7 +219,7 @@ std::optional<webrtc::SdpType> SdpTypeFromString(const std::string& type_str) {
   } else if (type_str == webrtc::SessionDescriptionInterface::kAnswer) {
     return webrtc::SdpType::kAnswer;
   } else {
-    return std::nullopt;
+    return absl::nullopt;
   }
 }
 

--- a/libs/mrwebrtc/src/sdp_utils.h
+++ b/libs/mrwebrtc/src/sdp_utils.h
@@ -66,7 +66,7 @@ std::string EncodeIceServers(const std::string& url,
 // Copied from src/pc/jsepsessiondescription.cc so that we don't rely on a binary
 // representation of absl::optional as per the Abseil Compatibility Guidelines:
 // https://abseil.io/about/compatibility
-std::optional<webrtc::SdpType> SdpTypeFromString(const std::string& type_str);
+absl::optional<webrtc::SdpType> SdpTypeFromString(const std::string& type_str);
 
 /// Convert an API SDP message type to an internal implementation SDP type.
 webrtc::SdpType SdpTypeFromApiType(mrsSdpMessageType api_type);

--- a/libs/mrwebrtc/src/sdp_utils.h
+++ b/libs/mrwebrtc/src/sdp_utils.h
@@ -16,7 +16,7 @@ namespace WebRTC {
 /// Check if the given SDP token is valid according to the RFC 4566 standard.
 /// See https://tools.ietf.org/html/rfc4566#page-43 for details.
 /// This is used to validate e.g. track, transceiver, or stream IDs.
-bool SdpIsValidToken(std::string_view token) noexcept;
+bool SdpIsValidToken(absl::string_view token) noexcept;
 
 /// Parse a list of semicolon-separated pairs of "key=value" arguments into a
 /// map of (key, value) pairs.

--- a/libs/mrwebrtc/src/sdp_utils.h
+++ b/libs/mrwebrtc/src/sdp_utils.h
@@ -9,7 +9,9 @@
 #include "callback.h"
 #include "interop_api.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// Check if the given SDP token is valid according to the RFC 4566 standard.
 /// See https://tools.ietf.org/html/rfc4566#page-43 for details.
@@ -72,4 +74,6 @@ webrtc::SdpType SdpTypeFromApiType(mrsSdpMessageType api_type);
 /// Convert an internal implementation SDP type to an API SDP message type.
 mrsSdpMessageType ApiTypeFromSdpType(webrtc::SdpType type);
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/str.cpp
+++ b/libs/mrwebrtc/src/str.cpp
@@ -8,7 +8,9 @@
 
 #if defined(MRS_USE_STR_WRAPPER)
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 str::str() = default;
 str::str(const std::string& s) : str_(s) {}
@@ -67,6 +69,8 @@ bool operator!=(const std::string& lhs, const str& rhs) noexcept {
   return (lhs != rhs.str_);
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft
 
 #endif  // defined(MRS_USE_STR_WRAPPER)

--- a/libs/mrwebrtc/src/str.cpp
+++ b/libs/mrwebrtc/src/str.cpp
@@ -15,7 +15,7 @@ namespace WebRTC {
 str::str() = default;
 str::str(const std::string& s) : str_(s) {}
 str::str(std::string&& s) noexcept : str_(std::move(s)) {}
-str::str(std::string_view view) : str_(view) {}
+str::str(absl::string_view view) : str_(view) {}
 str::str(const char* s) : str_(s) {}
 str::~str() = default;
 

--- a/libs/mrwebrtc/src/str.h
+++ b/libs/mrwebrtc/src/str.h
@@ -11,7 +11,9 @@
 
 #include "export.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 #if defined(MRS_USE_STR_WRAPPER)
 
@@ -58,7 +60,9 @@ using str = std::string;
 
 #endif  // defined(MRS_USE_STR_WRAPPER)
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft
 
 #if defined(MRS_USE_STR_WRAPPER)
 

--- a/libs/mrwebrtc/src/str.h
+++ b/libs/mrwebrtc/src/str.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include <functional>
 #include <string>
-#include <string_view>
 
 #include "export.h"
 
@@ -24,7 +23,7 @@ class str {
   str();
   explicit str(const std::string& s);
   explicit str(std::string&& s) noexcept;
-  explicit str(std::string_view view);
+  explicit str(absl::string_view view);
   explicit str(const char* s);
   ~str();
   str& operator=(const std::string& s);

--- a/libs/mrwebrtc/src/str.h
+++ b/libs/mrwebrtc/src/str.h
@@ -28,10 +28,10 @@ class str {
   ~str();
   str& operator=(const std::string& s);
   str& operator=(std::string&& s) noexcept;
-  [[nodiscard]] bool empty() const noexcept;
-  [[nodiscard]] uint32_t size() const noexcept;
-  [[nodiscard]] const char* data() const noexcept;
-  [[nodiscard]] const char* c_str() const noexcept;
+  MRS_NODISCARD bool empty() const noexcept;
+  MRS_NODISCARD uint32_t size() const noexcept;
+  MRS_NODISCARD const char* data() const noexcept;
+  MRS_NODISCARD const char* c_str() const noexcept;
 
   // Do not use in API
   std::size_t hash() const noexcept { return std::hash<std::string>()(str_); }

--- a/libs/mrwebrtc/src/toggle_audio_mixer.cpp
+++ b/libs/mrwebrtc/src/toggle_audio_mixer.cpp
@@ -7,7 +7,9 @@
 
 #include "toggle_audio_mixer.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 ToggleAudioMixer::ToggleAudioMixer()
     : base_impl_(webrtc::AudioMixerImpl::Create()) {}
@@ -130,4 +132,6 @@ void ToggleAudioMixer::OutputSource(int ssrc, bool output) {
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/toggle_audio_mixer.h
+++ b/libs/mrwebrtc/src/toggle_audio_mixer.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// Can mix selected audio sources only.
 class ToggleAudioMixer : public webrtc::AudioMixer {
@@ -32,4 +34,6 @@ class ToggleAudioMixer : public webrtc::AudioMixer {
   std::map<int, KnownSource> source_from_id_;
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/tracked_object.cpp
+++ b/libs/mrwebrtc/src/tracked_object.cpp
@@ -6,7 +6,9 @@
 #include "interop/global_factory.h"
 #include "tracked_object.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 TrackedObject::TrackedObject(RefPtr<GlobalFactory> global_factory,
                              ObjectType object_type)
@@ -18,4 +20,6 @@ TrackedObject::~TrackedObject() noexcept {
   global_factory_->RemoveObject(this);
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/tracked_object.h
+++ b/libs/mrwebrtc/src/tracked_object.h
@@ -8,7 +8,9 @@
 #include "ref_counted_base.h"
 #include "refptr.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 class GlobalFactory;
 
@@ -62,4 +64,6 @@ class TrackedObject : public RefCountedBase {
   void* user_data_{nullptr};
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/tracked_object.h
+++ b/libs/mrwebrtc/src/tracked_object.h
@@ -50,7 +50,7 @@ class TrackedObject : public RefCountedBase {
   /// limitation.
   virtual std::string GetName() const = 0;
 
-  [[nodiscard]] constexpr void* GetUserData() const noexcept {
+  MRS_NODISCARD constexpr void* GetUserData() const noexcept {
     return user_data_;
   }
 

--- a/libs/mrwebrtc/src/video_frame_observer.cpp
+++ b/libs/mrwebrtc/src/video_frame_observer.cpp
@@ -42,13 +42,13 @@ rtc::scoped_refptr<webrtc::I420BufferInterface> ArgbBuffer::ToI420() {
 
 void VideoFrameObserver::SetCallback(
     I420AFrameReadyCallback callback) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   i420a_callback_ = std::move(callback);
 }
 
 void VideoFrameObserver::SetCallback(
     Argb32FrameReadyCallback callback) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   argb_callback_ = std::move(callback);
 }
 
@@ -64,7 +64,7 @@ ArgbBuffer* VideoFrameObserver::GetArgbScratchBuffer(int width, int height) {
 }
 
 void VideoFrameObserver::OnFrame(const webrtc::VideoFrame& frame) noexcept {
-  auto lock = std::scoped_lock{mutex_};
+  std::lock_guard<std::mutex> lock(mutex_);
   if (!i420a_callback_ && !argb_callback_) {
     return;
   }

--- a/libs/mrwebrtc/src/video_frame_observer.cpp
+++ b/libs/mrwebrtc/src/video_frame_observer.cpp
@@ -13,7 +13,9 @@ constexpr int kBufferAlignment = 64;
 
 }  // namespace
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 ArgbBuffer::ArgbBuffer(int width, int height, int stride) noexcept
     : width_(width),
@@ -151,4 +153,6 @@ void VideoFrameObserver::OnFrame(const webrtc::VideoFrame& frame) noexcept {
   }
 }
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/video_frame_observer.h
+++ b/libs/mrwebrtc/src/video_frame_observer.h
@@ -13,7 +13,9 @@
 
 #include "rtc_base/memory/aligned_malloc.h"
 
-namespace Microsoft::MixedReality::WebRTC {
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
 
 /// Callback fired on newly available video frame, encoded as I420.
 using I420AFrameReadyCallback = Callback<const I420AVideoFrame&>;
@@ -132,4 +134,6 @@ class VideoFrameObserver : public rtc::VideoSinkInterface<webrtc::VideoFrame> {
   rtc::scoped_refptr<ArgbBuffer> argb_scratch_buffer_ RTC_GUARDED_BY(mutex_);
 };
 
-}  // namespace Microsoft::MixedReality::WebRTC
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/tools/build/android/webrtc-native/build.gradle
+++ b/tools/build/android/webrtc-native/build.gradle
@@ -17,7 +17,7 @@ android {
         }
         externalNativeBuild {
             cmake {
-                cppFlags "-std=c++17 -DANDROID_STL=c++_shared -DMRS_USE_STR_WRAPPER -DMR_SHARING_ANDROID -DWEBRTC_POSIX -DWEBRTC_ANDROID"
+                cppFlags "-std=c++14 -DANDROID_STL=c++_shared -DMRS_USE_STR_WRAPPER -DMR_SHARING_ANDROID -DWEBRTC_POSIX -DWEBRTC_ANDROID"
             }
         }
     }

--- a/tools/build/build.ps1
+++ b/tools/build/build.ps1
@@ -107,7 +107,11 @@ function Build-CoreWebRTC
         [string]$ScriptPlatform
     )
     $cmd = "python ..\..\external\webrtc-uwp-sdk\scripts\run.py -a prepare build -t webrtc"
-    $cmd = "$cmd -p $ScriptPlatform --cpus $BuildArch -c $BuildConfig --noColor --noWrapper --cpp17"
+    $cmd = "$cmd -p $ScriptPlatform --cpus $BuildArch -c $BuildConfig --noColor --noWrapper"
+    # UWP uses C++17 due to C++/WinRT dependency (see WebRTC UWP SDK project)
+    if ($ScriptPlatform -eq "winuwp") {
+        $cmd = "$cmd --cpp17"
+    }
     Invoke-Expression $cmd | Tee-Object -Variable output
     if (Select-String -Pattern "=================== Failed" -InputObject $output -SimpleMatch -CaseSensitive -Quiet)
     {

--- a/tools/build/build.ps1
+++ b/tools/build/build.ps1
@@ -109,9 +109,11 @@ function Build-CoreWebRTC
     $cmd = "python ..\..\external\webrtc-uwp-sdk\scripts\run.py -a prepare build -t webrtc"
     $cmd = "$cmd -p $ScriptPlatform --cpus $BuildArch -c $BuildConfig --noColor --noWrapper"
     # UWP uses C++17 due to C++/WinRT dependency (see WebRTC UWP SDK project)
-    if ($ScriptPlatform -eq "winuwp") {
+    # FIXME - Until we have NuGet packages for libwebrtc built with C++14, do not flip the switch
+    #         and keep building with C++17 even on Win32 platform.
+    #if ($ScriptPlatform -eq "winuwp") {
         $cmd = "$cmd --cpp17"
-    }
+    #}
     Invoke-Expression $cmd | Tee-Object -Variable output
     if (Select-String -Pattern "=================== Failed" -InputObject $output -SimpleMatch -CaseSensitive -Quiet)
     {

--- a/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj
+++ b/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj
@@ -111,6 +111,7 @@
       <ConformanceMode>false</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
@@ -88,7 +88,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;UNICODE;_WINDLL;MR_SHARING_WIN;MRS_USE_STR_WRAPPER;_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(MRWebRTCProjectRoot)libs\mrwebrtc\include;$(MRWebRTCProjectRoot)libs\mrwebrtc\src;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc;$(WebRTCCoreRepoPath)webrtc\xplatform$(WebRTCCoreRepoPath)webrtc\xplatform\chromium;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows\wrapper\generated\cppwinrt;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows\wrapper\override\cppwinrt;$(WebRTCCoreRepoPath)webrtc\xplatform\chromium\third_party\abseil-cpp;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\third_party\idl;$(WebRTCCoreRepoPath)webrtc\xplatform\zsLib;$(WebRTCCoreRepoPath)webrtc\xplatform\zsLib-eventing;$(WebRTCCoreRepoPath)webrtc\xplatform\libyuv\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
@@ -90,6 +90,7 @@
       <AdditionalIncludeDirectories>$(MRWebRTCProjectRoot)libs\mrwebrtc\include;$(MRWebRTCProjectRoot)libs\mrwebrtc\src;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc;$(WebRTCCoreRepoPath)webrtc\xplatform$(WebRTCCoreRepoPath)webrtc\xplatform\chromium;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows\wrapper\generated\cppwinrt;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows\wrapper\override\cppwinrt;$(WebRTCCoreRepoPath)webrtc\xplatform\chromium\third_party\abseil-cpp;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\third_party\idl;$(WebRTCCoreRepoPath)webrtc\xplatform\zsLib;$(WebRTCCoreRepoPath)webrtc\xplatform\zsLib-eventing;$(WebRTCCoreRepoPath)webrtc\xplatform\libyuv\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp14</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
@@ -88,7 +88,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;UNICODE;_WINDLL;MR_SHARING_WIN;MRS_USE_STR_WRAPPER;_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(MRWebRTCProjectRoot)libs\mrwebrtc\include;$(MRWebRTCProjectRoot)libs\mrwebrtc\src;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc;$(WebRTCCoreRepoPath)webrtc\xplatform$(WebRTCCoreRepoPath)webrtc\xplatform\chromium;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows\wrapper\generated\cppwinrt;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\sdk\windows\wrapper\override\cppwinrt;$(WebRTCCoreRepoPath)webrtc\xplatform\chromium\third_party\abseil-cpp;$(WebRTCCoreRepoPath)webrtc\xplatform\webrtc\third_party\idl;$(WebRTCCoreRepoPath)webrtc\xplatform\zsLib;$(WebRTCCoreRepoPath)webrtc\xplatform\zsLib-eventing;$(WebRTCCoreRepoPath)webrtc\xplatform\libyuv\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp14</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>


### PR DESCRIPTION
This prevent binary incompatibility between `libwebrtc`, which is always
compiled as C++14 officially (except on UWP where some experimental C++17
support was added by WebRTC UWP SDK) and `mrwebrtc` which links statically
against it. In particular this avoids binary incompatible `std::optional` and
`absl::optional`, which cause hard-to-debug issues.

Note that in theory this change should also downgrade the `mrwebrtc-win32`
project, but this breaks compatibility with the NuGet prebuilt libwebrtc
v1.0.3, and therefore change on that project is delayed to prevent binary
incompatibility until C++14-compatible NuGet packages are available.

Bug: #329