### PR TITLE
Log when exception occur in device sources

### DIFF
--- a/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
@@ -98,10 +98,21 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             {
                 AutoGainControl = _autoGainControl,
             };
-            Source = await DeviceAudioTrackSource.CreateAsync(initConfig);
-            if (Source == null)
+            try
             {
-                throw new Exception("Failed to create microphone audio source.");
+                Source = await DeviceAudioTrackSource.CreateAsync(initConfig);
+                if (Source == null)
+                {
+                    throw new Exception("DeviceAudioTrackSource.CreateAsync() returned a NULL source.");
+                }
+            }
+            catch (Exception ex)
+            {
+                // Disable MicrophoneSource
+                Debug.LogError("Failed to create audio source for MicrophoneSource component; disabling it.");
+                enabled = false;
+                // Throw again to log the exception message with a callstack
+                throw ex;
             }
 
             IsStreaming = true;

--- a/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
@@ -108,11 +108,9 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             }
             catch (Exception ex)
             {
-                // Disable MicrophoneSource
-                Debug.LogError("Failed to create audio source for MicrophoneSource component; disabling it.");
-                enabled = false;
-                // Throw again to log the exception message with a callstack
-                throw ex;
+                Debug.LogError($"Failed to create device track source for {nameof(MicrophoneSource)} component '{name}'.");
+                Debug.LogException(ex, this);
+                return;
             }
 
             IsStreaming = true;

--- a/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
@@ -326,11 +326,9 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             }
             catch (Exception ex)
             {
-                // Disable WebcamSource
-                Debug.LogError("Failed to create video source for WebcamSource component; disabling it.");
-                enabled = false;
-                // Throw again to log the exception message with a callstack
-                throw ex;
+                Debug.LogError($"Failed to create device track source for {nameof(WebcamSource)} component '{name}'.");
+                Debug.LogException(ex, this);
+                return;
             }
 
             IsStreaming = true;

--- a/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
@@ -316,10 +316,21 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                 enableMrc = EnableMixedRealityCapture,
                 enableMrcRecordingIndicator = EnableMRCRecordingIndicator
             };
-            Source = await DeviceVideoTrackSource.CreateAsync(deviceConfig);
-            if (Source == null)
+            try
             {
-                throw new Exception("Failed ot create webcam video source.");
+                Source = await DeviceVideoTrackSource.CreateAsync(deviceConfig);
+                if (Source == null)
+                {
+                    throw new Exception("DeviceVideoTrackSource.CreateAsync() returned a NULL source.");
+                }
+            }
+            catch (Exception ex)
+            {
+                // Disable WebcamSource
+                Debug.LogError("Failed to create video source for WebcamSource component; disabling it.");
+                enabled = false;
+                // Throw again to log the exception message with a callstack
+                throw ex;
             }
 
             IsStreaming = true;


### PR DESCRIPTION
Catch exceptions when failing to create a device track source in WebcamSource
and MicrophoneSource components, and log the exception with its callstack along
with an error message with the component name.

This is a clean-up loosely related to #335, though the code triggering that
issue has been changed so the issue does not occur anymore.
