### PR TITLE
[TestAppUWP] Assign selected video profile

### DIFF
--- a/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
@@ -307,6 +307,12 @@ namespace TestAppUwp
                 deviceConfig.height = formatInfo.Format.height;
                 deviceConfig.framerate = formatInfo.Format.framerate;
             }
+            if (deviceInfo.SupportsVideoProfiles)
+            {
+                MediaCaptureVideoProfile profile = VideoProfiles.SelectedItem;
+                deviceConfig.videoProfileId = profile?.Id;
+                deviceConfig.videoProfileKind = SelectedVideoProfileKind;
+            }
             var source = await DeviceVideoTrackSource.CreateAsync(deviceConfig);
             // FIXME - this leaks the source, never disposed
 


### PR DESCRIPTION
Fix a regression in TestAppUWP where the selected video profile was not
assigned anymore when opening the webcam, which prevented using video
profiles.