### PR TITLE
Add split audio track source

### DIFF
--- a/examples/TestAppUwp/MediaPlayerPage.xaml.cs
+++ b/examples/TestAppUwp/MediaPlayerPage.xaml.cs
@@ -52,6 +52,8 @@ namespace TestAppUwp
     /// </summary>
     public class AudioTrackViewModel
     {
+        // FIXME - this leaks 'source', never disposed (and is the track itself disposed??)
+        public AudioTrackSource Source;
         public IAudioTrack Track;
         public MediaTrack TrackImpl;
         public bool IsRemote;

--- a/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
@@ -33,14 +33,19 @@ namespace TestAppUwp
 
             await RequestMediaAccessAsync(StreamingCaptureMode.Audio);
 
-            var settings = new LocalAudioTrackSettings
+                    // FIXME - this leaks 'source', never disposed (and is the track itself disposed??)
+            var initConfig = new LocalAudioDeviceInitConfig();
+            var source = await AudioTrackSource.CreateFromDeviceAsync(initConfig);
+
+            var settings = new LocalAudioTrackInitConfig
             {
                 trackName = trackName
             };
-            var track = await LocalAudioTrack.CreateFromDeviceAsync(settings);
+            var track = await LocalAudioTrack.CreateFromSourceAsync(source, settings);
 
             SessionModel.Current.AudioTracks.Add(new AudioTrackViewModel
             {
+                Source = source,
                 Track = track,
                 TrackImpl = track,
                 IsRemote = false,

--- a/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
@@ -117,7 +117,10 @@ namespace TestAppUwp
                 DisplayName = "Local microphone (default device)",
                 Factory = async () =>
                 {
-                    return await LocalAudioTrack.CreateFromDeviceAsync();
+                    // FIXME - this leaks 'source', never disposed (and is the track itself disposed??)
+                    var source = await AudioTrackSource.CreateFromDeviceAsync();
+                    var settings = new LocalAudioTrackInitConfig();
+                    return await LocalAudioTrack.CreateFromSourceAsync(source, settings);
                 }
             });
 

--- a/examples/TestNetCoreConsole/Program.cs
+++ b/examples/TestNetCoreConsole/Program.cs
@@ -14,6 +14,7 @@ namespace TestNetCoreConsole
         {
             Transceiver audioTransceiver = null;
             Transceiver videoTransceiver = null;
+            AudioTrackSource audioTrackSource = null;
             LocalAudioTrack localAudioTrack = null;
             LocalVideoTrack localVideoTrack = null;
 
@@ -58,7 +59,13 @@ namespace TestNetCoreConsole
                 if (needAudio)
                 {
                     Console.WriteLine("Opening local microphone...");
-                    localAudioTrack = await LocalAudioTrack.CreateFromDeviceAsync();
+                    audioTrackSource = await AudioTrackSource.CreateFromDeviceAsync();
+
+                    Console.WriteLine("Create local audio track...");
+                    var trackSettings = new LocalAudioTrackInitConfig { trackName = "mic_track" };
+                    localAudioTrack = await LocalAudioTrack.CreateFromSourceAsync(audioTrackSource, trackSettings);
+
+                    Console.WriteLine("Create audio transceiver and add mic track...");
                     audioTransceiver = pc.AddTransceiver(MediaKind.Audio);
                     audioTransceiver.DesiredDirection = Transceiver.Direction.SendReceive;
                     audioTransceiver.LocalAudioTrack = localAudioTrack;
@@ -118,6 +125,10 @@ namespace TestNetCoreConsole
             localVideoTrack?.Dispose();
 
             Console.WriteLine("Program termined.");
+
+            localAudioTrack.Dispose();
+            localVideoTrack.Dispose();
+            audioTrackSource.Dispose();
         }
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/AudioTrackSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/AudioTrackSource.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.MixedReality.WebRTC.Interop;
+
+namespace Microsoft.MixedReality.WebRTC
+{
+    /// <summary>
+    /// Configuration to initialize capture on a local audio device (microphone).
+    /// </summary>
+    public class LocalAudioDeviceInitConfig
+    {
+        /// <summary>
+        /// Enable automated gain control (AGC) on the audio device capture pipeline.
+        /// </summary>
+        public bool? AutoGainControl = null;
+    }
+
+    /// <summary>
+    /// Audio source for WebRTC audio tracks.
+    /// 
+    /// The audio source is not bound to any peer connection, and can therefore be shared by multiple audio
+    /// tracks from different peer connections. This is especially useful to share local audio capture devices
+    /// (microphones) amongst multiple peer connections when building a multi-peer experience with a mesh topology
+    /// (one connection per pair of peers).
+    /// 
+    /// The user owns the audio track source, and is in charge of keeping it alive until after all tracks using it
+    /// are destroyed, and then dispose of it. The behavior of disposing of the track source while a track is still
+    /// using it is undefined. The <see cref="Tracks"/> property contains the list of tracks currently using the
+    /// source.
+    /// </summary>
+    /// <seealso cref="LocalAudioTrack"/>
+    public class AudioTrackSource : IDisposable
+    {
+        /// <summary>
+        /// A name for the audio track source, used for logging and debugging.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                // Note: the name cannot change internally, so no need to query the native layer.
+                // This avoids a round-trip to native and some string encoding conversion.
+                return _name;
+            }
+            set
+            {
+                AudioTrackSourceInterop.AudioTrackSource_SetName(_nativeHandle, value);
+                _name = value;
+            }
+        }
+
+        /// <summary>
+        /// List of local audio tracks this source is providing raw audio frames to.
+        /// </summary>
+        public List<LocalAudioTrack> Tracks { get; private set; } = new List<LocalAudioTrack>();
+
+        /// <summary>
+        /// Handle to the native AudioTrackSource object.
+        /// </summary>
+        /// <remarks>
+        /// In native land this is a <code>Microsoft::MixedReality::WebRTC::AudioTrackSourceHandle</code>.
+        /// </remarks>
+        internal AudioTrackSourceHandle _nativeHandle { get; private set; } = new AudioTrackSourceHandle();
+
+        /// <summary>
+        /// Backing field for <see cref="Name"/>, and cache for the native name.
+        /// Since the name can only be set by the user, this cached value is always up-to-date with the
+        /// internal name of the native object, by design.
+        /// </summary>
+        private string _name = string.Empty;
+
+        /// <summary>
+        /// Create an audio track source using a local audio capture device (microphone).
+        /// </summary>
+        /// <param name="initConfig">Optional configuration to initialize the audio capture on the device.</param>
+        /// <returns>The newly create audio track source.</returns>
+        public static Task<AudioTrackSource> CreateFromDeviceAsync(LocalAudioDeviceInitConfig initConfig = null)
+        {
+            return Task.Run(() =>
+            {
+                // On UWP this cannot be called from the main UI thread, so always call it from
+                // a background worker thread.
+
+                var config = new AudioTrackSourceInterop.LocalAudioDeviceMarshalInitConfig(initConfig);
+                uint ret = AudioTrackSourceInterop.AudioTrackSource_CreateFromDevice(in config, out AudioTrackSourceHandle handle);
+                Utils.ThrowOnErrorCode(ret);
+                return new AudioTrackSource(handle);
+            });
+        }
+
+        internal AudioTrackSource(AudioTrackSourceHandle nativeHandle)
+        {
+            _nativeHandle = nativeHandle;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_nativeHandle.IsClosed)
+            {
+                return;
+            }
+
+            // TODO - Can we support destroying the source and leaving tracks with silence instead?
+            if (Tracks.Count > 0)
+            {
+                throw new InvalidOperationException($"Trying to dispose of AudioTrackSource '{Name}' while still in use by one or more audio tracks.");
+            }
+
+            // Unregister from tracks
+            // TODO...
+            //AudioTrackSourceInterop.AudioTrackSource_Shutdown(_nativeHandle);
+
+            // Destroy the native object. This may be delayed if a P/Invoke callback is underway,
+            // but will be handled at some point anyway, even if the managed instance is gone.
+            _nativeHandle.Dispose();
+        }
+
+        /// <summary>
+        /// Internal callback when a track starts using this source.
+        /// </summary>
+        /// <param name="track">The track using this source.</param>
+        internal void OnTrackAddedToSource(LocalAudioTrack track)
+        {
+            Debug.Assert(!_nativeHandle.IsClosed);
+            Debug.Assert(!Tracks.Contains(track));
+            Tracks.Add(track);
+        }
+
+        /// <summary>
+        /// Internal callback when a track stops using this source.
+        /// </summary>
+        /// <param name="track">The track not using this source anymore.</param>
+        internal void OnTrackRemovedFromSource(LocalAudioTrack track)
+        {
+            Debug.Assert(!_nativeHandle.IsClosed);
+            bool removed = Tracks.Remove(track);
+            Debug.Assert(removed);
+        }
+
+        /// <summary>
+        /// Internal callback when a list of tracks stop using this source, generally
+        /// as a result of a peer connection owning said tracks being closed.
+        /// </summary>
+        /// <param name="tracks">The list of tracks not using this source anymore.</param>
+        internal void OnTracksRemovedFromSource(List<LocalAudioTrack> tracks)
+        {
+            Debug.Assert(!_nativeHandle.IsClosed);
+            var remainingTracks = new List<LocalAudioTrack>();
+            foreach (var track in tracks)
+            {
+                if (track.Source == this)
+                {
+                    bool removed = Tracks.Remove(track);
+                    Debug.Assert(removed);
+                }
+                else
+                {
+                    remainingTracks.Add(track);
+                }
+            }
+            Tracks = remainingTracks;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"(AudioTrackSource)\"{Name}\"";
+        }
+    }
+}

--- a/libs/Microsoft.MixedReality.WebRTC/AudioTrackSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/AudioTrackSource.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// 
     /// The user owns the audio track source, and is in charge of keeping it alive until after all tracks using it
     /// are destroyed, and then dispose of it. The behavior of disposing of the track source while a track is still
-    /// using it is undefined. The <see cref="_tracks"/> property contains the list of tracks currently using the
+    /// using it is undefined. The <see cref="Tracks"/> property contains the list of tracks currently using the
     /// source.
     /// </summary>
     /// <seealso cref="LocalAudioTrack"/>

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/AudioTrackSourceInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/AudioTrackSourceInterop.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.MixedReality.WebRTC.Interop
+{
+    /// <summary>
+    /// Handle to a native audio track source object.
+    /// </summary>
+    internal sealed class AudioTrackSourceHandle : SafeHandle
+    {
+        /// <summary>
+        /// Check if the current handle is invalid, which means it is not referencing
+        /// an actual native object. Note that a valid handle only means that the internal
+        /// handle references a native object, but does not guarantee that the native
+        /// object is still accessible. It is only safe to access the native object if
+        /// the handle is not closed, which implies it being valid.
+        /// </summary>
+        public override bool IsInvalid => (handle == IntPtr.Zero);
+
+        /// <summary>
+        /// Default constructor for an invalid handle.
+        /// </summary>
+        public AudioTrackSourceHandle() : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        /// <summary>
+        /// Constructor for a valid handle referencing the given native object.
+        /// </summary>
+        /// <param name="handle">The valid internal handle to the native object.</param>
+        public AudioTrackSourceHandle(IntPtr handle) : base(IntPtr.Zero, ownsHandle: true)
+        {
+            SetHandle(handle);
+        }
+
+        /// <summary>
+        /// Release the native object while the handle is being closed.
+        /// </summary>
+        /// <returns>Return <c>true</c> if the native object was successfully released.</returns>
+        protected override bool ReleaseHandle()
+        {
+            AudioTrackSourceInterop.AudioTrackSource_RemoveRef(handle);
+            return true;
+        }
+    }
+
+    internal class AudioTrackSourceInterop
+    {
+        /// <summary>
+        /// Marshaling struct for initializing settings when opening a local audio device.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        internal ref struct LocalAudioDeviceMarshalInitConfig
+        {
+            public mrsOptBool AutoGainControl;
+
+            /// <summary>
+            /// Constructor for creating a local audio device initialization settings marshaling struct.
+            /// </summary>
+            /// <param name="settings">The settings to initialize the newly created marshaling struct.</param>
+            /// <seealso cref="AudioTrackSource.CreateFromDeviceAsync(LocalAudioDeviceInitConfig)"/>
+            public LocalAudioDeviceMarshalInitConfig(LocalAudioDeviceInitConfig settings)
+            {
+                AutoGainControl = new mrsOptBool(settings?.AutoGainControl);
+            }
+        }
+
+        #region P/Invoke static functions
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsAudioTrackSourceAddRef")]
+        public static unsafe extern void AudioTrackSource_AddRef(AudioTrackSourceHandle handle);
+
+        // Note - This is used during SafeHandle.ReleaseHandle(), so cannot use AudioTrackSourceHandle
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsAudioTrackSourceRemoveRef")]
+        public static unsafe extern void AudioTrackSource_RemoveRef(IntPtr handle);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsAudioTrackSourceSetName")]
+        public static unsafe extern void AudioTrackSource_SetName(AudioTrackSourceHandle handle, string name);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsAudioTrackSourceGetName")]
+        public static unsafe extern uint AudioTrackSource_GetName(AudioTrackSourceHandle handle, StringBuilder buffer,
+            ref ulong bufferCapacity);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsAudioTrackSourceSetUserData")]
+        public static unsafe extern void AudioTrackSource_SetUserData(AudioTrackSourceHandle handle, IntPtr userData);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsAudioTrackSourceGetUserData")]
+        public static unsafe extern IntPtr AudioTrackSource_GetUserData(AudioTrackSourceHandle handle);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsAudioTrackSourceCreateFromDevice")]
+        public static unsafe extern uint AudioTrackSource_CreateFromDevice(
+            in LocalAudioDeviceMarshalInitConfig config, out AudioTrackSourceHandle sourceHandle);
+
+        #endregion
+    }
+}

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/AudioTrackSourceInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/AudioTrackSourceInterop.cs
@@ -65,7 +65,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             /// <seealso cref="AudioTrackSource.CreateFromDeviceAsync(LocalAudioDeviceInitConfig)"/>
             public LocalAudioDeviceMarshalInitConfig(LocalAudioDeviceInitConfig settings)
             {
-                AutoGainControl = new mrsOptBool(settings?.AutoGainControl);
+                AutoGainControl = (mrsOptBool)settings?.AutoGainControl;
             }
         }
 

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/LocalAudioTrackInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/LocalAudioTrackInterop.cs
@@ -56,6 +56,14 @@ namespace Microsoft.MixedReality.WebRTC.Interop
 
     internal class LocalAudioTrackInterop
     {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        internal ref struct TrackInitConfig
+        {
+            [MarshalAs(UnmanagedType.LPStr)]
+            public string TrackName;
+        }
+
+
         #region Native functions
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
@@ -68,9 +76,9 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         public static unsafe extern void LocalAudioTrack_RemoveRef(IntPtr handle);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
-            EntryPoint = "mrsLocalAudioTrackCreateFromDevice")]
-        public static unsafe extern uint LocalAudioTrack_CreateFromDevice(in PeerConnectionInterop.LocalAudioTrackInteropInitConfig config,
-            string trackName, out LocalAudioTrackHandle trackHandle);
+            EntryPoint = "mrsLocalAudioTrackCreateFromSource")]
+        public static unsafe extern uint LocalAudioTrack_CreateFromSource(in TrackInitConfig initSettings,
+            AudioTrackSourceHandle sourceHandle, out LocalAudioTrackHandle trackHandle);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsLocalAudioTrackRegisterFrameCallback")]
@@ -86,6 +94,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         public static extern uint LocalAudioTrack_SetEnabled(LocalAudioTrackHandle trackHandle, int enabled);
 
         #endregion
+
 
         public class InteropCallbackArgs
         {

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/PeerConnectionInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/PeerConnectionInterop.cs
@@ -351,23 +351,6 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         }
 
         /// <summary>
-        /// Helper structure to pass parameters to the native implementation when creating a local audio track.
-        /// </summary>
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-        internal ref struct LocalAudioTrackInteropInitConfig
-        {
-            /// <summary>
-            /// Constructor for creating a local audio track.
-            /// </summary>
-            /// <param name="track">The newly created track wrapper.</param>
-            /// <param name="settings">The settings to initialize the newly created native track.</param>
-            /// <seealso cref="LocalAudioTrack.CreateFromDeviceAsync(LocalAudioTrackSettings)"/>
-            public LocalAudioTrackInteropInitConfig(LocalAudioTrack track, LocalAudioTrackSettings settings)
-            {
-            }
-        }
-
-        /// <summary>
         /// Helper structure to pass parameters to the native implementation when creating a local video track
         /// by opening a local video capture device.
         /// </summary>

--- a/libs/mrwebrtc/include/audio_track_source_interop.h
+++ b/libs/mrwebrtc/include/audio_track_source_interop.h
@@ -71,6 +71,6 @@ MRS_API mrsResult MRS_CALL mrsAudioTrackSourceCreateFromDevice(
 MRS_API void MRS_CALL mrsAudioTrackSourceRegisterFrameCallback(
     mrsAudioTrackSourceHandle source_handle,
     mrsAudioFrameCallback callback,
-    void* user_data) noexcept
+    void* user_data) noexcept;
 
 }  // extern "C"

--- a/libs/mrwebrtc/include/audio_track_source_interop.h
+++ b/libs/mrwebrtc/include/audio_track_source_interop.h
@@ -68,9 +68,9 @@ MRS_API mrsResult MRS_CALL mrsAudioTrackSourceCreateFromDevice(
 /// not hook those callbacks, and therefore the callback will never be called.
 /// This is a limitation of the underlying implementation.
 /// See https://bugs.chromium.org/p/webrtc/issues/detail?id=11602
-MRS_API void MRS_CALL mrsAudioTrackSourceRegisterFrameCallback(
-    mrsAudioTrackSourceHandle source_handle,
-    mrsAudioFrameCallback callback,
-    void* user_data) noexcept;
+//MRS_API void MRS_CALL mrsAudioTrackSourceRegisterFrameCallback(
+//    mrsAudioTrackSourceHandle source_handle,
+//    mrsAudioFrameCallback callback,
+//    void* user_data) noexcept;
 
 }  // extern "C"

--- a/libs/mrwebrtc/include/audio_track_source_interop.h
+++ b/libs/mrwebrtc/include/audio_track_source_interop.h
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "interop_api.h"
+
+extern "C" {
+
+/// Configuration for opening a local audio capture device (microphone) as an
+/// audio track source.
+struct mrsLocalAudioDeviceInitConfig {
+  /// Enable auto gain control (AGC).
+  mrsOptBool auto_gain_control_{mrsOptBool::kUnset};
+};
+
+/// Add a reference to the native object associated with the given handle.
+MRS_API void MRS_CALL
+mrsAudioTrackSourceAddRef(mrsAudioTrackSourceHandle handle) noexcept;
+
+/// Remove a reference from the native object associated with the given handle.
+MRS_API void MRS_CALL
+mrsAudioTrackSourceRemoveRef(mrsAudioTrackSourceHandle handle) noexcept;
+
+/// Assign some name to the track source, for logging and debugging.
+MRS_API void MRS_CALL
+mrsAudioTrackSourceSetName(mrsAudioTrackSourceHandle handle,
+                           const char* name) noexcept;
+
+/// Get the name to the track source. The caller must provide a buffer with a
+/// sufficent size to copy the name to, including a null terminator character.
+/// The |buffer| argument points to the raw buffer, and the |buffer_size| to the
+/// capacity of the buffer, in bytes. On return, if the buffer has enough
+/// capacity for the name and its null terminator, the name is copied to the
+/// buffer, and the actual buffer size consumed (including null terminator) is
+/// returned in |buffer_size|. If not, then the function returns
+/// |mrsResult::kBufferTooSmall|, and |buffer_size| contains the total size that
+/// the buffer would need for the call to succeed, such that the caller can
+/// retry with a buffer with that capacity.
+MRS_API mrsResult MRS_CALL
+mrsAudioTrackSourceGetName(mrsAudioTrackSourceHandle handle,
+                           char* buffer,
+                           uint64_t* buffer_size) noexcept;
+
+/// Assign some opaque user data to the audio track source. The implementation
+/// will store the pointer in the audio track source object and not touch it. It
+/// can be retrieved with |mrsAudioTrackSourceGetUserData()| at any point during
+/// the object lifetime. This is not multithread-safe.
+MRS_API void MRS_CALL
+mrsAudioTrackSourceSetUserData(mrsAudioTrackSourceHandle handle,
+                               void* user_data) noexcept;
+
+/// Get the opaque user data pointer previously assigned to the audio track
+/// source with |mrsAudioTrackSourceSetUserData()|. If no value was previously
+/// assigned, return |nullptr|. This is not multithread-safe.
+MRS_API void* MRS_CALL
+mrsAudioTrackSourceGetUserData(mrsAudioTrackSourceHandle handle) noexcept;
+
+/// Create an audio track source by opening a local audio capture device
+/// (microphone).
+MRS_API mrsResult MRS_CALL mrsAudioTrackSourceCreateFromDevice(
+    const mrsLocalAudioDeviceInitConfig* init_config,
+    mrsAudioTrackSourceHandle* source_handle_out) noexcept;
+
+/// Register a custom callback to be called when the audio track source produced
+/// a frame.
+/// WARNING: The default platform source internal implementation currently does
+/// not hook those callbacks, and therefore the callback will never be called.
+/// This is a limitation of the underlying implementation.
+/// See https://bugs.chromium.org/p/webrtc/issues/detail?id=11602
+MRS_API void MRS_CALL mrsAudioTrackSourceRegisterFrameCallback(
+    mrsAudioTrackSourceHandle source_handle,
+    mrsAudioFrameCallback callback,
+    void* user_data) noexcept
+
+}  // extern "C"

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -89,6 +89,9 @@ using mrsMediaTrackHandle = void*;
 /// Opaque handle to a native Transceiver interop object.
 using mrsTransceiverHandle = void*;
 
+/// Opaque handle to a native AudioTrackSource interop object.
+using mrsAudioTrackSourceHandle = void*;
+
 /// Opaque handle to a native LocalAudioTrack interop object.
 using mrsLocalAudioTrackHandle = void*;
 

--- a/libs/mrwebrtc/include/local_audio_track_interop.h
+++ b/libs/mrwebrtc/include/local_audio_track_interop.h
@@ -4,14 +4,18 @@
 #pragma once
 
 #include "audio_frame_observer.h"
+#include "audio_track_source_interop.h"
 #include "export.h"
 #include "interop_api.h"
 
 extern "C" {
 
-/// Configuration for opening a local audio capture device and creating a local
-/// audio track.
-struct mrsLocalAudioTrackInitConfig {};
+/// Configuration for creating a local audio track.
+struct mrsLocalAudioTrackInitSettings {
+  /// Track name. This must be a valid SDP token (see |mrsSdpTokenIsValid()|), or
+  /// |nullptr| to let the implementation generate a valid unique track name.
+  const char* track_name{};
+};
 
 /// Add a reference to the native object associated with the given handle.
 MRS_API void MRS_CALL
@@ -21,11 +25,10 @@ mrsLocalAudioTrackAddRef(mrsLocalAudioTrackHandle handle) noexcept;
 MRS_API void MRS_CALL
 mrsLocalAudioTrackRemoveRef(mrsLocalAudioTrackHandle handle) noexcept;
 
-/// Create a new local audio track by opening a local audio capture device
-/// (webcam).
-MRS_API mrsResult MRS_CALL mrsLocalAudioTrackCreateFromDevice(
-    const mrsLocalAudioTrackInitConfig* config,
-    const char* track_name,
+/// Create a new local audio track from an audio track source.
+MRS_API mrsResult MRS_CALL mrsLocalAudioTrackCreateFromSource(
+    const mrsLocalAudioTrackInitSettings* init_settings,
+    mrsAudioTrackSourceHandle source_handle,
     mrsLocalAudioTrackHandle* track_handle_out) noexcept;
 
 /// Register a custom callback to be called when the local audio track captured

--- a/libs/mrwebrtc/src/interop/audio_track_source_interop.cpp
+++ b/libs/mrwebrtc/src/interop/audio_track_source_interop.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This is a precompiled header, it must be on its own, followed by a blank
+// line, to prevent clang-format from reordering it with other headers.
+#include "pch.h"
+
+#include "audio_track_source_interop.h"
+#include "callback.h"
+#include "global_factory.h"
+#include "media/audio_track_source.h"
+#include "utils.h"
+
+using namespace Microsoft::MixedReality::WebRTC;
+
+void MRS_CALL
+mrsAudioTrackSourceAddRef(mrsAudioTrackSourceHandle handle) noexcept {
+  if (auto source = static_cast<AudioTrackSource*>(handle)) {
+    source->AddRef();
+  } else {
+    RTC_LOG(LS_WARNING)
+        << "Trying to add reference to NULL AudioTrackSource object.";
+  }
+}
+
+void MRS_CALL
+mrsAudioTrackSourceRemoveRef(mrsAudioTrackSourceHandle handle) noexcept {
+  if (auto source = static_cast<AudioTrackSource*>(handle)) {
+    source->RemoveRef();
+  } else {
+    RTC_LOG(LS_WARNING) << "Trying to remove reference from NULL "
+                           "AudioTrackSource object.";
+  }
+}
+
+void MRS_CALL mrsAudioTrackSourceSetName(mrsAudioTrackSourceHandle handle,
+                                         const char* name) noexcept {
+  if (auto source = static_cast<AudioTrackSource*>(handle)) {
+    source->SetName(name);
+  }
+}
+
+mrsResult MRS_CALL mrsAudioTrackSourceGetName(mrsAudioTrackSourceHandle handle,
+                                              char* buffer,
+                                              uint64_t* buffer_size) noexcept {
+  auto source = static_cast<AudioTrackSource*>(handle);
+  if (!source) {
+    RTC_LOG(LS_ERROR) << "Invalid handle to audio track source.";
+    return mrsResult::kInvalidNativeHandle;
+  }
+  if (!buffer) {
+    RTC_LOG(LS_ERROR) << "Invalid NULL string buffer.";
+    return mrsResult::kInvalidParameter;
+  }
+  if (!buffer_size) {
+    RTC_LOG(LS_ERROR) << "Invalid NULL string buffer size reference.";
+    return mrsResult::kInvalidParameter;
+  }
+  const std::string name = source->GetName();
+  const size_t capacity = *buffer_size;
+  const size_t size_with_terminator = name.size() + 1;
+  // Always assign size, even if buffer too small
+  *buffer_size = size_with_terminator;
+  if (size_with_terminator <= capacity) {
+    memcpy(buffer, name.c_str(), size_with_terminator);
+    return mrsResult::kSuccess;
+  }
+  return mrsResult::kBufferTooSmall;
+}
+
+void MRS_CALL mrsAudioTrackSourceSetUserData(mrsAudioTrackSourceHandle handle,
+                                             void* user_data) noexcept {
+  if (auto source = static_cast<AudioTrackSource*>(handle)) {
+    source->SetUserData(user_data);
+  }
+}
+
+void* MRS_CALL
+mrsAudioTrackSourceGetUserData(mrsAudioTrackSourceHandle handle) noexcept {
+  if (auto source = static_cast<AudioTrackSource*>(handle)) {
+    return source->GetUserData();
+  }
+  return nullptr;
+}
+
+mrsResult MRS_CALL mrsAudioTrackSourceCreateFromDevice(
+    const mrsLocalAudioDeviceInitConfig* init_config,
+    mrsAudioTrackSourceHandle* source_handle_out) noexcept {
+  if (!source_handle_out) {
+    RTC_LOG(LS_ERROR) << "Invalid NULL audio track source handle.";
+    return Result::kInvalidParameter;
+  }
+  *source_handle_out = nullptr;
+
+  RefPtr<GlobalFactory> global_factory(GlobalFactory::InstancePtr());
+  auto pc_factory = global_factory->GetPeerConnectionFactory();
+  if (!pc_factory) {
+    return Result::kInvalidOperation;
+  }
+
+  // Create the audio track source
+  cricket::AudioOptions options{};
+  options.auto_gain_control = ToOptional(init_config->auto_gain_control_);
+  rtc::scoped_refptr<webrtc::AudioSourceInterface> audio_source =
+      pc_factory->CreateAudioSource(options);
+  if (!audio_source) {
+    RTC_LOG(LS_ERROR)
+        << "Failed to create audio source from local audio capture device.";
+    return Result::kUnknownError;
+  }
+
+  // Create the wrapper
+  RefPtr<AudioTrackSource> wrapper =
+      new AudioTrackSource(global_factory, std::move(audio_source));
+  if (!wrapper) {
+    RTC_LOG(LS_ERROR) << "Failed to create audio track source.";
+    return Result::kUnknownError;
+  }
+  *source_handle_out = wrapper.release();
+  return Result::kSuccess;
+}
+
+void MRS_CALL mrsAudioTrackSourceRegisterFrameCallback(
+    mrsAudioTrackSourceHandle source_handle,
+    mrsAudioFrameCallback callback,
+    void* user_data) noexcept {
+  if (auto source = static_cast<AudioTrackSource*>(source_handle)) {
+    source->SetCallback(AudioFrameReadyCallback{callback, user_data});
+  }
+}

--- a/libs/mrwebrtc/src/interop/audio_track_source_interop.cpp
+++ b/libs/mrwebrtc/src/interop/audio_track_source_interop.cpp
@@ -120,11 +120,11 @@ mrsResult MRS_CALL mrsAudioTrackSourceCreateFromDevice(
   return Result::kSuccess;
 }
 
-void MRS_CALL mrsAudioTrackSourceRegisterFrameCallback(
-    mrsAudioTrackSourceHandle source_handle,
-    mrsAudioFrameCallback callback,
-    void* user_data) noexcept {
-  if (auto source = static_cast<AudioTrackSource*>(source_handle)) {
-    source->SetCallback(AudioFrameReadyCallback{callback, user_data});
-  }
-}
+//void MRS_CALL mrsAudioTrackSourceRegisterFrameCallback(
+//    mrsAudioTrackSourceHandle source_handle,
+//    mrsAudioFrameCallback callback,
+//    void* user_data) noexcept {
+//  if (auto source = static_cast<AudioTrackSource*>(source_handle)) {
+//    source->SetCallback(AudioFrameReadyCallback{callback, user_data});
+//  }
+//}

--- a/libs/mrwebrtc/src/interop/global_factory.cpp
+++ b/libs/mrwebrtc/src/interop/global_factory.cpp
@@ -40,6 +40,8 @@ absl::string_view ObjectTypeToString(ObjectType type) {
       return "AudioTransceiver";
     case ObjectType::kVideoTransceiver:
       return "VideoTransceiver";
+    case ObjectType::kAudioTrackSource:
+      return "AudioTrackSource";
     default:
       RTC_NOTREACHED();
       return "<UnknownObjectType>";

--- a/libs/mrwebrtc/src/interop/local_audio_track_interop.cpp
+++ b/libs/mrwebrtc/src/interop/local_audio_track_interop.cpp
@@ -5,8 +5,11 @@
 // line, to prevent clang-format from reordering it with other headers.
 #include "pch.h"
 
+#include "interop/global_factory.h"
 #include "local_audio_track_interop.h"
+#include "media/audio_track_source.h"
 #include "media/local_audio_track.h"
+#include "utils.h"
 
 using namespace Microsoft::MixedReality::WebRTC;
 
@@ -34,7 +37,51 @@ mrsLocalAudioTrackRemoveRef(mrsLocalAudioTrackHandle handle) noexcept {
   }
 }
 
-// mrsLocalAudioTrackCreateFromDevice -> interop_api.cpp
+mrsResult MRS_CALL mrsLocalAudioTrackCreateFromSource(
+    const mrsLocalAudioTrackInitSettings* init_settings,
+    mrsAudioTrackSourceHandle source_handle,
+    mrsLocalAudioTrackHandle* track_handle_out) noexcept {
+  if (!init_settings) {
+    RTC_LOG(LS_ERROR) << "Invalid NULL local audio track init settings.";
+    return Result::kInvalidParameter;
+  }
+  if (mrsBool::kFalse == mrsSdpIsValidToken(init_settings->track_name)) {
+    RTC_LOG(LS_ERROR) << "Local audio track name " << init_settings->track_name
+                      << " is not a valid SDP token.";
+    return Result::kInvalidParameter;
+  }
+  if (!source_handle) {
+    RTC_LOG(LS_ERROR) << "Invalid track source handle.";
+    return Result::kInvalidParameter;
+  }
+  if (!track_handle_out) {
+    RTC_LOG(LS_ERROR) << "Invalid NULL local audio track handle reference.";
+    return Result::kInvalidParameter;
+  }
+  *track_handle_out = nullptr;
+
+  RefPtr<GlobalFactory> global_factory(GlobalFactory::InstancePtr());
+  auto pc_factory = global_factory->GetPeerConnectionFactory();
+  if (!pc_factory) {
+    return Result::kInvalidOperation;
+  }
+
+  // Create the audio track
+  auto source = static_cast<AudioTrackSource*>(source_handle);
+  rtc::scoped_refptr<webrtc::AudioTrackInterface> audio_track =
+      pc_factory->CreateAudioTrack(init_settings->track_name,
+                                   source->impl().get());
+  if (!audio_track) {
+    RTC_LOG(LS_ERROR) << "Failed to create local audio track from source.";
+    return Result::kUnknownError;
+  }
+
+  // Create the audio track wrapper
+  RefPtr<LocalAudioTrack> track =
+      new LocalAudioTrack(std::move(global_factory), std::move(audio_track));
+  *track_handle_out = track.release();
+  return Result::kSuccess;
+}
 
 void MRS_CALL
 mrsLocalAudioTrackRegisterFrameCallback(mrsLocalAudioTrackHandle trackHandle,

--- a/libs/mrwebrtc/src/media/audio_track_source.cpp
+++ b/libs/mrwebrtc/src/media/audio_track_source.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "interop/global_factory.h"
+#include "media/audio_track_source.h"
+
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
+
+AudioSourceAdapter::AudioSourceAdapter(
+    rtc::scoped_refptr<webrtc::AudioSourceInterface> source)
+    : source_(std::move(source)), state_(source->state()) {}
+
+void AudioSourceAdapter::RegisterObserver(webrtc::ObserverInterface* observer) {
+  observer_ = observer;
+}
+
+void AudioSourceAdapter::UnregisterObserver(
+    webrtc::ObserverInterface* observer) {
+  RTC_DCHECK_EQ(observer_, observer);
+  observer_ = nullptr;
+}
+
+void AudioSourceAdapter::AddSink(webrtc::AudioTrackSinkInterface* sink) {
+  sinks_.push_back(sink);
+}
+
+void AudioSourceAdapter::RemoveSink(webrtc::AudioTrackSinkInterface* sink) {
+  auto it = std::find(sinks_.begin(), sinks_.end(), sink);
+  if (it != sinks_.end()) {
+    sinks_.erase(it);
+  }
+}
+
+AudioTrackSource::AudioTrackSource(
+    RefPtr<GlobalFactory> global_factory,
+    rtc::scoped_refptr<webrtc::AudioSourceInterface> source) noexcept
+    : TrackedObject(std::move(global_factory), ObjectType::kAudioTrackSource),
+      source_(std::move(source)) {
+  RTC_CHECK(source_);
+}
+
+AudioTrackSource::~AudioTrackSource() {
+  if (observer_) {
+    source_->RemoveSink(observer_.get());
+  }
+}
+
+void AudioTrackSource::SetCallback(AudioFrameReadyCallback callback) noexcept {
+  std::lock_guard<std::mutex> lock(observer_mutex_);
+  if (callback) {
+    // When assigning a new callback, create and register an observer.
+    if (!observer_) {
+      observer_ = std::make_unique<AudioFrameObserver>();
+      source_->AddSink(observer_.get());
+    }
+    observer_->SetCallback(callback);
+  } else {
+    // When clearing the existing callback, unregister and destroy the observer.
+    // This ensures the native source knows when there is no more observer, and
+    // can potentially optimize its behavior.
+    if (observer_) {
+      source_->RemoveSink(observer_.get());
+      observer_.reset();
+    }
+  }
+}
+
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/audio_track_source.h
+++ b/libs/mrwebrtc/src/media/audio_track_source.h
@@ -41,15 +41,12 @@ class AudioSourceAdapter : public webrtc::AudioSourceInterface {
   //
 
   // Sets the volume of the source. |volume| is in  the range of [0, 10].
-  // TODO(tommi): This method should be on the track and ideally volume should
-  // be applied in the track in a way that does not affect clones of the track.
   void SetVolume(double /*volume*/) override {}
 
   // Registers/unregisters observers to the audio source.
   void RegisterAudioObserver(AudioObserver* /*observer*/) override {}
   void UnregisterAudioObserver(AudioObserver* /*observer*/) override {}
 
-  // TODO(tommi): Make pure virtual.
   void AddSink(webrtc::AudioTrackSinkInterface* sink) override;
   void RemoveSink(webrtc::AudioTrackSinkInterface* sink) override;
 

--- a/libs/mrwebrtc/src/media/audio_track_source.h
+++ b/libs/mrwebrtc/src/media/audio_track_source.h
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "external_video_track_source_interop.h"
+#include "mrs_errors.h"
+#include "refptr.h"
+#include "tracked_object.h"
+#include "video_frame.h"
+
+#include "api/mediastreaminterface.h"
+
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
+
+class AudioTrackSource;
+
+/// Adapter for a local audio source backing one or more local audio tracks.
+class AudioSourceAdapter : public webrtc::AudioSourceInterface {
+ public:
+  AudioSourceAdapter(rtc::scoped_refptr<webrtc::AudioSourceInterface> source);
+
+  //
+  // NotifierInterface
+  //
+
+  void RegisterObserver(webrtc::ObserverInterface* observer) override;
+  void UnregisterObserver(webrtc::ObserverInterface* observer) override;
+
+  //
+  // MediaSourceInterface
+  //
+
+  SourceState state() const override { return state_; }
+  bool remote() const override { return false; }
+
+  //
+  // AudioSourceInterface
+  //
+
+  // Sets the volume of the source. |volume| is in  the range of [0, 10].
+  // TODO(tommi): This method should be on the track and ideally volume should
+  // be applied in the track in a way that does not affect clones of the track.
+  void SetVolume(double /*volume*/) override {}
+
+  // Registers/unregisters observers to the audio source.
+  void RegisterAudioObserver(AudioObserver* /*observer*/) override {}
+  void UnregisterAudioObserver(AudioObserver* /*observer*/) override {}
+
+  // TODO(tommi): Make pure virtual.
+  void AddSink(webrtc::AudioTrackSinkInterface* sink) override;
+  void RemoveSink(webrtc::AudioTrackSinkInterface* sink) override;
+
+ protected:
+  rtc::scoped_refptr<webrtc::AudioSourceInterface> source_;
+  std::vector<webrtc::AudioTrackSinkInterface*> sinks_;
+  SourceState state_{SourceState::kEnded};
+  webrtc::ObserverInterface* observer_{nullptr};
+  AudioObserver* audio_observer_{nullptr};
+};
+
+/// Base class for an audio track source acting as a frame source for one or
+/// more audio tracks.
+class AudioTrackSource : public TrackedObject {
+ public:
+  ///// Helper to create an audio track source from a custom audio frame request
+  ///// callback.
+  // static RefPtr<AudioTrackSource> createFromCustom(
+  //    RefPtr<GlobalFactory> global_factory,
+  //    RefPtr<CustomAudioSource> audio_source);
+
+  AudioTrackSource(
+      RefPtr<GlobalFactory> global_factory,
+      rtc::scoped_refptr<webrtc::AudioSourceInterface> source) noexcept;
+  ~AudioTrackSource() override;
+
+  void SetName(absl::string_view name) {
+    name_.assign(name.data(), name.size());
+  }
+
+  /// Get the name of the audio track source.
+  std::string GetName() const noexcept override { return name_; }
+
+  void SetCallback(AudioFrameReadyCallback callback) noexcept;
+
+  inline rtc::scoped_refptr<webrtc::AudioSourceInterface> impl() const
+      noexcept {
+    return source_;
+  }
+
+ protected:
+  rtc::scoped_refptr<webrtc::AudioSourceInterface> source_;
+  std::string name_;
+  std::unique_ptr<AudioFrameObserver> observer_;
+  std::mutex observer_mutex_;
+};
+
+namespace detail {
+
+//
+// Helpers
+//
+
+///// Create a custom audio track source wrapping the given interop callback.
+// RefPtr<AudioTrackSource> AudioTrackSourceCreateFromCustom(
+//    RefPtr<GlobalFactory> global_factory,
+//    mrsRequestCustomAudioFrameCallback callback,
+//    void* user_data);
+
+}  // namespace detail
+
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/tracked_object.h
+++ b/libs/mrwebrtc/src/tracked_object.h
@@ -29,6 +29,7 @@ enum class ObjectType : int {
   kDataChannel,
   kAudioTransceiver,
   kVideoTransceiver,
+  kAudioTrackSource,
 };
 
 /// Object tracked for interop, exposing helper methods for debugging purpose.

--- a/libs/mrwebrtc/test/audio_track_source_tests.cpp
+++ b/libs/mrwebrtc/test/audio_track_source_tests.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "audio_frame.h"
+#include "audio_track_source_interop.h"
+#include "interop_api.h"
+
+#include "test_utils.h"
+
+namespace {
+
+class AudioTrackSourceTests
+    : public TestUtils::TestBase,
+      public testing::WithParamInterface<mrsSdpSemantic> {};
+
+}  // namespace
+
+#if !defined(MRSW_EXCLUDE_DEVICE_TESTS)
+
+INSTANTIATE_TEST_CASE_P(,
+                        AudioTrackSourceTests,
+                        testing::ValuesIn(TestUtils::TestSemantics),
+                        TestUtils::SdpSemanticToString);
+
+TEST_P(AudioTrackSourceTests, CreateFromDevice) {
+  mrsLocalAudioDeviceInitConfig config{};
+  mrsAudioTrackSourceHandle source_handle{};
+  ASSERT_EQ(mrsResult::kSuccess,
+            mrsAudioTrackSourceCreateFromDevice(&config, &source_handle));
+  ASSERT_NE(nullptr, source_handle);
+  mrsAudioTrackSourceRemoveRef(source_handle);
+}
+
+// TODO - Don't use device, run outside MRSW_EXCLUDE_DEVICE_TESTS
+TEST_P(AudioTrackSourceTests, Name) {
+  mrsLocalAudioDeviceInitConfig config{};
+  mrsAudioTrackSourceHandle source_handle{};
+  ASSERT_EQ(mrsResult::kSuccess,
+            mrsAudioTrackSourceCreateFromDevice(&config, &source_handle));
+  ASSERT_NE(nullptr, source_handle);
+
+  // Exact-fit buffer
+  {
+    constexpr const char kTestName[] = "test_name_exact_fit_buffer";
+    constexpr const size_t kTestNameSize =
+        sizeof(kTestName);  // incl. zero-terminator
+    mrsAudioTrackSourceSetName(source_handle, kTestName);
+    constexpr const size_t kBufferSize = kTestNameSize;  // exact-fit
+    char buffer[kBufferSize];
+    size_t size = kBufferSize;
+    ASSERT_EQ(mrsResult::kSuccess,
+              mrsAudioTrackSourceGetName(source_handle, buffer, &size));
+    ASSERT_EQ(kTestNameSize, size);
+    ASSERT_EQ(0, memcmp(buffer, kTestName, kTestNameSize));
+  }
+
+  // Larger buffer
+  {
+    constexpr const char kTestName[] = "test_name_larger_buffer";
+    constexpr const size_t kTestNameSize =
+        sizeof(kTestName);  // incl. zero-terminator
+    mrsAudioTrackSourceSetName(source_handle, kTestName);
+    constexpr const size_t kBufferSize = kTestNameSize + 1;  // larger
+    char buffer[kBufferSize];
+    size_t size = kBufferSize;
+    ASSERT_EQ(mrsResult::kSuccess,
+              mrsAudioTrackSourceGetName(source_handle, buffer, &size));
+    ASSERT_EQ(kTestNameSize, size);
+    ASSERT_EQ(0, memcmp(buffer, kTestName, kTestNameSize));
+  }
+
+  // Buffer too small
+  {
+    constexpr const char kTestName[] = "test_name_buffer_too_small";
+    constexpr const size_t kTestNameSize =
+        sizeof(kTestName);  // incl. zero-terminator
+    mrsAudioTrackSourceSetName(source_handle, kTestName);
+    constexpr const size_t kBufferSize = kTestNameSize - 1;  // too small
+    char buffer[kBufferSize];
+    size_t size = kBufferSize;
+    ASSERT_EQ(mrsResult::kBufferTooSmall,
+              mrsAudioTrackSourceGetName(source_handle, buffer, &size));
+    ASSERT_EQ(kTestNameSize, size);
+  }
+
+  // Invalid buffer
+  {
+    size_t size = 0;
+    ASSERT_EQ(mrsResult::kInvalidParameter,
+              mrsAudioTrackSourceGetName(source_handle, nullptr, &size));
+  }
+
+  // Invalid size
+  {
+    char buffer[5];
+    ASSERT_EQ(mrsResult::kInvalidParameter,
+              mrsAudioTrackSourceGetName(source_handle, buffer, nullptr));
+  }
+
+  mrsAudioTrackSourceRemoveRef(source_handle);
+}
+
+#endif  // MRSW_EXCLUDE_DEVICE_TESTS

--- a/libs/mrwebrtc/test/audio_track_tests.cpp
+++ b/libs/mrwebrtc/test/audio_track_tests.cpp
@@ -127,11 +127,20 @@ TEST_P(AudioTrackTests, Simple) {
                                             &audio_transceiver1));
   ASSERT_NE(nullptr, audio_transceiver1);
 
+  // Create the audio source #1
+  mrsLocalAudioDeviceInitConfig device_config{};
+  mrsAudioTrackSourceHandle audio_source1{};
+  ASSERT_EQ(Result::kSuccess, mrsAudioTrackSourceCreateFromDevice(
+                                  &device_config, &audio_source1));
+  ASSERT_NE(nullptr, audio_source1);
+
   // Create the local audio track #1
-  mrsLocalAudioTrackInitConfig config{};
+  mrsLocalAudioTrackInitSettings init_settings{};
+  init_settings.track_name = "test_audio_track";
   mrsLocalAudioTrackHandle audio_track1{};
-  ASSERT_EQ(Result::kSuccess, mrsLocalAudioTrackCreateFromDevice(
-                                  &config, "test_audio_track", &audio_track1));
+  ASSERT_EQ(Result::kSuccess,
+            mrsLocalAudioTrackCreateFromSource(&init_settings, audio_source1,
+                                               &audio_track1));
   ASSERT_NE(nullptr, audio_track1);
 
   // Audio tracks start enabled
@@ -242,6 +251,7 @@ TEST_P(AudioTrackTests, Simple) {
   // Clean-up
   mrsRemoteAudioTrackRegisterFrameCallback(audio_track2, nullptr, nullptr);
   mrsLocalAudioTrackRemoveRef(audio_track1);
+  mrsAudioTrackSourceRemoveRef(audio_source1);
 }
 
 TEST_P(AudioTrackTests, Muted) {
@@ -274,11 +284,20 @@ TEST_P(AudioTrackTests, Muted) {
                                             &audio_transceiver1));
   ASSERT_NE(nullptr, audio_transceiver1);
 
+  // Create the audio source #1
+  mrsLocalAudioDeviceInitConfig device_config{};
+  mrsAudioTrackSourceHandle audio_source1{};
+  ASSERT_EQ(Result::kSuccess, mrsAudioTrackSourceCreateFromDevice(
+                                  &device_config, &audio_source1));
+  ASSERT_NE(nullptr, audio_source1);
+
   // Create the local audio track #1
-  mrsLocalAudioTrackInitConfig config{};
+  mrsLocalAudioTrackInitSettings init_settings{};
+  init_settings.track_name = "test_audio_track";
   mrsLocalAudioTrackHandle audio_track1{};
-  ASSERT_EQ(Result::kSuccess, mrsLocalAudioTrackCreateFromDevice(
-                                  &config, "test_audio_track", &audio_track1));
+  ASSERT_EQ(Result::kSuccess,
+            mrsLocalAudioTrackCreateFromSource(&init_settings, audio_source1,
+                                               &audio_track1));
   ASSERT_NE(nullptr, audio_track1);
 
   // Audio tracks start enabled
@@ -377,6 +396,7 @@ TEST_P(AudioTrackTests, Muted) {
   // Clean-up
   mrsRemoteAudioTrackRegisterFrameCallback(audio_track2, nullptr, nullptr);
   mrsLocalAudioTrackRemoveRef(audio_track1);
+  mrsAudioTrackSourceRemoveRef(audio_source1);
 }
 
 #endif  // MRSW_EXCLUDE_DEVICE_TESTS

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/AudioTrackSourceTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/AudioTrackSourceTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Microsoft.MixedReality.WebRTC.Tests
+{
+    [TestFixture(SdpSemantic.PlanB)]
+    [TestFixture(SdpSemantic.UnifiedPlan)]
+    internal class AudioTrackSourceTests : PeerConnectionTestBase
+    {
+        public AudioTrackSourceTests(SdpSemantic sdpSemantic) : base(sdpSemantic)
+        {
+        }
+
+#if !MRSW_EXCLUDE_DEVICE_TESTS
+
+        [Test]
+        public async Task CreateFromDevice()
+        {
+            using (AudioTrackSource source = await AudioTrackSource.CreateFromDeviceAsync())
+            {
+                Assert.IsNotNull(source);
+                Assert.AreEqual(string.Empty, source.Name);
+                Assert.AreEqual(0, source.Tracks.Count);
+            }
+        }
+
+        // TODO - Don't use device, run outside MRSW_EXCLUDE_DEVICE_TESTS
+        [Test]
+        public async Task Name()
+        {
+            using (AudioTrackSource source = await AudioTrackSource.CreateFromDeviceAsync())
+            {
+                Assert.IsNotNull(source);
+
+                const string kTestName = "test_audio_track_source_name";
+                source.Name = kTestName;
+                Assert.AreEqual(kTestName, source.Name);
+            }
+        }
+
+#endif // MRSW_EXCLUDE_DEVICE_TESTS
+    }
+}

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/LocalAudioTrackTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/LocalAudioTrackTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Microsoft.MixedReality.WebRTC.Tests
+{
+    [TestFixture(SdpSemantic.PlanB)]
+    [TestFixture(SdpSemantic.UnifiedPlan)]
+    internal class LocalAudioTrackTests : PeerConnectionTestBase
+    {
+        public LocalAudioTrackTests(SdpSemantic sdpSemantic) : base(sdpSemantic)
+        {
+        }
+
+#if !MRSW_EXCLUDE_DEVICE_TESTS
+
+        // TODO - Don't use device, run outside MRSW_EXCLUDE_DEVICE_TESTS
+        [Test]
+        public async Task CreateFromSource()
+        {
+            using (AudioTrackSource source = await AudioTrackSource.CreateFromDeviceAsync())
+            {
+                Assert.IsNotNull(source);
+
+                var settings = new LocalAudioTrackInitConfig { trackName = "track_name" };
+                using (LocalAudioTrack track = await LocalAudioTrack.CreateFromSourceAsync(source, settings))
+                {
+                    Assert.IsNotNull(track);
+                }
+            }
+        }
+
+#endif // MRSW_EXCLUDE_DEVICE_TESTS
+    }
+}

--- a/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj
+++ b/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj
@@ -150,6 +150,7 @@
   <ItemGroup>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\pch.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_frame.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\data_channel_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\export.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\external_video_track_source_interop.h" />
@@ -163,6 +164,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\data_channel.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\global_factory.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_read_buffer.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source_impl.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\local_video_track.h" />
@@ -193,6 +195,7 @@
     </ClCompile>
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\audio_frame_observer.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\data_channel.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\audio_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\data_channel_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\external_video_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\global_factory.cpp" />
@@ -200,6 +203,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\local_video_track_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\peer_connection_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_read_buffer.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\local_video_track.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\transceiver_interop.cpp" />

--- a/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj.filters
+++ b/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\external_video_track_source_interop.cpp">
@@ -87,6 +87,12 @@
     </ClCompile>
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\toggle_audio_mixer.cpp">
       <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.cpp">
+      <Filter>src\media</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\audio_track_source_interop.cpp">
+      <Filter>src\interop</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -203,6 +209,12 @@
     </ClInclude>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\toggle_audio_mixer.h">
       <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.h">
+      <Filter>src\media</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_track_source_interop.h">
+      <Filter>include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
@@ -123,6 +123,7 @@
   <ItemGroup>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\pch.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_frame.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\data_channel_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\export.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\external_video_track_source_interop.h" />
@@ -153,6 +154,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\tracked_object.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\utils.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\video_frame_observer.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\local_audio_track.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\media_track.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\remote_audio_track.h" />
@@ -167,6 +169,7 @@
     </ClCompile>
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\audio_frame_observer.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\data_channel.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\audio_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\data_channel_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\external_video_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\global_factory.cpp" />
@@ -180,6 +183,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\local_audio_track_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\remote_audio_track_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\remote_video_track_interop.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\local_audio_track.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\media_track.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\remote_audio_track.cpp" />

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj.filters
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\external_video_track_source_interop.cpp">
@@ -88,6 +88,12 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\toggle_audio_mixer.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\audio_track_source_interop.cpp">
+      <Filter>src\interop</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.cpp">
+      <Filter>src\media</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.h">
@@ -147,7 +153,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\mrs_errors.h">
       <Filter>src</Filter>
     </ClInclude>
-    <ClInclude Include="../pch.h">
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\pch.h">
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\peer_connection.h">
@@ -203,6 +209,12 @@
     </ClInclude>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\toggle_audio_mixer.h">
       <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_track_source_interop.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.h">
+      <Filter>src\media</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj
+++ b/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj
@@ -63,6 +63,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\video_test_utils.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\audio_track_source_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\audio_track_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\external_video_track_source_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\library_tests.cpp" />


### PR DESCRIPTION
Split the audio track source from the audio track, to allow sharing
across peer connections.

This change splits the former local audio track into 2 separate
components:
- The audio track source, which generates the raw audio frames,
  generally from a local audio capture device (microphone) but not
  necessarily. At this time only device-based sources are supported
  though. The audio track source is not associated with any peer
  connection in particular, and can be shared amongst any number of
  local audio tracks, from the same peer connection or not.
- The local audio track, which is associated with a particular peer
  connection, and which is a slim bridge between an audio track source
  and the audio transceiver of the peer connection.

This change adds support to the native and C# libraries only.