### PR TITLE
Always add MediaLines to track source

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/LocalAudioTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/LocalAudioTrack.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// Audio track sending to the remote peer audio frames originating from
     /// a local track source (local microphone or other audio recording device).
     /// </summary>
-    public class LocalAudioTrack : MediaTrack, IAudioTrack, IDisposable
+    public class LocalAudioTrack : LocalMediaTrack, IAudioTrack
     {
         /// <summary>
         /// Enabled status of the track. If enabled, send local audio frames to the remote peer as
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.WebRTC
 
         /// <summary>
         /// Create an audio track from an existing audio track source.
-        /// 
+        ///
         /// This does not add the track to any peer connection. Instead, the track must be added manually to
         /// an audio transceiver to be attached to a peer connection and transmitted to a remote peer.
         /// </summary>
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.WebRTC
         }
 
         /// <inheritdoc/>
-        public void Dispose()
+        public override void Dispose()
         {
             if (_nativeHandle.IsClosed)
             {

--- a/libs/Microsoft.MixedReality.WebRTC/LocalVideoTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/LocalVideoTrack.cs
@@ -95,7 +95,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// Video track sending to the remote peer video frames originating from
     /// a local track source.
     /// </summary>
-    public class LocalVideoTrack : MediaTrack, IVideoTrack, IDisposable
+    public class LocalVideoTrack : LocalMediaTrack, IVideoTrack
     {
         /// <summary>
         /// Video track source this track is pulling its video frames from.
@@ -154,7 +154,7 @@ namespace Microsoft.MixedReality.WebRTC
 
         /// <summary>
         /// Create a video track from an existing video track source.
-        /// 
+        ///
         /// This does not add the track to any peer connection. Instead, the track must be added manually to
         /// a video transceiver to be attached to a peer connection and transmitted to a remote peer.
         /// </summary>
@@ -231,7 +231,7 @@ namespace Microsoft.MixedReality.WebRTC
         }
 
         /// <inheritdoc/>
-        public void Dispose()
+        public override void Dispose()
         {
             if (_nativeHandle.IsClosed)
             {

--- a/libs/Microsoft.MixedReality.WebRTC/MediaTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/MediaTrack.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.MixedReality.WebRTC
 {
     /// <summary>
@@ -25,7 +27,7 @@ namespace Microsoft.MixedReality.WebRTC
         /// </summary>
         public string Name { get; }
 
-        internal MediaTrack(PeerConnection peer, string trackName)
+        private protected MediaTrack(PeerConnection peer, string trackName)
         {
             PeerConnection = peer;
             Name = trackName;
@@ -38,5 +40,22 @@ namespace Microsoft.MixedReality.WebRTC
         {
             return $"(MediaTrack)\"{Name}\"";
         }
+    }
+
+    /// <summary>
+    /// Base class for media tracks sending to the remote peer.
+    /// </summary>
+    public abstract class LocalMediaTrack : MediaTrack, IDisposable
+    {
+        private protected LocalMediaTrack(PeerConnection peer, string trackName)
+            : base(peer, trackName)
+        {
+        }
+
+        /// <summary>
+        /// Remove the track from the associated <see cref="Transceiver"/> (if there is one)
+        /// and release the corresponding resources.
+        /// </summary>
+        public abstract void Dispose();
     }
 }

--- a/libs/unity/library/Runtime/Scripts/Media/AudioTrackSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/AudioTrackSource.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
     {
         /// <summary>
         /// Audio track source object from the underlying C# library that this component encapsulates.
-        /// 
+        ///
         /// The object is owned by this component, which will create it and dispose of it automatically.
         /// </summary>
         public WebRTC.AudioTrackSource Source { get; protected set; } = null;
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// <summary>
         /// Register a frame callback to listen to outgoing audio data produced by this audio sender
         /// and sent to the remote peer.
-        /// 
+        ///
         /// <div class="WARNING alert alert-warning">
         /// <h5>WARNING</h5>
         /// <p>
@@ -81,7 +81,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// Unlike for video, where a typical application might display some local feedback of a local
         /// webcam recording, local audio feedback is rare, so this callback is not typically used.
         /// One possible use case would be to display some visual feedback, like an audio spectrum analyzer.
-        /// 
+        ///
         /// Note that registering a callback does not influence the audio capture and sending to the
         /// remote peer, which occur whether or not a callback is registered.
         /// </remarks>
@@ -113,12 +113,12 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         {
             if (Source != null)
             {
-                // Notify media lines using that source. OnSourceDestroyed() calls
-                // OnMediaLineRemoved() which will modify the collection.
-                while (_mediaLines.Count > 0)
+                // Notify media lines using this source.
+                foreach (var ml in _mediaLines)
                 {
-                    _mediaLines[_mediaLines.Count - 1].OnSourceDestroyed();
+                    ml.OnSourceDestroyed();
                 }
+                _mediaLines.Clear();
 
                 // Audio track sources are disposable objects owned by the user (this component)
                 Source.Dispose();

--- a/libs/unity/library/Runtime/Scripts/Media/VideoRenderer.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/VideoRenderer.cs
@@ -299,7 +299,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                 }
 
                 // Copy data from C# buffer into system memory managed by Unity.
-                // Note: This only "looks right" in Unity because we apply the 
+                // Note: This only "looks right" in Unity because we apply the
                 // "YUVFeedShader(Unlit)" to the texture (converting YUV planar to RGB).
                 // Note: Texture2D.LoadRawTextureData() expects some bottom-up texture data but
                 // the WebRTC video frame is top-down, so the image is uploaded vertically flipped,

--- a/libs/unity/library/Runtime/Scripts/Media/VideoTrackSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/VideoTrackSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
     {
         /// <summary>
         /// Video track source object from the underlying C# library that this component encapsulates.
-        /// 
+        ///
         /// The object is owned by this component, which will create it and dispose of it automatically.
         /// </summary>
         public WebRTC.VideoTrackSource Source { get; protected set; } = null;
@@ -129,12 +129,12 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         {
             if (Source != null)
             {
-                // Notify media lines using that source. OnSourceDestroyed() calls
-                // OnMediaLineRemoved() which will modify the collection.
-                while (_mediaLines.Count > 0)
+                // Notify media lines using this source.
+                foreach (var ml in _mediaLines)
                 {
-                    _mediaLines[_mediaLines.Count - 1].OnSourceDestroyed();
+                    ml.OnSourceDestroyed();
                 }
+                _mediaLines.Clear();
 
                 // Video track sources are disposable objects owned by the user (this component)
                 Source.Dispose();


### PR DESCRIPTION
The fix is in MediaLine.OnAfterDeserialize. The rest is small refactorings/simplifications.

This fixes #426. The behavior is still a bit weird - we are removing the source from the MediaLine when it is disabled, but have no way to re-add it when it is re-enabled.