### PR TITLE
Make Track.CreateFromSource synchronous

### DIFF
--- a/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
@@ -41,7 +41,7 @@ namespace TestAppUwp
             {
                 trackName = trackName
             };
-            var track = await LocalAudioTrack.CreateFromSourceAsync(source, settings);
+            var track = LocalAudioTrack.CreateFromSource(source, settings);
 
             SessionModel.Current.AudioTracks.Add(new AudioTrackViewModel
             {

--- a/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
@@ -120,7 +120,7 @@ namespace TestAppUwp
                     // FIXME - this leaks 'source', never disposed (and is the track itself disposed??)
                     var source = await AudioTrackSource.CreateFromDeviceAsync();
                     var settings = new LocalAudioTrackInitConfig();
-                    return await LocalAudioTrack.CreateFromSourceAsync(source, settings);
+                    return LocalAudioTrack.CreateFromSource(source, settings);
                 }
             });
 
@@ -132,7 +132,7 @@ namespace TestAppUwp
                     // FIXME - this leaks 'source', never disposed (and is the track itself disposed??)
                     var source = await VideoTrackSource.CreateFromDeviceAsync();
                     var settings = new LocalVideoTrackInitConfig();
-                    return await LocalVideoTrack.CreateFromSourceAsync(source, settings);
+                    return LocalVideoTrack.CreateFromSource(source, settings);
                 }
             });
 

--- a/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
@@ -315,7 +315,7 @@ namespace TestAppUwp
                 settings.height = formatInfo.Format.height;
                 settings.framerate = formatInfo.Format.framerate;
             }
-            var track = await LocalVideoTrack.CreateFromSourceAsync(source, settings);
+            var track = LocalVideoTrack.CreateFromSource(source, settings);
             // FIXME - this probably leaks the track, never disposed
 
             SessionModel.Current.VideoTracks.Add(new VideoTrackViewModel

--- a/examples/TestNetCoreConsole/Program.cs
+++ b/examples/TestNetCoreConsole/Program.cs
@@ -54,7 +54,7 @@ namespace TestNetCoreConsole
 
                     Console.WriteLine("Create local video track...");
                     var trackSettings = new LocalVideoTrackInitConfig { trackName = "webcam_track" };
-                    localVideoTrack = await LocalVideoTrack.CreateFromSourceAsync(videoTrackSource, trackSettings);
+                    localVideoTrack = LocalVideoTrack.CreateFromSource(videoTrackSource, trackSettings);
 
                     Console.WriteLine("Create video transceiver and add webcam track...");
                     videoTransceiver = pc.AddTransceiver(MediaKind.Video);
@@ -70,7 +70,7 @@ namespace TestNetCoreConsole
 
                     Console.WriteLine("Create local audio track...");
                     var trackSettings = new LocalAudioTrackInitConfig { trackName = "mic_track" };
-                    localAudioTrack = await LocalAudioTrack.CreateFromSourceAsync(audioTrackSource, trackSettings);
+                    localAudioTrack = LocalAudioTrack.CreateFromSource(audioTrackSource, trackSettings);
 
                     Console.WriteLine("Create audio transceiver and add mic track...");
                     audioTransceiver = pc.AddTransceiver(MediaKind.Audio);

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/LocalAudioTrackTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/LocalAudioTrackTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.WebRTC.Tests
                 Assert.IsNotNull(source);
 
                 var settings = new LocalAudioTrackInitConfig { trackName = "track_name" };
-                using (LocalAudioTrack track = await LocalAudioTrack.CreateFromSourceAsync(source, settings))
+                using (LocalAudioTrack track = LocalAudioTrack.CreateFromSource(source, settings))
                 {
                     Assert.IsNotNull(track);
                 }

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/LocalVideoTrackTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/LocalVideoTrackTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.MixedReality.WebRTC.Tests
 
             // Create local video track
             var settings = new LocalVideoTrackInitConfig();
-            LocalVideoTrack track1 = await LocalVideoTrack.CreateFromSourceAsync(source1, settings);
+            LocalVideoTrack track1 = LocalVideoTrack.CreateFromSource(source1, settings);
             Assert.IsNotNull(track1);
 
             // Add local video track channel to #1
@@ -244,7 +244,7 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             // Create local video track
             renegotiationEvent1_.Reset();
             var settings = new LocalVideoTrackInitConfig();
-            LocalVideoTrack track1 = await LocalVideoTrack.CreateFromSourceAsync(source1, settings);
+            LocalVideoTrack track1 = LocalVideoTrack.CreateFromSource(source1, settings);
             Assert.IsNotNull(track1);
             Assert.IsNull(track1.PeerConnection);
             Assert.IsNull(track1.Transceiver);


### PR DESCRIPTION
The process of creating the track from the source consists solely in creating the track object, and is therefore lightweight and does not mandate an asynchronous call. Make it synchronous for simplicity.