### PR TITLE
Recycle ARGB buffer when frame rotates

### DIFF
--- a/libs/mrwebrtc/src/video_frame_observer.cpp
+++ b/libs/mrwebrtc/src/video_frame_observer.cpp
@@ -56,6 +56,7 @@ ArgbBuffer* VideoFrameObserver::GetArgbScratchBuffer(int width, int height) {
   const size_t needed_size = Argb32FrameSize(width, height);
   if (auto* buffer = argb_scratch_buffer_.get()) {
     if (buffer->Size() >= needed_size) {
+      buffer->Recycle(width, height);  // Update stride
       return buffer;
     }
   }


### PR DESCRIPTION
Properly handle ARGB buffer recycling in VideoFrameObserver when the
buffer rotates, which keeps the overall storage size but requires an
update of the width, height, and most importantly stride.