### PR TITLE
Add optional CG task to mrwebrtc build template

### DIFF
--- a/tools/ci/ci-cpp.yaml
+++ b/tools/ci/ci-cpp.yaml
@@ -22,74 +22,101 @@ pr: none
 # Give a unique name to the build each time it runs
 name: ci-cpp-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
 
+parameters:
+# Build agent pool
+- name: buildAgent
+  displayName: 'Build Agent Pool'
+  type: string
+  default: 'Hosted VS2017' # vs2017-win2016
+# Restore PDBs of libwebrtc from Core build
+- name: restoreCorePdbs
+  displayName: 'Restore core PDBs'
+  type: boolean
+  default: true
+# Run Component Governance detection and submit results
+- name: runComponentDetection
+  displayName: 'Run component detection'
+  type: boolean
+  default: true
+
 jobs:
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'Win32'
     buildArch: 'x86'
-    msbuildPlatform: 'Win32'
     buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'Win32'
     buildArch: 'x86'
-    msbuildPlatform: 'Win32'
     buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'Win32'
     buildArch: 'x64'
-    msbuildPlatform: 'x64'
     buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'Win32'
     buildArch: 'x64'
-    msbuildPlatform: 'x64'
     buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'UWP'
     buildArch: 'x86'
-    msbuildPlatform: 'Win32'
     buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'UWP'
     buildArch: 'x86'
-    msbuildPlatform: 'Win32'
     buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'UWP'
     buildArch: 'x64'
-    msbuildPlatform: 'x64'
     buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'UWP'
     buildArch: 'x64'
-    msbuildPlatform: 'x64'
     buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'UWP'
     buildArch: 'ARM'
-    msbuildPlatform: 'ARM'
     buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
-    buildAgent: 'Hosted VS2017' # vs2017-win2016
+    buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'UWP'
     buildArch: 'ARM'
-    msbuildPlatform: 'ARM'
     buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}

--- a/tools/ci/ci-cpp.yaml
+++ b/tools/ci/ci-cpp.yaml
@@ -40,83 +40,83 @@ parameters:
   default: true
 
 jobs:
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'Win32'
-    buildArch: 'x86'
-    buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'Win32'
-    buildArch: 'x86'
-    buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'Win32'
-    buildArch: 'x64'
-    buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'Win32'
+#     buildArch: 'x86'
+#     buildConfig: 'Debug'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'Win32'
+#     buildArch: 'x86'
+#     buildConfig: 'Release'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
     buildAgent: ${{parameters.buildAgent}}
     buildPlatform: 'Win32'
     buildArch: 'x64'
-    buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'x86'
     buildConfig: 'Debug'
     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'x86'
-    buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'x64'
-    buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'x64'
-    buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'ARM'
-    buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'ARM'
-    buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-    runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'Win32'
+#     buildArch: 'x64'
+#     buildConfig: 'Release'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'x86'
+#     buildConfig: 'Debug'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'x86'
+#     buildConfig: 'Release'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'x64'
+#     buildConfig: 'Debug'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'x64'
+#     buildConfig: 'Release'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'ARM'
+#     buildConfig: 'Debug'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'ARM'
+#     buildConfig: 'Release'
+#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+#     runComponentDetection: ${{parameters.runComponentDetection}}

--- a/tools/ci/ci-cpp.yaml
+++ b/tools/ci/ci-cpp.yaml
@@ -33,29 +33,30 @@ parameters:
   displayName: 'Restore core PDBs'
   type: boolean
   default: true
-# Run Component Governance detection and submit results
+# Run Component Governance detection and submit results.
+# This require the CG task, which is not available on CI.
 - name: runComponentDetection
   displayName: 'Run component detection'
   type: boolean
-  default: true
+  default: false
 
 jobs:
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'Win32'
-#     buildArch: 'x86'
-#     buildConfig: 'Debug'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'Win32'
-#     buildArch: 'x86'
-#     buildConfig: 'Release'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'Win32'
+    buildArch: 'x86'
+    buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'Win32'
+    buildArch: 'x86'
+    buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
 - template: templates/jobs-cpp.yaml
   parameters:
     buildAgent: ${{parameters.buildAgent}}
@@ -64,59 +65,59 @@ jobs:
     buildConfig: 'Debug'
     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'Win32'
-#     buildArch: 'x64'
-#     buildConfig: 'Release'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'x86'
-#     buildConfig: 'Debug'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'x86'
-#     buildConfig: 'Release'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'x64'
-#     buildConfig: 'Debug'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'x64'
-#     buildConfig: 'Release'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'ARM'
-#     buildConfig: 'Debug'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'ARM'
-#     buildConfig: 'Release'
-#     restoreCorePdbs: ${{parameters.restoreCorePdbs}}
-#     runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'Win32'
+    buildArch: 'x64'
+    buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'x86'
+    buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'x86'
+    buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'x64'
+    buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'x64'
+    buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'ARM'
+    buildConfig: 'Debug'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'ARM'
+    buildConfig: 'Release'
+    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
+    runComponentDetection: ${{parameters.runComponentDetection}}

--- a/tools/ci/computePdbPackageVars.ps1
+++ b/tools/ci/computePdbPackageVars.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Compute the name and version of the Universal Package used for PDBs,
 # and populate the relevant pipeline variables.
 

--- a/tools/ci/copyPdbsForBuilding.ps1
+++ b/tools/ci/copyPdbsForBuilding.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Copy all PDBs from their packaging folder back next to webrtc.lib
 # Note that this is not their original location, but this is where
 # the linker currently looks for them.

--- a/tools/ci/copyPdbsForPackaging.ps1
+++ b/tools/ci/copyPdbsForPackaging.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Copy all PDBs into a single folder for packaging as Universal Package
 
 param(

--- a/tools/ci/generateCppPackagesConfig.ps1
+++ b/tools/ci/generateCppPackagesConfig.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Generate a custom packages.config to restore only the necessary Core
 # NuGet packages for the given build triple, to save on disk space
 

--- a/tools/ci/mapVariables.ps1
+++ b/tools/ci/mapVariables.ps1
@@ -1,10 +1,9 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See LICENSE in the project root for license information.
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 # Map build* variables to script* variables
 #   build* variables are for MSVC and use uppercase : ARM(64), Debug|Release, Win32|UWP
 #   script* variables are for the Google Python scripts and use lowercase: arm(64), debug|release, win|winuwp
-# See https://github.com/webrtc-uwp/webrtc-scripts/blob/3f2eb87b1baa3f49c6341d144e0b3c3be11c78ae/defaults.py#L17
 
 param(
     [Parameter(Position=0)]
@@ -12,7 +11,7 @@ param(
     [string]$BuildPlatform,
 
     [Parameter(Position=1)]
-    [ValidateSet('x86','x64','ARM')]
+    [ValidateSet('x86','x64','ARM','ARM64')]
     [string]$BuildArch,
 
     [Parameter(Position=2)]
@@ -24,40 +23,49 @@ param(
 # scriptPlatform = win|winuwp
 Write-Host "buildPlatform = $BuildPlatform"
 if ($BuildPlatform -eq "Win32") {
-    Write-Host "##vso[task.setvariable variable=scriptPlatform;]win"
+    $scriptPlatform = "win"
 }
 elseif ($BuildPlatform -eq "UWP") {
-    Write-Host "##vso[task.setvariable variable=scriptPlatform;]winuwp"
+    $scriptPlatform = "winuwp"
 }
 else {
     Write-Host "##vso[task.complete result=Failed;]Unknown build platform '$BuildPlatform'."
 }
+Write-Host "##vso[task.setvariable variable=scriptPlatform;]$scriptPlatform"
+Write-Host "scriptPlatform = $scriptPlatform"
 
 # buildArch = x86|x64|ARM
 # scriptArch = x86|x64|arm
 Write-Host "buildArch = $BuildArch"
 if ($BuildArch -eq "x86") {
-    Write-Host "##vso[task.setvariable variable=scriptArch; ]x86"
+    $scriptArch = "x86"
 }
 elseif ($BuildArch -eq "x64") {
-    Write-Host "##vso[task.setvariable variable=scriptArch; ]x64"
+    $scriptArch = "x64"
 }
 elseif ($BuildArch -eq "ARM") {
-    Write-Host "##vso[task.setvariable variable=scriptArch; ]arm"
+    $scriptArch = "arm"
+}
+elseif ($BuildArch -eq "ARM64") {
+    $scriptArch = "arm64"
 }
 else {
     Write-Host "##vso[task.complete result=Failed; ]Unknown build architecture '$BuildArch'."
 }
+Write-Host "##vso[task.setvariable variable=scriptArch;]$scriptArch"
+Write-Host "scriptArch = $scriptArch"
 
 # buildConfig = Debug|Release
 # scriptConfig = debug|release
 Write-Host "buildConfig = $BuildConfig"
 if ($BuildConfig -eq "Debug") {
-    Write-Host "##vso[task.setvariable variable=scriptConfig; ]debug"
+    $scriptConfig = "debug"
 }
 elseif ($BuildConfig -eq "Release") {
-    Write-Host "##vso[task.setvariable variable=scriptConfig; ]release"
+    $scriptConfig = "release"
 }
 else {
     Write-Host "##vso[task.complete result=Failed; ]Unknown build config '$BuildConfig'."
 }
+Write-Host "##vso[task.setvariable variable=scriptConfig;]$scriptConfig"
+Write-Host "scriptConfig = $scriptConfig"

--- a/tools/ci/modifyCppProject.ps1
+++ b/tools/ci/modifyCppProject.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Modify the .vcxproj project file to only import the NuGet packages for
 # the current build triple, which are the only ones restored.
 

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -73,7 +73,7 @@ jobs:
   - powershell: |
       if ("$env:BUILD_ARCH" -eq "x86") {
         $msbuildPlatform = "Win32"
-      } else {s
+      } else {
         $msbuildPlatform = $env:BUILD_ARCH
       }
       Write-Host "MSBuild platform = $msbuildPlatform"

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -131,6 +131,15 @@ jobs:
       arguments: '-a prepare -p $(scriptPlatform) --cpus $(scriptArch) -c $(scriptConfig)'
     timeoutInMinutes: 10
 
+  # Clean-up unused files
+  - script: |
+      del /F /S /Q "depot_tools/external_bin/gsutil"
+      del /F /S /Q "chromium/third_party/protobuf/java"
+      del /F /S /Q "chromium/tools/android"
+      del /F /S /Q "chromium/tools/code_coverage"
+    workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'
+    displayName: 'Clean-up unused files'
+
   # Generate custom .vcxproj to import only the necessary packages for the current build triple
   - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
     - task: PowerShell@2

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -42,38 +42,38 @@ jobs:
     timeoutInMinutes: 5
 
   # Compute the PDB package variables
-  - task: PowerShell@2
-    displayName: 'Compute libwebrtc PDB package variables'
-    inputs:
-      targetType: 'filePath'
-      filePath: '$(Build.SourcesDirectory)/tools/ci/computePdbPackageVars.ps1'
-    env:
-      # Read $(MRWebRTC_PdbPackageVersion) from pipeline variables
-      WRITE_VERSION: 'false'
-    condition: eq(variables['MRWebRTC_RestorePDBs'], 'true')
-    timeoutInMinutes: 5
+  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+    - task: PowerShell@2
+      displayName: 'Compute libwebrtc PDB package variables'
+      inputs:
+        targetType: 'filePath'
+        filePath: '$(Build.SourcesDirectory)/tools/ci/computePdbPackageVars.ps1'
+      env:
+        # Read $(MRWebRTC_PdbPackageVersion) from pipeline variables
+        WRITE_VERSION: 'false'
+      timeoutInMinutes: 5
 
   # Download the PDBs for libwebrtc
-  - task: UniversalPackages@0
-    displayName: 'Download libwebrtc PDBs'
-    inputs:
-      command: download
-      vstsFeed: $(MRWebRTC_PdbFeed)
-      vstsFeedPackage: $(MRWebRTC_PdbPackageName)
-      vstsPackageVersion: $(MRWebRTC_PdbPackageVersion)
-      downloadDirectory: '$(Build.SourcesDirectory)\_pdbs'
-    condition: eq(variables['MRWebRTC_RestorePDBs'], 'true')
-    timeoutInMinutes: 10
+  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+    - task: UniversalPackages@0
+      displayName: 'Download libwebrtc PDBs'
+      inputs:
+        command: download
+        vstsFeed: $(MRWebRTC_PdbFeed)
+        vstsFeedPackage: $(MRWebRTC_PdbPackageName)
+        vstsPackageVersion: $(MRWebRTC_PdbPackageVersion)
+        downloadDirectory: '$(Build.SourcesDirectory)\_pdbs'
+      timeoutInMinutes: 10
 
   # Move PDBs back into their original location for the linker to find them
-  - task: PowerShell@2
-    displayName: 'Move libwebrtc PDBs back in place'
-    inputs:
-      targetType: 'filePath'
-      filePath: '$(Build.SourcesDirectory)/tools/ci/copyPdbsForBuilding.ps1'
-      arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -SourcePath "$(Build.SourcesDirectory)/_pdbs" -OutputPath "bin/${{parameters.buildPlatform}}/${{parameters.buildArch}}/${{parameters.buildConfig}}"'
-    condition: eq(variables['MRWebRTC_RestorePDBs'], 'true')
-    timeoutInMinutes: 10
+  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+    - task: PowerShell@2
+      displayName: 'Move libwebrtc PDBs back in place'
+      inputs:
+        targetType: 'filePath'
+        filePath: '$(Build.SourcesDirectory)/tools/ci/copyPdbsForBuilding.ps1'
+        arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -SourcePath "$(Build.SourcesDirectory)/_pdbs" -OutputPath "bin/${{parameters.buildPlatform}}/${{parameters.buildArch}}/${{parameters.buildConfig}}"'
+      timeoutInMinutes: 10
 
   # Use NuGet 5.2.0
   - task: NuGetToolInstaller@1
@@ -85,14 +85,14 @@ jobs:
   # Generate custom packages.config to restore only the necessary packages for the current build triple.
   # This helps both with decreasing restore time and with minimizing disk space to avoid the 10GB limit.
   # This task sets $(PackagesConfigFile) to the filename of the generated 'packages.config' file.
-  - task: PowerShell@2
-    displayName: 'Generate packages.config for build triple'
-    inputs:
-      targetType: 'filePath'
-      filePath: '$(Build.SourcesDirectory)/tools/ci/generateCppPackagesConfig.ps1'
-      arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -BuildArch ${{parameters.buildArch}} -InputFile "$(Build.SourcesDirectory)/tools/build/mrwebrtc/${{parameters.buildPlatform}}/packages.config" -OutputFile "bin/${{parameters.buildPlatform}}/${{parameters.buildArch}}/${{parameters.buildConfig}}/packages.config"'
-    condition: eq(variables['MRWebRTC_RestorePDBs'], 'true')
-    timeoutInMinutes: 5
+  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+    - task: PowerShell@2
+      displayName: 'Generate packages.config for build triple'
+      inputs:
+        targetType: 'filePath'
+        filePath: '$(Build.SourcesDirectory)/tools/ci/generateCppPackagesConfig.ps1'
+        arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -BuildArch ${{parameters.buildArch}} -InputFile "$(Build.SourcesDirectory)/tools/build/mrwebrtc/${{parameters.buildPlatform}}/packages.config" -OutputFile "bin/${{parameters.buildPlatform}}/${{parameters.buildArch}}/${{parameters.buildConfig}}/packages.config"'
+      timeoutInMinutes: 5
 
   # Restore the NuGet packages containing the input dependencies (non-PDB case)
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand@2
@@ -115,16 +115,16 @@ jobs:
 
   # Map build* variables to script* ones
   - task: PowerShell@2
-    displayName: Map script variables
+    displayName: 'Map script variables'
     inputs:
-      targetType: filePath
-      filePath: tools/ci/mapVariables.ps1
+      targetType: 'filePath'
+      filePath: 'tools/ci/mapVariables.ps1'
       arguments: '${{parameters.buildPlatform}} ${{parameters.buildArch}} ${{parameters.buildConfig}}'
     timeoutInMinutes: 5
 
   # Prepare the environment with the setup script from Google
   - task: PythonScript@0
-    displayName: Prepare WebRTC env
+    displayName: 'Prepare WebRTC env'
     inputs:
       scriptSource: 'filePath'
       scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
@@ -132,13 +132,19 @@ jobs:
     timeoutInMinutes: 10
 
   # Generate custom .vcxproj to import only the necessary packages for the current build triple
-  - task: PowerShell@2
-    displayName: 'Modify .vcxproj for build triple'
-    inputs:
-      targetType: filePath
-      filePath: tools/ci/modifyCppProject.ps1
-      arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -BuildArch ${{parameters.buildArch}} -ProjectFile "tools/build/mrwebrtc/${{parameters.buildPlatform}}/mrwebrtc-${{parameters.buildPlatform}}.vcxproj"'
-    condition: eq(variables['MRWebRTC_RestorePDBs'], 'true')
+  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+    - task: PowerShell@2
+      displayName: 'Modify .vcxproj for build triple'
+      inputs:
+        targetType: filePath
+        filePath: tools/ci/modifyCppProject.ps1
+        arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -BuildArch ${{parameters.buildArch}} -ProjectFile "tools/build/mrwebrtc/${{parameters.buildPlatform}}/mrwebrtc-${{parameters.buildPlatform}}.vcxproj"'
+
+  # Run component detection
+  - ${{ if eq(variables['MRWebRTC_RunComponentDetection'], 'true') }}:
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'
+      timeoutInMinutes: 15
 
   # Build mrwebrtc.dll
   - task: MSBuild@1

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -76,7 +76,7 @@ jobs:
       } else {s
         $msbuildPlatform = $env:BUILD_ARCH
       }
-      Write-Host "MSBuild $(Platform) = $msbuildPlatform"
+      Write-Host "MSBuild platform = $msbuildPlatform"
       Write-Host "##vso[task.setvariable variable=msbuildPlatform;]$msbuildPlatform"
     displayName: 'Compute MSBuild platform'
     env:

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -4,12 +4,52 @@
 # [TEMPLATE] Compile library mrwebrtc.dll
 
 parameters:
-  buildAgent: ''
-  buildPlatform: ''    # Win32|UWP
-  buildArch: ''        # x86|x64|ARM|ARM64
-  msbuildPlatform: ''  # Win32|x64|ARM|ARM64
-  buildConfig: ''      # Debug|Release
-  withTesting: true    # true|false
+# Build agent pool
+- name: buildAgent
+  displayName: 'Build Agent Pool'
+  type: string
+  default: ''
+# Restore PDBs of libwebrtc from Core build
+- name: restoreCorePdbs
+  displayName: 'Restore core PDBs'
+  type: boolean
+  default: true
+# Run Component Governance detection and submit results
+- name: runComponentDetection
+  displayName: 'Run component detection'
+  type: boolean
+  default: true
+# Build platform
+- name: buildPlatform
+  displayName: 'Build Platform'
+  type: string
+  default: ''
+  values:
+  - 'Win32'
+  - 'UWP'
+# Build architecture
+- name: buildArch
+  displayName: 'Build Architecture'
+  type: string
+  default: ''
+  values:
+  - 'x86'
+  - 'x64'
+  - 'ARM'
+  - 'ARM64'
+# Build configuration
+- name: buildConfig
+  displayName: 'Build Configuration'
+  type: string
+  default: ''
+  values:
+  - 'Debug'
+  - 'Release'
+# Do testing
+- name: withTesting
+  displayName: 'Enable testing'
+  type: boolean
+  default: true
 
 jobs:
 
@@ -28,6 +68,22 @@ jobs:
   - name: PackagesConfigFile
     value: '$(Build.SourcesDirectory)/tools/build/mrwebrtc/${{parameters.buildPlatform}}/packages.config'
   steps:
+
+  # Calculate MSBuild platform
+  - powershell: |
+      if ("$env:BUILD_ARCH" -eq "x86") {
+        $msbuildPlatform = "Win32"
+      } else {s
+        $msbuildPlatform = $env:BUILD_ARCH
+      }
+      Write-Host "MSBuild $(Platform) = $msbuildPlatform"
+      Write-Host "##vso[task.setvariable variable=msbuildPlatform;]$msbuildPlatform"
+    displayName: 'Compute MSBuild platform'
+    env:
+      BUILD_ARCH: ${{parameters.buildArch}}
+    timeoutInMinutes: 5
+
+  # Checkout MixedReality-WebRTC
   - checkout: 'self'
     submodules: 'recursive'
     fetchDepth: '1'
@@ -42,7 +98,7 @@ jobs:
     timeoutInMinutes: 5
 
   # Compute the PDB package variables
-  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
     - task: PowerShell@2
       displayName: 'Compute libwebrtc PDB package variables'
       inputs:
@@ -54,7 +110,7 @@ jobs:
       timeoutInMinutes: 5
 
   # Download the PDBs for libwebrtc
-  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
     - task: UniversalPackages@0
       displayName: 'Download libwebrtc PDBs'
       inputs:
@@ -66,7 +122,7 @@ jobs:
       timeoutInMinutes: 10
 
   # Move PDBs back into their original location for the linker to find them
-  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
     - task: PowerShell@2
       displayName: 'Move libwebrtc PDBs back in place'
       inputs:
@@ -85,7 +141,7 @@ jobs:
   # Generate custom packages.config to restore only the necessary packages for the current build triple.
   # This helps both with decreasing restore time and with minimizing disk space to avoid the 10GB limit.
   # This task sets $(PackagesConfigFile) to the filename of the generated 'packages.config' file.
-  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
     - task: PowerShell@2
       displayName: 'Generate packages.config for build triple'
       inputs:
@@ -141,7 +197,7 @@ jobs:
     displayName: 'Clean-up unused files'
 
   # Generate custom .vcxproj to import only the necessary packages for the current build triple
-  - ${{ if eq(variables['MRWebRTC_RestorePDBs'], 'true') }}:
+  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
     - task: PowerShell@2
       displayName: 'Modify .vcxproj for build triple'
       inputs:
@@ -150,7 +206,7 @@ jobs:
         arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -BuildArch ${{parameters.buildArch}} -ProjectFile "tools/build/mrwebrtc/${{parameters.buildPlatform}}/mrwebrtc-${{parameters.buildPlatform}}.vcxproj"'
 
   # Run component detection
-  - ${{ if eq(variables['MRWebRTC_RunComponentDetection'], 'true') }}:
+  - ${{ if eq(parameters.runComponentDetection, 'true') }}:
     - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
       displayName: 'Component Detection'
       timeoutInMinutes: 15
@@ -162,7 +218,7 @@ jobs:
       solution: 'tools/build/mrwebrtc/${{parameters.buildPlatform}}/mrwebrtc-${{parameters.buildPlatform}}.vcxproj'
       msbuildVersion: 15.0
       msbuildArchitecture: x64
-      platform: '${{parameters.msbuildPlatform}}'
+      platform: '$(msbuildPlatform)'
       configuration: '${{parameters.buildConfig}}'
     timeoutInMinutes: 20
 
@@ -210,7 +266,7 @@ jobs:
         solution: '$(Build.SourcesDirectory)/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj'
         msbuildVersion: '15.0'
         msbuildArchitecture: 'x64'
-        platform: '${{parameters.msbuildPlatform}}'
+        platform: '$(msbuildPlatform)'
         configuration: '${{parameters.buildConfig}}'
         msbuildArguments: '/p:DisableDeviceTests=1' # Disable tests requiring a webcam or microphone
       timeoutInMinutes: 15


### PR DESCRIPTION
Before the build starts, delete unused files checked out by the Google build
scripts but not used in the build, and optionally run the Component Governance
detection task to monitor use of third-party software for compliance.