### PR TITLE
Fix crash in TestAppUWP on invalid local peer ID

### DIFF
--- a/examples/TestAppUwp/MainPage.xaml.cs
+++ b/examples/TestAppUwp/MainPage.xaml.cs
@@ -193,10 +193,6 @@ namespace TestAppUwp
                     sessionModel.NodeDssSignaler.LocalPeerId = str;
                 }
             }
-            if (string.IsNullOrWhiteSpace(sessionModel.NodeDssSignaler.LocalPeerId))
-            {
-                sessionModel.NodeDssSignaler.LocalPeerId = GetDeviceName();
-            }
             if (localSettings.Values.TryGetValue("RemotePeerID", out object remoteObj))
             {
                 if (remoteObj is string str)
@@ -219,6 +215,13 @@ namespace TestAppUwp
                 var tmp = sessionModel.NodeDssSignaler.LocalPeerId;
                 sessionModel.NodeDssSignaler.LocalPeerId = sessionModel.NodeDssSignaler.RemotePeerId;
                 sessionModel.NodeDssSignaler.RemotePeerId = tmp;
+            }
+
+            // Ensure the local peer is not empty, otherwise the signaler will throw an exception
+            // during OnLoaded(), which will crash the application.
+            if (string.IsNullOrWhiteSpace(sessionModel.NodeDssSignaler.LocalPeerId))
+            {
+                sessionModel.NodeDssSignaler.LocalPeerId = GetDeviceName();
             }
 
             if (localSettings.Values.TryGetValue("PreferredAudioCodec", out object preferredAudioObj))


### PR DESCRIPTION
Prevent the local peer ID from being an empty string when launching a
second instance while the saved settings contain an empty string for the
remote peer, which gets swapped in that second instance with the local
peer after the empty string override has been applied. Instead apply the
fallback after the 2-instance helper possibly swapped the values.