### PR TITLE
Add E_BUFFER_TOO_SMALL error code

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/Exceptions.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Exceptions.cs
@@ -6,6 +6,33 @@ using System;
 namespace Microsoft.MixedReality.WebRTC
 {
     /// <summary>
+    /// Exception raised when a buffer is too small to perform the current operation.
+    /// 
+    /// Generally the buffer was provided by the caller, and this indicates that the caller
+    /// must provide a larger buffer.
+    /// </summary>
+    public class BufferTooSmallException : Exception
+    {
+        /// <inheritdoc/>
+        public BufferTooSmallException()
+            : base("Buffer too small to perform the current operation.")
+        {
+        }
+
+        /// <inheritdoc/>
+        public BufferTooSmallException(string message)
+            : base(message)
+        {
+        }
+
+        /// <inheritdoc/>
+        public BufferTooSmallException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+
+    /// <summary>
     /// Exception thrown when trying to add a data channel to a peer connection after
     /// a connection to a remote peer was established without an SCTP handshake.
     /// When using data channels, at least one data channel must be added to the peer

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -55,6 +55,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         internal const uint MRS_E_NOT_INITIALIZED = 0x80000006u;
         internal const uint MRS_E_UNSUPPORTED = 0x80000007u;
         internal const uint MRS_E_OUT_OF_RANGE = 0x80000008u;
+        internal const uint MRS_E_BUFFER_TOO_SMALL = 0x80000009u;
         internal const uint MRS_E_PEER_CONNECTION_CLOSED = 0x80000101u;
         internal const uint MRS_E_SCTP_NOT_NEGOTIATED = 0x80000301u;
         internal const uint MRS_E_INVALID_DATA_CHANNEL_ID = 0x80000302u;
@@ -188,6 +189,9 @@ namespace Microsoft.MixedReality.WebRTC.Interop
 
             case MRS_E_OUT_OF_RANGE:
                 return new ArgumentOutOfRangeException();
+
+            case MRS_E_BUFFER_TOO_SMALL:
+                return new BufferTooSmallException();
 
             case MRS_E_SCTP_NOT_NEGOTIATED:
                 return new SctpNotNegotiatedException();

--- a/libs/mrwebrtc/include/result.h
+++ b/libs/mrwebrtc/include/result.h
@@ -55,6 +55,10 @@ enum class Result : std::uint32_t {
   /// expected range.
   kOutOfRange = 0x80000008,
 
+  /// The buffer provided by the caller was too small for the operation to
+  /// complete successfully.
+  kBufferTooSmall = 0x80000009,
+
   //
   // Peer connection (0x1xx)
   //


### PR DESCRIPTION
Add some error code to signal the user a buffer is too small to perform
the current operation. The buffer is generally allocated by the caller,
which gives them an opportunity to retry with a larger buffer.