### PR TITLE
Fix vertical flip of video on OpenGL platforms

### DIFF
--- a/libs/unity/library/Runtime/Scripts/Media/MediaPlayer.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MediaPlayer.cs
@@ -179,15 +179,15 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             var videoSrc = (IVideoSource)VideoSource;
             switch (videoSrc.FrameEncoding)
             {
-                case VideoEncoding.I420A:
-                    _i420aFrameQueue = new VideoFrameQueue<I420AVideoFrameStorage>(frameQueueSize);
-                    videoSrc.RegisterCallback(I420AVideoFrameReady);
-                    break;
+            case VideoEncoding.I420A:
+                _i420aFrameQueue = new VideoFrameQueue<I420AVideoFrameStorage>(frameQueueSize);
+                videoSrc.RegisterCallback(I420AVideoFrameReady);
+                break;
 
-                case VideoEncoding.Argb32:
-                    _argb32FrameQueue = new VideoFrameQueue<Argb32VideoFrameStorage>(frameQueueSize);
-                    videoSrc.RegisterCallback(Argb32VideoFrameReady);
-                    break;
+            case VideoEncoding.Argb32:
+                _argb32FrameQueue = new VideoFrameQueue<Argb32VideoFrameStorage>(frameQueueSize);
+                videoSrc.RegisterCallback(Argb32VideoFrameReady);
+                break;
             }
         }
 
@@ -330,7 +330,10 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
                 // Copy data from C# buffer into system memory managed by Unity.
                 // Note: This only "looks right" in Unity because we apply the 
-                // "YUVFeedShader" to the texture (converting YUV planar to RGB).
+                // "YUVFeedShader(Unlit)" to the texture (converting YUV planar to RGB).
+                // Note: Texture2D.LoadRawTextureData() expects some bottom-up texture data but
+                // the WebRTC vdeo frame is top-down, so the image is uploaded vertically flipped,
+                // and needs to be flipped by in the shader used to sample it. See #388.
                 using (var profileScope = loadTextureDataMarker.Auto())
                 {
                     unsafe
@@ -378,6 +381,9 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                 }
 
                 // Copy data from C# buffer into system memory managed by Unity.
+                // Note: Texture2D.LoadRawTextureData() expects some bottom-up texture data but
+                // the WebRTC vdeo frame is top-down, so the image is uploaded vertically flipped,
+                // and needs to be flipped by in the shader used to sample it. See #388.
                 using (var profileScope = loadTextureDataMarker.Auto())
                 {
                     unsafe

--- a/libs/unity/library/Runtime/Scripts/Media/MediaPlayer.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MediaPlayer.cs
@@ -332,7 +332,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                 // Note: This only "looks right" in Unity because we apply the 
                 // "YUVFeedShader(Unlit)" to the texture (converting YUV planar to RGB).
                 // Note: Texture2D.LoadRawTextureData() expects some bottom-up texture data but
-                // the WebRTC vdeo frame is top-down, so the image is uploaded vertically flipped,
+                // the WebRTC video frame is top-down, so the image is uploaded vertically flipped,
                 // and needs to be flipped by in the shader used to sample it. See #388.
                 using (var profileScope = loadTextureDataMarker.Auto())
                 {
@@ -382,7 +382,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
                 // Copy data from C# buffer into system memory managed by Unity.
                 // Note: Texture2D.LoadRawTextureData() expects some bottom-up texture data but
-                // the WebRTC vdeo frame is top-down, so the image is uploaded vertically flipped,
+                // the WebRTC video frame is top-down, so the image is uploaded vertically flipped,
                 // and needs to be flipped by in the shader used to sample it. See #388.
                 using (var profileScope = loadTextureDataMarker.Auto())
                 {

--- a/libs/unity/library/Runtime/Shaders/ARGBFeedShaderUnlit.shader
+++ b/libs/unity/library/Runtime/Shaders/ARGBFeedShaderUnlit.shader
@@ -43,12 +43,18 @@ Shader "Video/ARGBFeedShader (unlit)"
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
-#if UNITY_UV_STARTS_AT_TOP
+                
+                // Flip texture coordinates vertically.
+                // Texture2D.LoadRawTextureData() always expects a bottom-up image, but the MediaPlayer
+                // upload code always get a top-down frame from WebRTC. The most efficient is to upload
+                // as is (inverted) and revert here.
                 o.uv.y = 1 - v.uv.y;
-#endif
+
 #ifdef MIRROR
+                // Optional left-right mirroring (horizontal flipping)
                 o.uv.x = 1 - v.uv.x;
 #endif
+
                 return o;
             }
 

--- a/libs/unity/library/Runtime/Shaders/YUVFeedShader.shader
+++ b/libs/unity/library/Runtime/Shaders/YUVFeedShader.shader
@@ -46,10 +46,15 @@ Shader "Video/YUVFeedShader (standard lit)"
         void surf(Input IN, inout SurfaceOutput o)
         {
             half3 yuv;
-#if UNITY_UV_STARTS_AT_TOP
+            
+            // Flip texture coordinates vertically.
+            // Texture2D.LoadRawTextureData() always expects a bottom-up image, but the MediaPlayer
+            // upload code always get a top-down frame from WebRTC. The most efficient is to upload
+            // as is (inverted) and revert here.
             IN.uv_YPlane.y = 1 - IN.uv_YPlane.y;
-#endif
+
 #ifdef MIRROR
+            // Optional left-right mirroring (horizontal flipping)
             IN.uv_YPlane.x = 1 - IN.uv_YPlane.x;
 #endif
             yuv.x = tex2D(_YPlane, IN.uv_YPlane).r;

--- a/libs/unity/library/Runtime/Shaders/YUVFeedShaderUnlit.shader
+++ b/libs/unity/library/Runtime/Shaders/YUVFeedShaderUnlit.shader
@@ -45,10 +45,15 @@ Shader "Video/YUVFeedShader (unlit)"
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
-#if UNITY_UV_STARTS_AT_TOP
+
+                // Flip texture coordinates vertically.
+                // Texture2D.LoadRawTextureData() always expects a bottom-up image, but the MediaPlayer
+                // upload code always get a top-down frame from WebRTC. The most efficient is to upload
+                // as is (inverted) and revert here.
                 o.uv.y = 1 - v.uv.y;
-#endif
+
 #ifdef MIRROR
+                // Optional left-right mirroring (horizontal flipping)
                 o.uv.x = 1 - v.uv.x;
 #endif
                 return o;


### PR DESCRIPTION
Fix video being rendered vertically flipped by the MediaPlayer component
when using the YUVFeedShader(Unlit) or ARGBFeedShader(Unlit) on
platforms using the OpenGL graphics API.

The Unity Texture2D.LoadRawTextureData() method used by the MediaPlayer
component always expects bottom-up image data, even when using Direct3D,
but the WebRTC video frames are always top-down. Instead of using a
costly CPU transform, simply upload the video frames inverted into the
YUV planar textures or the ARGB texture, and use the shader to flip the
texture back before rendering.

Bug: #388