### PR TITLE
Split audio device source and base audio source

### DIFF
--- a/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/AudioCaptureViewModel.cs
@@ -35,7 +35,7 @@ namespace TestAppUwp
 
                     // FIXME - this leaks 'source', never disposed (and is the track itself disposed??)
             var initConfig = new LocalAudioDeviceInitConfig();
-            var source = await AudioTrackSource.CreateFromDeviceAsync(initConfig);
+            var source = await DeviceAudioTrackSource.CreateAsync(initConfig);
 
             var settings = new LocalAudioTrackInitConfig
             {

--- a/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
@@ -118,7 +118,7 @@ namespace TestAppUwp
                 Factory = async () =>
                 {
                     // FIXME - this leaks 'source', never disposed (and is the track itself disposed??)
-                    var source = await AudioTrackSource.CreateFromDeviceAsync();
+                    var source = await DeviceAudioTrackSource.CreateAsync();
                     var settings = new LocalAudioTrackInitConfig();
                     return LocalAudioTrack.CreateFromSource(source, settings);
                 }

--- a/examples/TestNetCoreConsole/Program.cs
+++ b/examples/TestNetCoreConsole/Program.cs
@@ -66,7 +66,7 @@ namespace TestNetCoreConsole
                 if (needAudio)
                 {
                     Console.WriteLine("Opening local microphone...");
-                    audioTrackSource = await AudioTrackSource.CreateFromDeviceAsync();
+                    audioTrackSource = await DeviceAudioTrackSource.CreateAsync();
 
                     Console.WriteLine("Create local audio track...");
                     var trackSettings = new LocalAudioTrackInitConfig { trackName = "mic_track" };

--- a/libs/Microsoft.MixedReality.WebRTC/AudioTrackSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/AudioTrackSource.cs
@@ -4,22 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using Microsoft.MixedReality.WebRTC.Interop;
 
 namespace Microsoft.MixedReality.WebRTC
 {
-    /// <summary>
-    /// Configuration to initialize capture on a local audio device (microphone).
-    /// </summary>
-    public class LocalAudioDeviceInitConfig
-    {
-        /// <summary>
-        /// Enable automated gain control (AGC) on the audio device capture pipeline.
-        /// </summary>
-        public bool? AutoGainControl = null;
-    }
-
     /// <summary>
     /// Audio source for WebRTC audio tracks.
     /// 
@@ -34,7 +22,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// source.
     /// </summary>
     /// <seealso cref="LocalAudioTrack"/>
-    public class AudioTrackSource : IDisposable
+    public abstract class AudioTrackSource : IDisposable
     {
         /// <summary>
         /// A name for the audio track source, used for logging and debugging.
@@ -78,25 +66,6 @@ namespace Microsoft.MixedReality.WebRTC
         /// Backing field for <see cref="Tracks"/>.
         /// </summary>
         private List<LocalAudioTrack> _tracks = new List<LocalAudioTrack>();
-
-        /// <summary>
-        /// Create an audio track source using a local audio capture device (microphone).
-        /// </summary>
-        /// <param name="initConfig">Optional configuration to initialize the audio capture on the device.</param>
-        /// <returns>The newly create audio track source.</returns>
-        public static Task<AudioTrackSource> CreateFromDeviceAsync(LocalAudioDeviceInitConfig initConfig = null)
-        {
-            return Task.Run(() =>
-            {
-                // On UWP this cannot be called from the main UI thread, so always call it from
-                // a background worker thread.
-
-                var config = new AudioTrackSourceInterop.LocalAudioDeviceMarshalInitConfig(initConfig);
-                uint ret = AudioTrackSourceInterop.AudioTrackSource_CreateFromDevice(in config, out AudioTrackSourceHandle handle);
-                Utils.ThrowOnErrorCode(ret);
-                return new AudioTrackSource(handle);
-            });
-        }
 
         internal AudioTrackSource(AudioTrackSourceHandle nativeHandle)
         {

--- a/libs/Microsoft.MixedReality.WebRTC/DeviceAudioTrackSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/DeviceAudioTrackSource.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.MixedReality.WebRTC.Interop;
+
+namespace Microsoft.MixedReality.WebRTC
+{
+    /// <summary>
+    /// Configuration to initialize capture on a local audio device (microphone).
+    /// </summary>
+    public class LocalAudioDeviceInitConfig
+    {
+        /// <summary>
+        /// Enable automated gain control (AGC) on the audio device capture pipeline.
+        /// </summary>
+        public bool? AutoGainControl = null;
+    }
+
+    /// <summary>
+    /// Implementation of an audio track source producing frames captured from an audio capture device (microphone).
+    /// </summary>
+    /// <seealso cref="LocalAudioTrack"/>
+    public class DeviceAudioTrackSource : AudioTrackSource
+    {
+        /// <summary>
+        /// Create an audio track source using a local audio capture device (microphone).
+        /// </summary>
+        /// <param name="initConfig">Optional configuration to initialize the audio capture on the device.</param>
+        /// <returns>The newly create audio track source.</returns>
+        /// <seealso cref="LocalAudioTrack.CreateFromSource(AudioTrackSource, LocalAudioTrackInitConfig)"/>
+        public static Task<DeviceAudioTrackSource> CreateAsync(LocalAudioDeviceInitConfig initConfig = null)
+        {
+            return Task.Run(() =>
+            {
+                // On UWP this cannot be called from the main UI thread, so always call it from
+                // a background worker thread.
+
+                var config = new DeviceAudioTrackSourceInterop.LocalAudioDeviceMarshalInitConfig(initConfig);
+                uint ret = DeviceAudioTrackSourceInterop.DeviceAudioTrackSource_Create(in config, out DeviceAudioTrackSourceHandle handle);
+                Utils.ThrowOnErrorCode(ret);
+                return new DeviceAudioTrackSource(handle);
+            });
+        }
+
+        internal DeviceAudioTrackSource(AudioTrackSourceHandle nativeHandle) : base(nativeHandle)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"(DeviceAudioTrackSource)\"{Name}\"";
+        }
+    }
+}

--- a/libs/Microsoft.MixedReality.WebRTC/DeviceVideoTrackSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/DeviceVideoTrackSource.cs
@@ -147,7 +147,7 @@ namespace Microsoft.MixedReality.WebRTC
         /// </code>
         /// </example>
         /// <seealso cref="LocalVideoTrack.CreateFromSource(VideoTrackSource, LocalVideoTrackInitConfig)"/>
-        public static Task<VideoTrackSource> CreateAsync(LocalVideoDeviceInitConfig initConfig = null)
+        public static Task<DeviceVideoTrackSource> CreateAsync(LocalVideoDeviceInitConfig initConfig = null)
         {
             return Task.Run(() =>
             {
@@ -157,7 +157,7 @@ namespace Microsoft.MixedReality.WebRTC
                 var config = new DeviceVideoTrackSourceInterop.LocalVideoDeviceMarshalInitConfig(initConfig);
                 uint ret = DeviceVideoTrackSourceInterop.DeviceVideoTrackSource_Create(in config, out DeviceVideoTrackSourceHandle handle);
                 Utils.ThrowOnErrorCode(ret);
-                return (VideoTrackSource)new DeviceVideoTrackSource(handle);
+                return new DeviceVideoTrackSource(handle);
             });
         }
 

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/AudioTrackSourceInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/AudioTrackSourceInterop.cs
@@ -3,43 +3,11 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Microsoft.MixedReality.WebRTC.Interop
 {
     /// <summary>
     /// Handle to a native audio track source object.
     /// </summary>
-    internal sealed class AudioTrackSourceHandle : RefCountedObjectHandle { }
-
-    internal class AudioTrackSourceInterop
-    {
-        /// <summary>
-        /// Marshaling struct for initializing settings when opening a local audio device.
-        /// </summary>
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-        internal ref struct LocalAudioDeviceMarshalInitConfig
-        {
-            public mrsOptBool AutoGainControl;
-
-            /// <summary>
-            /// Constructor for creating a local audio device initialization settings marshaling struct.
-            /// </summary>
-            /// <param name="settings">The settings to initialize the newly created marshaling struct.</param>
-            /// <seealso cref="AudioTrackSource.CreateFromDeviceAsync(LocalAudioDeviceInitConfig)"/>
-            public LocalAudioDeviceMarshalInitConfig(LocalAudioDeviceInitConfig settings)
-            {
-                AutoGainControl = (mrsOptBool)settings?.AutoGainControl;
-            }
-        }
-
-        #region P/Invoke static functions
-
-        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
-            EntryPoint = "mrsAudioTrackSourceCreateFromDevice")]
-        public static unsafe extern uint AudioTrackSource_CreateFromDevice(
-            in LocalAudioDeviceMarshalInitConfig config, out AudioTrackSourceHandle sourceHandle);
-
-        #endregion
-    }
+    internal class AudioTrackSourceHandle : RefCountedObjectHandle { }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/DeviceAudioTrackSourceInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/DeviceAudioTrackSourceInterop.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.MixedReality.WebRTC.Interop
+{
+    /// <summary>
+    /// Handle to a native device audio track source object.
+    /// </summary>
+    internal sealed class DeviceAudioTrackSourceHandle : AudioTrackSourceHandle { }
+
+    internal class DeviceAudioTrackSourceInterop
+    {
+        /// <summary>
+        /// Marshaling struct for initializing settings when opening a local audio device.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        internal ref struct LocalAudioDeviceMarshalInitConfig
+        {
+            public mrsOptBool AutoGainControl;
+
+            /// <summary>
+            /// Constructor for creating a local audio device initialization settings marshaling struct.
+            /// </summary>
+            /// <param name="settings">The settings to initialize the newly created marshaling struct.</param>
+            /// <seealso cref="DeviceAudioTrackSource.CreateAsync(LocalAudioDeviceInitConfig)"/>
+            public LocalAudioDeviceMarshalInitConfig(LocalAudioDeviceInitConfig settings)
+            {
+                AutoGainControl = (mrsOptBool)settings?.AutoGainControl;
+            }
+        }
+
+        #region P/Invoke static functions
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsDeviceAudioTrackSourceCreate")]
+        public static unsafe extern uint DeviceAudioTrackSource_Create(
+            in LocalAudioDeviceMarshalInitConfig config, out DeviceAudioTrackSourceHandle sourceHandle);
+
+        #endregion
+    }
+}

--- a/libs/mrwebrtc/include/audio_track_source_interop.h
+++ b/libs/mrwebrtc/include/audio_track_source_interop.h
@@ -7,20 +7,6 @@
 
 extern "C" {
 
-/// Configuration for opening a local audio capture device (microphone) as an
-/// audio track source.
-struct mrsLocalAudioDeviceInitConfig {
-  /// Enable auto gain control (AGC).
-  mrsOptBool auto_gain_control_{mrsOptBool::kUnset};
-};
-
-
-/// Create an audio track source by opening a local audio capture device
-/// (microphone).
-MRS_API mrsResult MRS_CALL mrsAudioTrackSourceCreateFromDevice(
-    const mrsLocalAudioDeviceInitConfig* init_config,
-    mrsAudioTrackSourceHandle* source_handle_out) noexcept;
-
 /// Register a custom callback to be called when the audio track source produced
 /// a frame.
 /// WARNING: The default platform source internal implementation currently does

--- a/libs/mrwebrtc/include/device_audio_track_source_interop.h
+++ b/libs/mrwebrtc/include/device_audio_track_source_interop.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "interop_api.h"
+
+extern "C" {
+
+/// Configuration for opening a local audio capture device (microphone) as an
+/// audio track source.
+struct mrsLocalAudioDeviceInitConfig {
+  /// Enable auto gain control (AGC).
+  mrsOptBool auto_gain_control_{mrsOptBool::kUnset};
+};
+
+/// Create an audio track source by opening a local audio capture device
+/// (microphone).
+MRS_API mrsResult MRS_CALL mrsDeviceAudioTrackSourceCreate(
+    const mrsLocalAudioDeviceInitConfig* init_config,
+    mrsDeviceAudioTrackSourceHandle* source_handle_out) noexcept;
+
+}  // extern "C"

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -119,6 +119,9 @@ using mrsExternalVideoTrackSourceHandle = mrsVideoTrackSourceHandle;
 /// Opaque handle to a native DeviceVideoTrackSource interop object.
 using mrsDeviceVideoTrackSourceHandle = mrsVideoTrackSourceHandle;
 
+/// Opaque handle to a native DeviceAudioTrackSource interop object.
+using mrsDeviceAudioTrackSourceHandle = mrsAudioTrackSourceHandle;
+
 //
 // Video capture enumeration
 //
@@ -189,8 +192,8 @@ struct mrsIceCandidate {
 /// the JSEP offer/answer exchange successfully.
 using mrsPeerConnectionConnectedCallback = void(MRS_CALL*)(void* user_data);
 
-/// Callback invoked when a local SDP message has been prepared and is ready to be
-/// sent by the user via the signaling service.
+/// Callback invoked when a local SDP message has been prepared and is ready to
+/// be sent by the user via the signaling service.
 using mrsPeerConnectionLocalSdpReadytoSendCallback = void(
     MRS_CALL*)(void* user_data, mrsSdpMessageType type, const char* sdp_data);
 
@@ -224,8 +227,8 @@ enum class mrsIceGatheringState : int32_t {
 using mrsPeerConnectionIceStateChangedCallback =
     void(MRS_CALL*)(void* user_data, mrsIceConnectionState new_state);
 
-/// Callback invoked when a renegotiation of the current session needs to occur to
-/// account for new parameters (e.g. added or removed tracks).
+/// Callback invoked when a renegotiation of the current session needs to occur
+/// to account for new parameters (e.g. added or removed tracks).
 using mrsPeerConnectionRenegotiationNeededCallback =
     void(MRS_CALL*)(void* user_data);
 
@@ -320,9 +323,9 @@ struct mrsDataChannelAddedInfo {
   const char* label{nullptr};
 };
 
-/// Callback invoked when a data channel is added to the peer connection. This is
-/// called for both channels that are created locally and ones that are created
-/// by the remote peer.
+/// Callback invoked when a data channel is added to the peer connection. This
+/// is called for both channels that are created locally and ones that are
+/// created by the remote peer.
 ///
 /// Use this callback to call |mrsDataChannelRegisterCallbacks| on new data
 /// channels and to start listening for messages/state changes.
@@ -466,18 +469,18 @@ MRS_API void MRS_CALL mrsPeerConnectionRegisterIceStateChangedCallback(
     mrsPeerConnectionIceStateChangedCallback callback,
     void* user_data) noexcept;
 
-/// Register a callback invoked when a renegotiation of the current session needs
-/// to occur to account for new parameters (e.g. added or removed tracks).
+/// Register a callback invoked when a renegotiation of the current session
+/// needs to occur to account for new parameters (e.g. added or removed tracks).
 MRS_API void MRS_CALL mrsPeerConnectionRegisterRenegotiationNeededCallback(
     mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionRenegotiationNeededCallback callback,
     void* user_data) noexcept;
 
-/// Register a callback invoked when a remote audio track is added to the current
-/// peer connection.
-/// Note that the arguments include some object handles, which each hold a
-/// reference to the corresponding object and therefore must be released, even
-/// if the user does not make use of them in the callback.
+/// Register a callback invoked when a remote audio track is added to the
+/// current peer connection. Note that the arguments include some object
+/// handles, which each hold a reference to the corresponding object and
+/// therefore must be released, even if the user does not make use of them in
+/// the callback.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterAudioTrackAddedCallback(
     mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionAudioTrackAddedCallback callback,
@@ -493,11 +496,11 @@ MRS_API void MRS_CALL mrsPeerConnectionRegisterAudioTrackRemovedCallback(
     mrsPeerConnectionAudioTrackRemovedCallback callback,
     void* user_data) noexcept;
 
-/// Register a callback invoked when a remote video track is added to the current
-/// peer connection.
-/// Note that the arguments include some object handles, which each hold a
-/// reference to the corresponding object and therefore must be released, even
-/// if the user does not make use of them in the callback.
+/// Register a callback invoked when a remote video track is added to the
+/// current peer connection. Note that the arguments include some object
+/// handles, which each hold a reference to the corresponding object and
+/// therefore must be released, even if the user does not make use of them in
+/// the callback.
 MRS_API void MRS_CALL mrsPeerConnectionRegisterVideoTrackAddedCallback(
     mrsPeerConnectionHandle peer_handle,
     mrsPeerConnectionVideoTrackAddedCallback callback,

--- a/libs/mrwebrtc/src/interop/audio_track_source_interop.cpp
+++ b/libs/mrwebrtc/src/interop/audio_track_source_interop.cpp
@@ -13,43 +13,6 @@
 
 using namespace Microsoft::MixedReality::WebRTC;
 
-mrsResult MRS_CALL mrsAudioTrackSourceCreateFromDevice(
-    const mrsLocalAudioDeviceInitConfig* init_config,
-    mrsAudioTrackSourceHandle* source_handle_out) noexcept {
-  if (!source_handle_out) {
-    RTC_LOG(LS_ERROR) << "Invalid NULL audio track source handle.";
-    return Result::kInvalidParameter;
-  }
-  *source_handle_out = nullptr;
-
-  RefPtr<GlobalFactory> global_factory(GlobalFactory::InstancePtr());
-  auto pc_factory = global_factory->GetPeerConnectionFactory();
-  if (!pc_factory) {
-    return Result::kInvalidOperation;
-  }
-
-  // Create the audio track source
-  cricket::AudioOptions options{};
-  options.auto_gain_control = ToOptional(init_config->auto_gain_control_);
-  rtc::scoped_refptr<webrtc::AudioSourceInterface> audio_source =
-      pc_factory->CreateAudioSource(options);
-  if (!audio_source) {
-    RTC_LOG(LS_ERROR)
-        << "Failed to create audio source from local audio capture device.";
-    return Result::kUnknownError;
-  }
-
-  // Create the wrapper
-  RefPtr<AudioTrackSource> wrapper =
-      new AudioTrackSource(global_factory, std::move(audio_source));
-  if (!wrapper) {
-    RTC_LOG(LS_ERROR) << "Failed to create audio track source.";
-    return Result::kUnknownError;
-  }
-  *source_handle_out = wrapper.release();
-  return Result::kSuccess;
-}
-
 // void MRS_CALL mrsAudioTrackSourceRegisterFrameCallback(
 //    mrsAudioTrackSourceHandle source_handle,
 //    mrsAudioFrameCallback callback,

--- a/libs/mrwebrtc/src/interop/device_audio_track_source_interop.cpp
+++ b/libs/mrwebrtc/src/interop/device_audio_track_source_interop.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This is a precompiled header, it must be on its own, followed by a blank
+// line, to prevent clang-format from reordering it with other headers.
+#include "pch.h"
+
+#include "device_audio_track_source_interop.h"
+#include "interop/global_factory.h"
+#include "media/device_audio_track_source.h"
+
+using namespace Microsoft::MixedReality::WebRTC;
+
+mrsResult MRS_CALL mrsDeviceAudioTrackSourceCreate(
+    const mrsLocalAudioDeviceInitConfig* init_config,
+    mrsDeviceAudioTrackSourceHandle* source_handle_out) noexcept {
+  if (!source_handle_out) {
+    RTC_LOG(LS_ERROR) << "Invalid NULL audio track source handle.";
+    return Result::kInvalidParameter;
+  }
+  *source_handle_out = nullptr;
+
+  ErrorOr<RefPtr<DeviceAudioTrackSource>> result =
+      DeviceAudioTrackSource::Create(*init_config);
+  if (!result.ok()) {
+    RTC_LOG(LS_ERROR) << "Failed to create device audio track source.";
+    return result.error().result();
+  }
+  *source_handle_out = result.value().release();
+  return Result::kSuccess;
+}

--- a/libs/mrwebrtc/src/interop/device_audio_track_source_interop.cpp
+++ b/libs/mrwebrtc/src/interop/device_audio_track_source_interop.cpp
@@ -15,7 +15,7 @@ mrsResult MRS_CALL mrsDeviceAudioTrackSourceCreate(
     const mrsLocalAudioDeviceInitConfig* init_config,
     mrsDeviceAudioTrackSourceHandle* source_handle_out) noexcept {
   if (!source_handle_out) {
-    RTC_LOG(LS_ERROR) << "Invalid NULL audio track source handle.";
+    RTC_LOG(LS_ERROR) << "Invalid NULL source_handle_out.";
     return Result::kInvalidParameter;
   }
   *source_handle_out = nullptr;

--- a/libs/mrwebrtc/src/media/audio_track_source.cpp
+++ b/libs/mrwebrtc/src/media/audio_track_source.cpp
@@ -37,10 +37,12 @@ void AudioSourceAdapter::RemoveSink(webrtc::AudioTrackSinkInterface* sink) {
 
 AudioTrackSource::AudioTrackSource(
     RefPtr<GlobalFactory> global_factory,
+    ObjectType audio_track_source_type,
     rtc::scoped_refptr<webrtc::AudioSourceInterface> source) noexcept
-    : TrackedObject(std::move(global_factory), ObjectType::kAudioTrackSource),
+    : TrackedObject(std::move(global_factory), audio_track_source_type),
       source_(std::move(source)) {
   RTC_CHECK(source_);
+  RTC_CHECK(audio_track_source_type == ObjectType::kDeviceAudioTrackSource);
 }
 
 AudioTrackSource::~AudioTrackSource() {

--- a/libs/mrwebrtc/src/media/audio_track_source.h
+++ b/libs/mrwebrtc/src/media/audio_track_source.h
@@ -62,14 +62,9 @@ class AudioSourceAdapter : public webrtc::AudioSourceInterface {
 /// more audio tracks.
 class AudioTrackSource : public TrackedObject {
  public:
-  ///// Helper to create an audio track source from a custom audio frame request
-  ///// callback.
-  // static RefPtr<AudioTrackSource> createFromCustom(
-  //    RefPtr<GlobalFactory> global_factory,
-  //    RefPtr<CustomAudioSource> audio_source);
-
   AudioTrackSource(
       RefPtr<GlobalFactory> global_factory,
+      ObjectType audio_track_source_type,
       rtc::scoped_refptr<webrtc::AudioSourceInterface> source) noexcept;
   ~AudioTrackSource() override;
 

--- a/libs/mrwebrtc/src/media/device_audio_track_source.cpp
+++ b/libs/mrwebrtc/src/media/device_audio_track_source.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "interop/global_factory.h"
+#include "media/device_audio_track_source.h"
+#include "audio_track_source_interop.h"
+
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
+
+ErrorOr<RefPtr<DeviceAudioTrackSource>> DeviceAudioTrackSource::Create(
+    const mrsLocalAudioDeviceInitConfig& init_config) noexcept {
+  RefPtr<GlobalFactory> global_factory(GlobalFactory::InstancePtr());
+  auto pc_factory = global_factory->GetPeerConnectionFactory();
+  if (!pc_factory) {
+    return Error(Result::kInvalidOperation);
+  }
+
+  // Create the audio track source
+  cricket::AudioOptions options{};
+  options.auto_gain_control = ToOptional(init_config.auto_gain_control_);
+  rtc::scoped_refptr<webrtc::AudioSourceInterface> audio_source =
+      pc_factory->CreateAudioSource(options);
+  if (!audio_source) {
+    RTC_LOG(LS_ERROR)
+        << "Failed to create audio source from local audio capture device.";
+    return Error(Result::kUnknownError);
+  }
+
+  // Create the wrapper
+  RefPtr<DeviceAudioTrackSource> wrapper =
+      new DeviceAudioTrackSource(global_factory, std::move(audio_source));
+  if (!wrapper) {
+    RTC_LOG(LS_ERROR) << "Failed to create device audio track source.";
+    return Error(Result::kUnknownError);
+  }
+  return wrapper;
+}
+
+DeviceAudioTrackSource::DeviceAudioTrackSource(
+    RefPtr<GlobalFactory> global_factory,
+    rtc::scoped_refptr<webrtc::AudioSourceInterface> source) noexcept
+    : AudioTrackSource(std::move(global_factory),
+                       ObjectType::kDeviceAudioTrackSource,
+                       std::move(source)) {}
+
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/media/device_audio_track_source.h
+++ b/libs/mrwebrtc/src/media/device_audio_track_source.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "audio_frame.h"
+#include "audio_track_source.h"
+#include "device_audio_track_source_interop.h"
+#include "mrs_errors.h"
+#include "refptr.h"
+#include "tracked_object.h"
+
+#include "api/mediastreaminterface.h"
+
+namespace Microsoft {
+namespace MixedReality {
+namespace WebRTC {
+
+/// Audio track source generating frames from a local audio capture device
+/// (microphone).
+class DeviceAudioTrackSource : public AudioTrackSource {
+ public:
+  static ErrorOr<RefPtr<DeviceAudioTrackSource>> Create(
+      const mrsLocalAudioDeviceInitConfig& init_config) noexcept;
+
+ protected:
+  DeviceAudioTrackSource(
+      RefPtr<GlobalFactory> global_factory,
+      rtc::scoped_refptr<webrtc::AudioSourceInterface> source) noexcept;
+};
+
+}  // namespace WebRTC
+}  // namespace MixedReality
+}  // namespace Microsoft

--- a/libs/mrwebrtc/src/tracked_object.h
+++ b/libs/mrwebrtc/src/tracked_object.h
@@ -23,14 +23,14 @@ enum class ObjectType : int {
   kPeerConnection,
   kLocalAudioTrack,
   kLocalVideoTrack,
-  kExternalVideoTrackSource,
   kRemoteAudioTrack,
   kRemoteVideoTrack,
   kDataChannel,
   kAudioTransceiver,
   kVideoTransceiver,
-  kAudioTrackSource,
+  kDeviceAudioTrackSource,
   kDeviceVideoTrackSource,
+  kExternalVideoTrackSource,
 };
 
 /// Object tracked for interop, exposing helper methods for debugging purpose.

--- a/libs/mrwebrtc/src/utils.cpp
+++ b/libs/mrwebrtc/src/utils.cpp
@@ -112,8 +112,6 @@ absl::string_view ObjectTypeToString(ObjectType type) {
       return "LocalAudioTrack";
     case ObjectType::kLocalVideoTrack:
       return "LocalVideoTrack";
-    case ObjectType::kExternalVideoTrackSource:
-      return "ExternalVideoTrackSource";
     case ObjectType::kRemoteAudioTrack:
       return "RemoteAudioTrack";
     case ObjectType::kRemoteVideoTrack:
@@ -124,10 +122,12 @@ absl::string_view ObjectTypeToString(ObjectType type) {
       return "AudioTransceiver";
     case ObjectType::kVideoTransceiver:
       return "VideoTransceiver";
-    case ObjectType::kAudioTrackSource:
-      return "AudioTrackSource";
+    case ObjectType::kDeviceAudioTrackSource:
+      return "DeviceAudioTrackSource";
     case ObjectType::kDeviceVideoTrackSource:
       return "DeviceVideoTrackSource";
+    case ObjectType::kExternalVideoTrackSource:
+      return "ExternalVideoTrackSource";
     default:
       RTC_NOTREACHED();
       return "<UnknownObjectType>";

--- a/libs/mrwebrtc/test/audio_track_tests.cpp
+++ b/libs/mrwebrtc/test/audio_track_tests.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 
 #include "audio_frame.h"
+#include "device_audio_track_source_interop.h"
 #include "interop_api.h"
 #include "local_audio_track_interop.h"
 #include "remote_audio_track_interop.h"
@@ -122,9 +123,9 @@ TEST_P(AudioTrackTests, Simple) {
 
   // Create the audio source #1
   mrsLocalAudioDeviceInitConfig device_config{};
-  mrsAudioTrackSourceHandle audio_source1{};
-  ASSERT_EQ(Result::kSuccess, mrsAudioTrackSourceCreateFromDevice(
-                                  &device_config, &audio_source1));
+  mrsDeviceAudioTrackSourceHandle audio_source1{};
+  ASSERT_EQ(Result::kSuccess,
+            mrsDeviceAudioTrackSourceCreate(&device_config, &audio_source1));
   ASSERT_NE(nullptr, audio_source1);
 
   // Create the local audio track #1
@@ -279,9 +280,9 @@ TEST_P(AudioTrackTests, Muted) {
 
   // Create the audio source #1
   mrsLocalAudioDeviceInitConfig device_config{};
-  mrsAudioTrackSourceHandle audio_source1{};
-  ASSERT_EQ(Result::kSuccess, mrsAudioTrackSourceCreateFromDevice(
-                                  &device_config, &audio_source1));
+  mrsDeviceAudioTrackSourceHandle audio_source1{};
+  ASSERT_EQ(Result::kSuccess,
+            mrsDeviceAudioTrackSourceCreate(&device_config, &audio_source1));
   ASSERT_NE(nullptr, audio_source1);
 
   // Create the local audio track #1

--- a/libs/mrwebrtc/test/device_audio_track_source_tests.cpp
+++ b/libs/mrwebrtc/test/device_audio_track_source_tests.cpp
@@ -4,14 +4,14 @@
 #include "pch.h"
 
 #include "audio_frame.h"
-#include "audio_track_source_interop.h"
+#include "device_audio_track_source_interop.h"
 #include "interop_api.h"
 
 #include "test_utils.h"
 
 namespace {
 
-class AudioTrackSourceTests
+class DeviceAudioTrackSourceTests
     : public TestUtils::TestBase,
       public testing::WithParamInterface<mrsSdpSemantic> {};
 
@@ -20,15 +20,15 @@ class AudioTrackSourceTests
 #if !defined(MRSW_EXCLUDE_DEVICE_TESTS)
 
 INSTANTIATE_TEST_CASE_P(,
-                        AudioTrackSourceTests,
+                        DeviceAudioTrackSourceTests,
                         testing::ValuesIn(TestUtils::TestSemantics),
                         TestUtils::SdpSemanticToString);
 
-TEST_P(AudioTrackSourceTests, CreateFromDevice) {
+TEST_P(DeviceAudioTrackSourceTests, Create) {
   mrsLocalAudioDeviceInitConfig config{};
-  mrsAudioTrackSourceHandle source_handle{};
+  mrsDeviceAudioTrackSourceHandle source_handle{};
   ASSERT_EQ(mrsResult::kSuccess,
-            mrsAudioTrackSourceCreateFromDevice(&config, &source_handle));
+            mrsDeviceAudioTrackSourceCreate(&config, &source_handle));
   ASSERT_NE(nullptr, source_handle);
   mrsRefCountedObjectRemoveRef(source_handle);
 }

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/AudioTrackSourceTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/AudioTrackSourceTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.WebRTC.Tests
         [Test]
         public async Task CreateFromDevice()
         {
-            using (AudioTrackSource source = await AudioTrackSource.CreateFromDeviceAsync())
+            using (AudioTrackSource source = await DeviceAudioTrackSource.CreateAsync())
             {
                 Assert.IsNotNull(source);
                 Assert.AreEqual(string.Empty, source.Name);
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.WebRTC.Tests
         [Test]
         public async Task Name()
         {
-            using (AudioTrackSource source = await AudioTrackSource.CreateFromDeviceAsync())
+            using (AudioTrackSource source = await DeviceAudioTrackSource.CreateAsync())
             {
                 Assert.IsNotNull(source);
 

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/LocalAudioTrackTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/LocalAudioTrackTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.WebRTC.Tests
         [Test]
         public async Task CreateFromSource()
         {
-            using (AudioTrackSource source = await AudioTrackSource.CreateFromDeviceAsync())
+            using (AudioTrackSource source = await DeviceAudioTrackSource.CreateAsync())
             {
                 Assert.IsNotNull(source);
 

--- a/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj
+++ b/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj
@@ -152,6 +152,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_frame.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\data_channel_interop.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\device_audio_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\device_video_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\export.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\external_video_track_source_interop.h" />
@@ -173,6 +174,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\global_factory.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_read_buffer.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_video_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\local_audio_track.h" />
@@ -201,6 +203,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\data_channel.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\audio_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\data_channel_interop.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\device_audio_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\device_video_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\external_video_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\global_factory.cpp" />
@@ -216,6 +219,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\video_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_read_buffer.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_source.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_video_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\local_video_track.cpp" />

--- a/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj.filters
+++ b/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\external_video_track_source_interop.cpp">
@@ -108,6 +108,12 @@
     </ClCompile>
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\device_video_track_source_interop.cpp">
       <Filter>src\interop</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\device_audio_track_source_interop.cpp">
+      <Filter>src\interop</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.cpp">
+      <Filter>src\media</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -242,6 +248,12 @@
     </ClInclude>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\device_video_track_source_interop.h">
       <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\device_audio_track_source_interop.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.h">
+      <Filter>src\media</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
@@ -125,6 +125,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_frame.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\audio_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\data_channel_interop.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\device_audio_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\device_video_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\export.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\external_video_track_source_interop.h" />
@@ -145,6 +146,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\data_channel.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\global_factory.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_read_buffer.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_video_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\local_video_track.h" />
@@ -175,6 +177,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\data_channel.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\audio_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\data_channel_interop.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\device_audio_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\device_video_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\external_video_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\global_factory.cpp" />
@@ -189,6 +192,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\transceiver_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\video_track_source_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\audio_track_read_buffer.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_video_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\local_video_track.cpp" />

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj.filters
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj.filters
@@ -109,6 +109,12 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\device_video_track_source_interop.cpp">
       <Filter>src\interop</Filter>
     </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\device_audio_track_source_interop.cpp">
+      <Filter>src\interop</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.cpp">
+      <Filter>src\media</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.h">
@@ -242,6 +248,12 @@
     </ClInclude>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\device_video_track_source_interop.h">
       <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\device_audio_track_source_interop.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.h">
+      <Filter>src\media</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj
+++ b/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj
@@ -66,7 +66,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\audio_track_source_tests.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\device_audio_track_source_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\audio_track_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\data_channel_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\external_video_track_source_tests.cpp" />


### PR DESCRIPTION
Split the audio track source base class from the actual device-based
implementation, and make the former abstract. This allow extensibility
in the future to add e.g. an external audio track source, and makes the
API consistent with video track sources.