### PR TITLE
Add Windows DLL signing to Unity UPM release pipeline

### DIFF
--- a/tools/ci/release-cpp.yaml
+++ b/tools/ci/release-cpp.yaml
@@ -19,6 +19,7 @@ name: release-windows-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
 
 parameters:
 - name: nugetPackageVersion
+  displayName: 'NuGet package version (semver)'
   type: string
   default: '0.0.1-preview.1'
 

--- a/tools/ci/release-unity.yaml
+++ b/tools/ci/release-unity.yaml
@@ -11,83 +11,65 @@ pr: none
 name: release-unity-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
 
 parameters:
-- name: buildAgent
-  type: string
-  default: 'Hosted VS2017' # vs2017-win2016
-- name: npmPackageVersion
+- name: upmPackageVersion
+  displayName: 'UPM package version (semver)'
   type: string
   default: '0.0.1-preview.1'
 
 stages:
 
-# Compile all Release build variants of mrwebrtc.dll
-- stage: build_mrwebrtc
-  displayName: 'Build mrwebrtc'
+# Compile all Release build variants on Windows (Desktop and UWP).
+# This is done as a separate stage from packing to ensure all builds
+# for all variants succeeded before starting to pack anything.
+- stage: build
+  displayName: 'Build'
   jobs:
-  - template: templates/jobs-cpp.yaml
-    parameters:
-      buildAgent: '${{parameters.buildAgent}}'
-      buildPlatform: 'Win32'
-      buildArch: 'x86'
-      msbuildPlatform: 'Win32'
-      buildConfig: 'Release'
-      withTesting: false
-      publishArtifacts: true
-  - template: templates/jobs-cpp.yaml
-    parameters:
-      buildAgent: '${{parameters.buildAgent}}'
-      buildPlatform: 'Win32'
-      buildArch: 'x64'
-      msbuildPlatform: 'x64'
-      buildConfig: 'Release'
-      withTesting: false
-      publishArtifacts: true
-  - template: templates/jobs-cpp.yaml
-    parameters:
-      buildAgent: '${{parameters.buildAgent}}'
-      buildPlatform: 'UWP'
-      buildArch: 'x86'
-      msbuildPlatform: 'Win32'
-      buildConfig: 'Release'
-      withTesting: false
-      publishArtifacts: true
-  - template: templates/jobs-cpp.yaml
-    parameters:
-      buildAgent: '${{parameters.buildAgent}}'
-      buildPlatform: 'UWP'
-      buildArch: 'x64'
-      msbuildPlatform: 'x64'
-      buildConfig: 'Release'
-      withTesting: false
-      publishArtifacts: true
-  - template: templates/jobs-cpp.yaml
-    parameters:
-      buildAgent: '${{parameters.buildAgent}}'
-      buildPlatform: 'UWP'
-      buildArch: 'ARM'
-      msbuildPlatform: 'ARM'
-      buildConfig: 'Release'
-      withTesting: false
-      publishArtifacts: true
 
-# Compile Microsoft.MixedReality.WebRTC.dll
-- stage: build_cs
-  dependsOn: build_mrwebrtc
-  displayName: 'Build C# library'
-  jobs:
-  - template: templates/jobs-cs-build.yaml
+  # Build all Release variants of mrwebrtc.dll for Windows Desktop
+  - template: templates/jobs-mrwebrtc-release-build.yaml
     parameters:
-      buildAgent: '${{parameters.buildAgent}}'
+      buildPlatform: 'Win32'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x86'
       buildConfig: 'Release'
-      publishArtifacts: true
-      withTesting: false
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'Win32'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x64'
+      buildConfig: 'Release'
+
+  # Build all Release variants of mrwebrtc.dll for Windows UWP
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x86'
+      buildConfig: 'Release'
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x64'
+      buildConfig: 'Release'
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'ARM'
+      buildConfig: 'Release'
+
+  # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
+  - template: templates/jobs-cslib-release-build.yaml
+    parameters:
+      buildAgent: '$(MRWebRTC.BuildAgent)'
 
 # Package library and samples
 - stage: publish
-  dependsOn: build_cs
+  dependsOn: build
   displayName: 'Publish'
   jobs:
   - template: templates/jobs-unity-package.yaml
     parameters:
-      buildAgent: '${{parameters.buildAgent}}'
-      npmPackageVersion: '${{parameters.npmPackageVersion}}'
+      buildAgent: '$(MRWebRTC.PackageAgent)'
+      upmPackageVersion: '${{parameters.upmPackageVersion}}'

--- a/tools/ci/release-unity.yaml
+++ b/tools/ci/release-unity.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# MixedReality-WebRTC build pipeline for Unity packages release.
+# MixedReality-WebRTC build pipeline for Unity packages release
 
 # Disable branch and PR triggers
 trigger: none

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -7,7 +7,7 @@ parameters:
 - name: buildAgent
   type: string
   default: ''
-- name: npmPackageVersion
+- name: upmPackageVersion
   type: string
   default: ''
 
@@ -30,14 +30,14 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: '$(Build.SourcesDirectory)/tools/ci/computeNpmPackageVersion.ps1'
-      arguments: '-PackageJsonFile "libs/unity/library/package.json" -PackageVersion "${{parameters.npmPackageVersion}}"'
+      arguments: '-PackageJsonFile "libs/unity/library/package.json" -PackageVersion "${{parameters.upmPackageVersion}}"'
     timeoutInMinutes: 5
   - task: PowerShell@2
     displayName: 'Set package version (samples)'
     inputs:
       targetType: 'filePath'
       filePath: '$(Build.SourcesDirectory)/tools/ci/computeNpmPackageVersion.ps1'
-      arguments: '-PackageJsonFile "libs/unity/samples/package.json" -PackageVersion "${{parameters.npmPackageVersion}}"'
+      arguments: '-PackageJsonFile "libs/unity/samples/package.json" -PackageVersion "${{parameters.upmPackageVersion}}"'
     timeoutInMinutes: 5
 
   # Download mrwebrtc.dll
@@ -46,35 +46,35 @@ jobs:
     inputs:
       source: 'current'
       artifact: 'mrwebrtc_Win32-x86-Release'
-      patterns: '**/*.@(pdb|dll)'
+      patterns: '**/mrwebrtc.@(pdb|dll)'
       path: 'libs/unity/library/Runtime/Plugins/Win32/x86'
   - task: DownloadPipelineArtifact@2
     displayName: 'Download mrwebrtc library (Win32-x64-Release)'
     inputs:
       source: 'current'
       artifact: 'mrwebrtc_Win32-x64-Release'
-      patterns: '**/*.@(pdb|dll)'
+      patterns: '**/mrwebrtc.@(pdb|dll)'
       path: 'libs/unity/library/Runtime/Plugins/Win32/x86_64'
   - task: DownloadPipelineArtifact@2
     displayName: 'Download mrwebrtc library (UWP-x86-Release)'
     inputs:
       source: 'current'
       artifact: 'mrwebrtc_UWP-x86-Release'
-      patterns: '**/*.@(pdb|dll)'
+      patterns: '**/mrwebrtc.@(pdb|dll)'
       path: 'libs/unity/library/Runtime/Plugins/WSA/x86'
   - task: DownloadPipelineArtifact@2
     displayName: 'Download mrwebrtc library (UWP-x64-Release)'
     inputs:
       source: 'current'
       artifact: 'mrwebrtc_UWP-x64-Release'
-      patterns: '**/*.@(pdb|dll)'
+      patterns: '**/mrwebrtc.@(pdb|dll)'
       path: 'libs/unity/library/Runtime/Plugins/WSA/x86_64'
   - task: DownloadPipelineArtifact@2
     displayName: 'Download mrwebrtc library (UWP-ARM-Release)'
     inputs:
       source: 'current'
       artifact: 'mrwebrtc_UWP-ARM-Release'
-      patterns: '**/*.@(pdb|dll)'
+      patterns: '**/mrwebrtc.@(pdb|dll)'
       path: 'libs/unity/library/Runtime/Plugins/WSA/ARM'
 
   # Download Microsoft.MixedReality.WebRTC.dll
@@ -82,56 +82,120 @@ jobs:
     displayName: 'Download C# library'
     inputs:
       source: 'current'
-      artifact: 'cslib_Release'
-      patterns: '**/*.@(pdb|dll)'
+      artifact: 'cslib'
+      patterns: '**/Microsoft.MixedReality.WebRTC.@(pdb|dll)'
       path: 'libs/unity/library/Runtime/Plugins/Win32/x86_64'
 
-  # Write .npmrc
-  - task: PowerShell@2
-    displayName: 'Write .npmrc (library)'
+  # For debugging, list the packages content before signing
+  - powershell: |
+     foreach ($f in $(Get-ChildItem -Path libs/unity -Recurse)) {
+       Write-Host $f.FullName
+     }
+    displayName: 'List packages content'
+
+  # Run component detection before signing (mandatory by policy)
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection before signing'
     inputs:
-      targetType: 'filePath'
-      filePath: '$(Build.SourcesDirectory)/tools/ci/writeNpmrc.ps1'
-      arguments: '-Target "libs/unity/library/.npmrc"'
-    env:
-      NPM_PUBLISH_REGISTER: $(NPM_PUBLISH_REGISTER)
-      NPM_PUBLISH_AUTH: $(NPM_PUBLISH_AUTH)
-      NPM_PUBLISH_EMAIL: $(NPM_PUBLISH_EMAIL)
-    timeoutInMinutes: 5
+      sourceScanPath: 'libs/unity'
 
-  # Publish library
-  - script: |
-      cd libs/unity/library
-      npm publish --registry $(NPM_PUBLISH_REGISTER)
-    displayName: 'Publish NPM (library)'
-
-  # Delete .npmrc
-  - pwsh: |
-      Remove-Item -Path '$(Build.SourcesDirectory)/libs/unity/library/.npmrc' -Force -ErrorAction Ignore
-    displayName: 'Delete .npmrc (library)'
-    condition: always()
-
-  # Write .npmrc
-  - task: PowerShell@2
-    displayName: 'Write .npmrc (samples)'
+  # Sign library package content
+  - task: DownloadSecureFile@1
+    name: SignConfigFile_Content
+    displayName: 'Download signing file (content)'
     inputs:
-      targetType: 'filePath'
-      filePath: '$(Build.SourcesDirectory)/tools/ci/writeNpmrc.ps1'
-      arguments: '-Target "libs/unity/samples/.npmrc"'
+      secureFile: 'mr-webrtc-unity-signconfig-content.xml'
+    timeoutInMinutes: 10
+  - task: PkgESCodeSign@10
+    displayName: 'Sign library package content'
+    inputs:
+      signConfigXml: '$(SignConfigFile_Content.secureFilePath)'
+      inPathRoot: 'libs/unity/library'
+      outPathRoot: 'libs/unity/library'
     env:
-      NPM_PUBLISH_REGISTER: $(NPM_PUBLISH_REGISTER)
-      NPM_PUBLISH_AUTH: $(NPM_PUBLISH_AUTH)
-      NPM_PUBLISH_EMAIL: $(NPM_PUBLISH_EMAIL)
-    timeoutInMinutes: 5
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-  # Publish samples
-  - script: |
-      cd libs/unity/samples
-      npm publish --registry $(NPM_PUBLISH_REGISTER)
-    displayName: 'Publish NPM (samples)'
+  # For debugging, list the packages content after signing
+  - powershell: |
+     foreach ($f in $(Get-ChildItem -Path libs/unity -Recurse)) {
+       Write-Host $f.FullName
+     }
+    displayName: 'List packages content'
 
-  # Delete .npmrc
+  # Pack the NPM package (library)
   - pwsh: |
-      Remove-Item -Path '$(Build.SourcesDirectory)/libs/unity/samples/.npmrc' -Force -ErrorAction Ignore
-    displayName: 'Delete .npmrc (samples)'
-    condition: always()
+      Set-Location "libs/unity/library"
+      Invoke-Expression "npm pack ." | Tee-Object -Variable PackageName | Out-Null
+      Write-Host "##vso[task.setvariable variable=PackedLibraryFilename]$PackageName"
+    displayName: 'Pack NPM (library)'
+
+  # Pack the NPM package (samples)
+  - pwsh: |
+      Set-Location "libs/unity/samples"
+      Invoke-Expression "npm pack ." | Tee-Object -Variable PackageName | Out-Null
+      Write-Host "##vso[task.setvariable variable=PackedSamplesFilename]$PackageName"
+    displayName: 'Pack NPM (samples)'
+
+  # Publish the UPM package (library)
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish artifact (library)'
+    inputs:
+      path: '$PackedLibraryFilename'
+      artifact: 'upm_library'
+
+  # Publish the UPM package (samples)
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish artifact (samples)'
+    inputs:
+      path: '$PackedSamplesFilename'
+      artifact: 'upm_samples'
+
+  # # Write .npmrc
+  # - task: PowerShell@2
+  #   displayName: 'Write .npmrc (library)'
+  #   inputs:
+  #     targetType: 'filePath'
+  #     filePath: '$(Build.SourcesDirectory)/tools/ci/writeNpmrc.ps1'
+  #     arguments: '-Target "libs/unity/library/.npmrc"'
+  #   env:
+  #     NPM_PUBLISH_REGISTER: $(NPM_PUBLISH_REGISTER)
+  #     NPM_PUBLISH_AUTH: $(NPM_PUBLISH_AUTH)
+  #     NPM_PUBLISH_EMAIL: $(NPM_PUBLISH_EMAIL)
+  #   timeoutInMinutes: 5
+
+  # # Publish library
+  # - script: |
+  #     cd libs/unity/library
+  #     npm publish --registry $(NPM_PUBLISH_REGISTER)
+  #   displayName: 'Publish NPM (library)'
+
+  # # Delete .npmrc
+  # - pwsh: |
+  #     Remove-Item -Path '$(Build.SourcesDirectory)/libs/unity/library/.npmrc' -Force -ErrorAction Ignore
+  #   displayName: 'Delete .npmrc (library)'
+  #   condition: always()
+
+  # # Write .npmrc
+  # - task: PowerShell@2
+  #   displayName: 'Write .npmrc (samples)'
+  #   inputs:
+  #     targetType: 'filePath'
+  #     filePath: '$(Build.SourcesDirectory)/tools/ci/writeNpmrc.ps1'
+  #     arguments: '-Target "libs/unity/samples/.npmrc"'
+  #   env:
+  #     NPM_PUBLISH_REGISTER: $(NPM_PUBLISH_REGISTER)
+  #     NPM_PUBLISH_AUTH: $(NPM_PUBLISH_AUTH)
+  #     NPM_PUBLISH_EMAIL: $(NPM_PUBLISH_EMAIL)
+  #   timeoutInMinutes: 5
+
+  # # Publish samples
+  # - script: |
+  #     cd libs/unity/samples
+  #     npm publish --registry $(NPM_PUBLISH_REGISTER)
+  #   displayName: 'Publish NPM (samples)'
+
+  # # Delete .npmrc
+  # - pwsh: |
+  #     Remove-Item -Path '$(Build.SourcesDirectory)/libs/unity/samples/.npmrc' -Force -ErrorAction Ignore
+  #   displayName: 'Delete .npmrc (samples)'
+  #   condition: always()

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -126,6 +126,7 @@ jobs:
   - pwsh: |
       Set-Location "libs/unity/library"
       Invoke-Expression "npm pack ." | Tee-Object -Variable PackageName | Out-Null
+      Write-Host "Produced package '$PackageName'"
       Write-Host "##vso[task.setvariable variable=PackedLibraryFilename]$PackageName"
     displayName: 'Pack NPM (library)'
 
@@ -133,6 +134,7 @@ jobs:
   - pwsh: |
       Set-Location "libs/unity/samples"
       Invoke-Expression "npm pack ." | Tee-Object -Variable PackageName | Out-Null
+      Write-Host "Produced package '$PackageName'"
       Write-Host "##vso[task.setvariable variable=PackedSamplesFilename]$PackageName"
     displayName: 'Pack NPM (samples)'
 
@@ -140,14 +142,14 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: 'Publish artifact (library)'
     inputs:
-      path: '$(PackedLibraryFilename)'
+      path: '$(Build.SourcesDirectory)/libs/unity/library/$(PackedLibraryFilename)'
       artifact: 'upm_library'
 
   # Publish the UPM package (samples)
   - task: PublishPipelineArtifact@1
     displayName: 'Publish artifact (samples)'
     inputs:
-      path: '$(PackedSamplesFilename)'
+      path: '$(Build.SourcesDirectory)/libs/unity/samples/$(PackedSamplesFilename)'
       artifact: 'upm_samples'
 
   # # Write .npmrc

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -152,6 +152,13 @@ jobs:
       path: '$(Build.SourcesDirectory)/libs/unity/samples/$(PackedSamplesFilename)'
       artifact: 'upm_samples'
 
+  # The tasks below can replace the publish tasks above to publish directly to an NPM register
+  # instead of as an Azure Pipeline Artifact. Unfortunately Azure DevOps currently does not
+  # support manual gates ("approve button") for publishing, so to ensure more control we publish
+  # as artifacts and then manually upload those artifacts after a last quick manual check.
+  # Leaving the tasks below commented for reference, as correct auth was tricky to figure out;
+  # the built-in NPM tasks were not able to auth correctly with our test NPM register (private).
+
   # # Write .npmrc
   # - task: PowerShell@2
   #   displayName: 'Write .npmrc (library)'

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -110,8 +110,8 @@ jobs:
     displayName: 'Sign library package content'
     inputs:
       signConfigXml: '$(SignConfigFile_Content.secureFilePath)'
-      inPathRoot: 'libs/unity/library'
-      outPathRoot: 'libs/unity/library'
+      inPathRoot: '$(Build.SourcesDirectory)/libs/unity/library'
+      outPathRoot: '$(Build.SourcesDirectory)/libs/unity/library'
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -140,14 +140,14 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: 'Publish artifact (library)'
     inputs:
-      path: '$PackedLibraryFilename'
+      path: '$(PackedLibraryFilename)'
       artifact: 'upm_library'
 
   # Publish the UPM package (samples)
   - task: PublishPipelineArtifact@1
     displayName: 'Publish artifact (samples)'
     inputs:
-      path: '$PackedSamplesFilename'
+      path: '$(PackedSamplesFilename)'
       artifact: 'upm_samples'
 
   # # Write .npmrc


### PR DESCRIPTION
Make the Unity UPM release pipeline sign the Windows DLLs before packaging.