### PR TITLE
Expose WebRTC logging via user callback

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "external/webrtc-uwp-sdk"]
 	path = external/webrtc-uwp-sdk
 	url = https://github.com/webrtc-uwp/webrtc-uwp-sdk.git
-	branch = releases/m71

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/LoggingInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/LoggingInterop.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.MixedReality.WebRTC.Interop
+{
+    internal static class LoggingInterop
+    {
+        internal sealed class SinkWrapper
+        {
+            public ILogSink Sink;
+            public IntPtr SinkHandle;
+        }
+
+        /// <summary>
+        /// Add a new log message sink.
+        /// </summary>
+        /// <param name="sink">The sink to register.</param>
+        /// <param name="minimumSeverity">The minimum severity of messages to receive with that sink.</param>
+        public static void AddSink(ILogSink sink, LogSeverity minimumSeverity)
+        {
+            if (minimumSeverity == LogSeverity.None)
+            {
+                return;
+            }
+            var wrapper = new SinkWrapper { Sink = sink };
+            IntPtr wrapperHandle = Utils.MakeWrapperRef(wrapper);
+            lock (lock_)
+            {
+                wrapper.SinkHandle = Logging_AddSink(minimumSeverity, InteropLogMessageCallback, wrapperHandle);
+                if (wrapper.SinkHandle != IntPtr.Zero)
+                {
+                    sinks_.Add(sink, wrapper);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Remove a sink previously registered to stop receiving messages.
+        /// </summary>
+        /// <param name="sink">The sink to unregister.</param>
+        public static void RemoveSink(ILogSink sink)
+        {
+            lock (lock_)
+            {
+                if (sinks_.TryGetValue(sink, out SinkWrapper wrapper))
+                {
+                    sinks_.Remove(sink);
+                    Logging_RemoveSink(wrapper.SinkHandle);
+                }
+            }
+        }
+
+        private static readonly object lock_ = new object();
+        private static readonly Dictionary<ILogSink, SinkWrapper> sinks_ = new Dictionary<ILogSink, SinkWrapper>();
+
+
+        #region Native functions
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsLoggingAddSink")]
+        public static extern IntPtr Logging_AddSink(LogSeverity minSeverity, InteropLogMessageDelegate callback, IntPtr userData);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsLoggingRemoveSink")]
+        public static extern void Logging_RemoveSink(IntPtr sinkHandle);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsLogMessage")]
+        public static extern void Logging_LogMessage(LogSeverity severity, string message);
+
+        #endregion
+
+
+        #region Native callbacks
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        public delegate void InteropLogMessageDelegate(IntPtr sinkHandle, LogSeverity severity, string message);
+
+        // Keep alive a delegate object encapsulating the static function used as trampoline.
+        public static readonly InteropLogMessageDelegate InteropLogMessageCallback = LogMessageCallback;
+
+        [MonoPInvokeCallback(typeof(InteropLogMessageDelegate))]
+        private static void LogMessageCallback(IntPtr sinkHandle, LogSeverity severity, string message)
+        {
+            var sinkWrapper = Utils.ToWrapper<SinkWrapper>(sinkHandle);
+            sinkWrapper.Sink.LogMessage(severity, message);
+        }
+
+        #endregion
+    }
+}

--- a/libs/Microsoft.MixedReality.WebRTC/Logging.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Logging.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.WebRTC.Interop;
+
+namespace Microsoft.MixedReality.WebRTC
+{
+    /// <summary>
+    /// Log message severity.
+    /// </summary>
+    public enum LogSeverity : int
+    {
+        /// <summary>
+        /// Unknown severity level, could not be retrieved/assigned.
+        /// </summary>
+        Unknown = -1,
+
+        /// <summary>
+        /// Diagnostic message for debugging.
+        /// </summary>
+        Verbose = 1,
+
+        /// <summary>
+        /// Informational message for diagnosing.
+        /// </summary>
+        Info = 2,
+
+        /// <summary>
+        /// Warning message about some event to potentially investigate.
+        /// </summary>
+        Warning = 3,
+
+        /// <summary>
+        /// Error message about unexpected action or result.
+        /// </summary>
+        Error = 4,
+
+        /// <summary>
+        /// Logging disabled.
+        /// </summary>
+        None = 5
+    }
+
+    /// <summary>
+    /// Interface for a sink receiving log messages. The sink can be registered with
+    /// <see cref="Logging.AddSink(ILogSink, LogSeverity)"/> to receive logging messages.
+    /// </summary>
+    /// <seealso cref="Logging.AddSink(ILogSink, LogSeverity)"/>
+    /// <seealso cref="Logging.RemoveSink(ILogSink)"/>
+    public interface ILogSink
+    {
+        /// <summary>
+        /// Callback invoked when a log message is received.
+        /// </summary>
+        /// <param name="severity">Message severity.</param>
+        /// <param name="message">Message description.</param>
+        void LogMessage(LogSeverity severity, string message);
+    }
+
+    /// <summary>
+    /// Logging utilities.
+    /// </summary>
+    public static class Logging
+    {
+        /// <summary>
+        /// Add a log sink receiving messages.
+        /// </summary>
+        /// <param name="sink">The sink to register.</param>
+        /// <param name="minimumSeverity">Minimum severity of messages to forward to the sink.</param>
+        public static void AddSink(ILogSink sink, LogSeverity minimumSeverity)
+        {
+            LoggingInterop.AddSink(sink, minimumSeverity);
+        }
+
+        /// <summary>
+        /// Remove a log sink receiving messages.
+        /// </summary>
+        /// <param name="sink">The sink to unregister.</param>
+        public static void RemoveSink(ILogSink sink)
+        {
+            LoggingInterop.RemoveSink(sink);
+        }
+
+        /// <summary>
+        /// Log a message with a given severity. The message will be logged alongside the messages generated
+        /// by the implementation, and received by any registered sink callback like internal messages.
+        /// </summary>
+        /// <param name="severity">Message severity.</param>
+        /// <param name="message">Message content.</param>
+        public static void LogMessage(LogSeverity severity, string message)
+        {
+            LoggingInterop.Logging_LogMessage(severity, message);
+        }
+    }
+}

--- a/libs/mrwebrtc/include/logging_interop.h
+++ b/libs/mrwebrtc/include/logging_interop.h
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "interop_api.h"
+
+extern "C" {
+
+/// Severity of a log message.
+enum class mrsLogSeverity : int32_t {
+  kUnknown = -1,  // Could not assign a severity level
+  kVerbose = 1,
+  kInfo = 2,
+  kWarning = 3,
+  kError = 4,
+  kNone = 5,
+};
+
+struct mrsLogSinkHandleImpl {};
+
+/// Handle to a registered log sink, used to unregister it.
+using mrsLogSinkHandle = mrsLogSinkHandleImpl*;
+
+/// Callback invoked when a log message is received. The callback receives the
+/// log message severity and a string with the message content. The first
+/// argument is the opaque |user_data| parameter passed during registration.
+using mrsLogMessageCallback = void(MRS_CALL*)(void*,
+                                              mrsLogSeverity,
+                                              const char*);
+
+/// Register a log message sink in the form of a callback invoked when a log
+/// message is produced. The callback is invoked for any message with a severity
+/// great than or equal to the specified |min_severity|.
+MRS_API mrsLogSinkHandle MRS_CALL
+mrsLoggingAddSink(mrsLogSeverity min_severity,
+                  mrsLogMessageCallback callback,
+                  void* user_data) noexcept;
+
+/// Unregister a previously registered log message sink.
+MRS_API void MRS_CALL mrsLoggingRemoveSink(mrsLogSinkHandle handle) noexcept;
+
+/// Log a message with a given severity.
+MRS_API void MRS_CALL mrsLogMessage(mrsLogSeverity severity,
+                                    const char* message) noexcept;
+}

--- a/libs/mrwebrtc/src/interop/logging_interop.cpp
+++ b/libs/mrwebrtc/src/interop/logging_interop.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This is a precompiled header, it must be on its own, followed by a blank
+// line, to prevent clang-format from reordering it with other headers.
+#include "pch.h"
+
+#include "callback.h"
+#include "logging_interop.h"
+
+using namespace Microsoft::MixedReality::WebRTC;
+
+namespace {
+
+class InteropLogSink : public rtc::LogSink {
+ public:
+  using MessageCallback = Callback<mrsLogSeverity, const char*>;
+
+  static InteropLogSink* Create(MessageCallback callback) noexcept {
+    try {
+      auto sink = std::make_unique<InteropLogSink>(std::move(callback));
+      InteropLogSink* const ret = sink.get();
+      {
+        rtc::CritScope lock(&GetCS());
+        GetSinks().push_back(std::move(sink));
+      }
+      return ret;
+    } catch (...) {
+      return nullptr;
+    }
+  }
+
+  static void Destroy(InteropLogSink* sink) noexcept {
+    try {
+      rtc::CritScope lock(&GetCS());
+      auto& sinks = GetSinks();
+      auto it = std::find_if(
+          sinks.begin(), sinks.end(),
+          [sink](const std::unique_ptr<InteropLogSink>& registeredSink) {
+            return (registeredSink.get() == sink);
+          });
+      if (it != sinks.end()) {
+        sinks.erase(it);
+      }
+    } catch (...) {
+    }
+  }
+
+  InteropLogSink(MessageCallback callback) : callback_(std::move(callback)) {}
+
+  void OnLogMessage(const std::string& msg,
+                    rtc::LoggingSeverity severity,
+                    const char* /*tag*/) override {
+    callback_(static_cast<mrsLogSeverity>(severity), msg.c_str());
+  }
+
+  void OnLogMessage(const std::string& message,
+                    rtc::LoggingSeverity severity) override {
+    callback_((mrsLogSeverity)severity, message.c_str());
+  }
+
+  void OnLogMessage(const std::string& message) override {
+    callback_(mrsLogSeverity::kUnknown, message.c_str());
+  }
+
+  mrsLogSinkHandle ToHandle() noexcept {
+    return reinterpret_cast<mrsLogSinkHandle>(this);
+  }
+
+  static InteropLogSink* FromHandle(mrsLogSinkHandle handle) noexcept {
+    return reinterpret_cast<InteropLogSink*>(handle);
+  }
+
+ private:
+  MessageCallback callback_;
+  static std::vector<std::unique_ptr<InteropLogSink>> s_sinks_;
+
+ private:
+  static rtc::CriticalSection& GetCS() {
+    static rtc::CriticalSection cs;
+    return cs;
+  }
+  static std::vector<std::unique_ptr<InteropLogSink>>& GetSinks() {
+    static std::vector<std::unique_ptr<InteropLogSink>> sinks;
+    return sinks;
+  }
+};
+
+}  // namespace
+
+mrsLogSinkHandle MRS_CALL mrsLoggingAddSink(mrsLogSeverity min_severity,
+                                            mrsLogMessageCallback callback,
+                                            void* user_data) noexcept {
+  if ((min_severity == mrsLogSeverity::kNone) || !callback) {
+    return nullptr;
+  }
+  InteropLogSink* const sink = InteropLogSink::Create({callback, user_data});
+  // Doc says AddLogToStream() takes ownership, but RemoveLogToStream() doc says
+  // it doesn't delete the sink, so it's not really taking ownership.
+  rtc::LogMessage::AddLogToStream(
+      sink, static_cast<rtc::LoggingSeverity>(min_severity));
+  return sink->ToHandle();
+}
+
+void MRS_CALL mrsLoggingRemoveSink(mrsLogSinkHandle handle) noexcept {
+  if (InteropLogSink* const sink = InteropLogSink::FromHandle(handle)) {
+    rtc::LogMessage::RemoveLogToStream(sink);
+    InteropLogSink::Destroy(sink);
+  }
+}
+
+void mrsLogMessage(mrsLogSeverity severity, const char* message) noexcept {
+  if ((severity >= mrsLogSeverity::kVerbose) &&
+      (severity <= mrsLogSeverity::kError)) {
+    const rtc::LoggingSeverity sev = (rtc::LoggingSeverity)severity;
+    RTC_LOG_V(sev) << message;
+  }
+}

--- a/libs/mrwebrtc/src/pch.h
+++ b/libs/mrwebrtc/src/pch.h
@@ -67,6 +67,7 @@
 #include "modules/audio_processing/include/audio_processing.h"
 #include "modules/video_capture/video_capture_factory.h"
 #include "rtc_base/bind.h"
+#include "rtc_base/logging.h"
 #include "rtc_base/memory/aligned_malloc.h"
 #if defined(MR_SHARING_ANDROID)
 #include "sdk/android/native_api/jni/class_loader.h"

--- a/libs/mrwebrtc/test/data_channel_tests.cpp
+++ b/libs/mrwebrtc/test/data_channel_tests.cpp
@@ -215,7 +215,7 @@ TEST_P(DataChannelTests, Send) {
       [&](const void* data, const uint64_t size) {
         ASSERT_EQ(msg2_size, size);
         ASSERT_NE(nullptr, data);
-        ASSERT_EQ(0, memcmp(data, msg2_data, msg2_size));
+        ASSERT_EQ(0, memcmp(data, msg2_data, static_cast<size_t>(msg2_size)));
         ev_msg1.Set();
       });
   std::function<void(mrsDataChannelState, int32_t)> state1_cb(
@@ -233,7 +233,7 @@ TEST_P(DataChannelTests, Send) {
       [&](const void* data, const uint64_t size) {
         ASSERT_EQ(msg1_size, size);
         ASSERT_NE(nullptr, data);
-        ASSERT_EQ(0, memcmp(data, msg1_data, msg1_size));
+        ASSERT_EQ(0, memcmp(data, msg1_data, static_cast<size_t>(msg1_size)));
         ev_msg2.Set();
       });
   std::function<void(mrsDataChannelState, int32_t)> state2_cb(

--- a/libs/mrwebrtc/test/logging_tests.cpp
+++ b/libs/mrwebrtc/test/logging_tests.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "interop_api.h"
+#include "logging_interop.h"
+
+#include "test_utils.h"
+
+namespace {
+
+class LoggingTests : public TestUtils::TestBase {};
+
+void MRS_CALL LogCallback(void* /*user_data*/,
+                          mrsLogSeverity /*severity*/,
+                          const char* message) {
+  OutputDebugStringA(message);
+  OutputDebugStringA("\n");
+}
+
+/// Utility sink to log all messages and then check that specific keywords
+/// appear in those messages, to confirm logging worked as intended.
+struct CheckKeywordLogSink {
+  static void MRS_CALL LogCallback(void* user_data,
+                                   mrsLogSeverity severity,
+                                   const char* message) {
+    auto self = static_cast<CheckKeywordLogSink*>(user_data);
+    self->LogMessage(severity, message);
+  }
+
+  struct Msg {
+    mrsLogSeverity severity;
+    std::string message;
+  };
+
+  void LogMessage(mrsLogSeverity severity, const char* message) {
+    std::scoped_lock<std::mutex> lock(mutex_);
+    messages_.push_back({severity, message ? message : ""});
+  }
+
+  bool HasKeyword(absl::string_view keyword) const {
+    std::scoped_lock<std::mutex> lock(mutex_);
+    auto it = std::find_if(
+        messages_.begin(), messages_.end(), [keyword](const Msg& msg) {
+          return (msg.message.find(keyword.data(), 0, keyword.size()) !=
+                  std::string::npos);
+        });
+    return (it != messages_.end());
+  }
+
+  void Clear() {
+    std::scoped_lock<std::mutex> lock(mutex_);
+    messages_.clear();
+  }
+
+  mutable std::mutex mutex_;
+  std::vector<Msg> messages_;
+};
+
+struct RaiiSinkHandle {
+  RaiiSinkHandle(mrsLogSinkHandle handle) : handle_(handle) {}
+  ~RaiiSinkHandle() noexcept {
+    if (handle_) {
+      mrsLoggingRemoveSink(handle_);
+    }
+  }
+  mrsLogSinkHandle get() const { return handle_; }
+  operator mrsLogSinkHandle() const { return handle_; }
+  const mrsLogSinkHandle handle_{nullptr};
+};
+
+}  // namespace
+
+TEST_F(LoggingTests, AddRemoveSink) {
+  RaiiSinkHandle handle =
+      mrsLoggingAddSink(mrsLogSeverity::kInfo, LogCallback, nullptr);
+  ASSERT_NE(nullptr, handle.get());
+}
+
+TEST_F(LoggingTests, AddSinkInvalidArgs) {
+  // Invalid severity
+  ASSERT_EQ(nullptr,
+            mrsLoggingAddSink(mrsLogSeverity::kNone, LogCallback, nullptr));
+  // Invalid callback
+  ASSERT_EQ(nullptr,
+            mrsLoggingAddSink(mrsLogSeverity::kInfo, nullptr, nullptr));
+}
+
+TEST_F(LoggingTests, Severity) {
+  constexpr const char kLogKeyword[] = "MR_SHARING_WEBRTC_TEST_LOG_KEYWORD";
+  CheckKeywordLogSink sink;
+  RaiiSinkHandle handle = mrsLoggingAddSink(
+      mrsLogSeverity::kWarning, &CheckKeywordLogSink::LogCallback, &sink);
+  ASSERT_NE(nullptr, handle.get());
+  {
+    sink.Clear();
+    mrsLogMessage(mrsLogSeverity::kInfo, kLogKeyword);
+    ASSERT_FALSE(sink.HasKeyword(kLogKeyword));
+  }
+  {
+    sink.Clear();
+    mrsLogMessage(mrsLogSeverity::kWarning, kLogKeyword);
+    ASSERT_TRUE(sink.HasKeyword(kLogKeyword));
+  }
+  {
+    sink.Clear();
+    mrsLogMessage(mrsLogSeverity::kError, kLogKeyword);
+    ASSERT_TRUE(sink.HasKeyword(kLogKeyword));
+  }
+  {
+    sink.Clear();
+    mrsLogMessage(mrsLogSeverity::kNone, kLogKeyword);
+    ASSERT_FALSE(sink.HasKeyword(kLogKeyword));
+  }
+}

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/LoggingTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/LoggingTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Microsoft.MixedReality.WebRTC.Tests
+{
+    class CheckKeywordTestSink : ILogSink
+    {
+        public void LogMessage(LogSeverity severity, string message)
+        {
+            Messages.Add(new Msg { severity = severity, message = message });
+        }
+
+        public void Clear()
+        {
+            Messages.Clear();
+        }
+
+        public bool TryGetMessageByKeyword(string keyword, out Msg message)
+        {
+            foreach (var msg in Messages)
+            {
+                if (msg.message.Contains(keyword))
+                {
+                    message = msg;
+                    return true;
+                }
+            }
+            message = new Msg();
+            return false;
+        }
+
+        public bool HasKeyword(string keyword)
+        {
+            foreach (var msg in Messages)
+            {
+                if (msg.message.Contains(keyword))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public struct Msg
+        {
+            public LogSeverity severity;
+            public string message;
+        }
+
+        public List<Msg> Messages = new List<Msg>();
+    }
+
+    [TestFixture]
+    internal class LoggingTests
+    {
+        [Test]
+        public void AddRemoveSink()
+        {
+            var sink = new CheckKeywordTestSink();
+            Logging.AddSink(sink, LogSeverity.Info);
+            Logging.RemoveSink(sink);
+        }
+
+        [Test]
+        public void Severity()
+        {
+            const string Keyword = "Dummy message for logging test";
+            var sink = new CheckKeywordTestSink();
+            Logging.AddSink(sink, LogSeverity.Warning);
+            {
+                sink.Clear();
+                Logging.LogMessage(LogSeverity.Info, Keyword);
+                Assert.IsFalse(sink.HasKeyword(Keyword));
+            }
+            {
+                sink.Clear();
+                Logging.LogMessage(LogSeverity.Warning, Keyword);
+                Assert.IsTrue(sink.TryGetMessageByKeyword(Keyword, out CheckKeywordTestSink.Msg msg));
+                Assert.AreEqual(LogSeverity.Warning, msg.severity);
+            }
+            {
+                sink.Clear();
+                Logging.LogMessage(LogSeverity.Error, Keyword);
+                Assert.IsTrue(sink.TryGetMessageByKeyword(Keyword, out CheckKeywordTestSink.Msg msg));
+                Assert.AreEqual(LogSeverity.Error, msg.severity);
+            }
+            {
+                sink.Clear();
+                Logging.LogMessage(LogSeverity.None, Keyword);
+                Assert.IsFalse(sink.HasKeyword(Keyword));
+            }
+            Logging.RemoveSink(sink);
+        }
+    }
+}

--- a/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj
+++ b/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj
@@ -159,6 +159,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\interop_api.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\local_audio_track_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\local_video_track_interop.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\logging_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\object_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\peer_connection_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\ref_counted_object_interop.h" />
@@ -210,6 +211,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\interop_api.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\local_audio_track_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\local_video_track_interop.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\logging_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\object_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\peer_connection_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\ref_counted_object_interop.cpp" />

--- a/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj.filters
+++ b/tools/build/mrwebrtc/uwp/mrwebrtc-uwp.vcxproj.filters
@@ -115,6 +115,9 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.cpp">
       <Filter>src\media</Filter>
     </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\logging_interop.cpp">
+      <Filter>src\interop</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\global_factory.h">
@@ -254,6 +257,9 @@
     </ClInclude>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.h">
       <Filter>src\media</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\logging_interop.h">
+      <Filter>include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj
@@ -131,6 +131,7 @@
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\external_video_track_source_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\interop_api.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\local_video_track_interop.h" />
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\logging_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\peer_connection_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\ref_counted_object_interop.h" />
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\result.h" />
@@ -184,6 +185,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\interop_api.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\local_audio_track_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\local_video_track_interop.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\logging_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\object_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\peer_connection_interop.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\ref_counted_object_interop.cpp" />

--- a/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj.filters
+++ b/tools/build/mrwebrtc/win32/mrwebrtc-win32.vcxproj.filters
@@ -115,6 +115,9 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.cpp">
       <Filter>src\media</Filter>
     </ClCompile>
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\interop\logging_interop.cpp">
+      <Filter>src\interop</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\external_video_track_source.h">
@@ -254,6 +257,9 @@
     </ClInclude>
     <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\src\media\device_audio_track_source.h">
       <Filter>src\media</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\include\logging_interop.h">
+      <Filter>include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj
+++ b/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj
@@ -82,6 +82,7 @@
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\video_test_utils.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\device_video_track_source_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\video_track_tests.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\logging_tests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\mrwebrtc-win32.vcxproj">


### PR DESCRIPTION
Allow the user to register a callback invoked each time a message is
logged by the internal WebRTC implementation. This allows better error
reporting and easier debugging without the need to connect a debugger or
even have debug symbols available (PDBs).