### PR TITLE
Handle source enable/disable correctly

### DIFF
--- a/libs/unity/library/Runtime/Scripts/Media/AudioTrackSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/AudioTrackSource.cs
@@ -19,13 +19,21 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         ///
         /// The object is owned by this component, which will create it and dispose of it automatically.
         /// </summary>
-        public WebRTC.AudioTrackSource Source { get; protected set; } = null;
+        public WebRTC.AudioTrackSource Source { get; private set; } = null;
 
         /// <inheritdoc/>
         public override MediaKind MediaKind => MediaKind.Audio;
 
+        /// <inheritdoc/>
+        public override bool IsLive => Source != null;
 
-        protected virtual void OnDisable()
+        protected void AttachSource(WebRTC.AudioTrackSource source)
+        {
+            Source = source;
+            AttachToMediaLines();
+        }
+
+        protected void DisposeSource()
         {
             if (Source != null)
             {

--- a/libs/unity/library/Runtime/Scripts/Media/MediaTrackSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MediaTrackSource.cs
@@ -19,10 +19,14 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         public abstract MediaKind MediaKind { get; }
 
         /// <summary>
+        /// Indicates if the source is currently producing frames.
+        /// </summary>
+        public abstract bool IsLive { get; }
+
+        /// <summary>
         /// List of audio media lines using this source.
         /// </summary>
         public IReadOnlyList<MediaLine> MediaLines => _mediaLines;
-
         private readonly List<MediaLine> _mediaLines = new List<MediaLine>();
 
         internal void OnAddedToMediaLine(MediaLine mediaLine)
@@ -37,14 +41,20 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             Debug.Assert(removed);
         }
 
-        protected void DetachFromMediaLines()
+        protected void AttachToMediaLines()
         {
-            // Notify media lines using this source.
             foreach (var ml in _mediaLines)
             {
-                ml.OnSourceDestroyed();
+                ml.AttachSource();
             }
-            _mediaLines.Clear();
+        }
+
+        protected void DetachFromMediaLines()
+        {
+            foreach (var ml in _mediaLines)
+            {
+                ml.DetachSource();
+            }
         }
     }
 }

--- a/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
@@ -100,11 +100,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             };
             try
             {
-                Source = await DeviceAudioTrackSource.CreateAsync(initConfig);
-                if (Source == null)
-                {
-                    throw new Exception("DeviceAudioTrackSource.CreateAsync() returned a NULL source.");
-                }
+                AttachSource(await DeviceAudioTrackSource.CreateAsync(initConfig));
             }
             catch (Exception ex)
             {

--- a/libs/unity/library/Runtime/Scripts/Media/SceneVideoSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/SceneVideoSource.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// <summary>
         /// Camera event indicating the point in time during the Unity frame rendering
         /// when the camera rendering is to be captured.
-        /// 
+        ///
         /// This defaults to <see xref="CameraEvent.AfterEverything"/>, which is a reasonable
         /// default to capture the entire scene rendering, but can be customized to achieve
         /// other effects like capturing only a part of the scene.

--- a/libs/unity/library/Runtime/Scripts/Media/VideoTrackSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/VideoTrackSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         ///
         /// The object is owned by this component, which will create it and dispose of it automatically.
         /// </summary>
-        public WebRTC.VideoTrackSource Source { get; protected set; } = null;
+        public WebRTC.VideoTrackSource Source { get; private set; } = null;
 
         /// <summary>
         /// Event raised when the video stream started.
@@ -51,20 +51,28 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         public VideoStreamStoppedEvent VideoStreamStopped = new VideoStreamStoppedEvent();
 
         /// <inheritdoc/>
-        public override MediaKind MediaKind => MediaKind.Video;
-        private readonly List<MediaLine> _mediaLines = new List<MediaLine>();
+        public override bool IsLive => Source != null;
 
-        protected virtual void OnDisable()
+        /// <inheritdoc/>
+        public override MediaKind MediaKind => MediaKind.Video;
+
+        protected void AttachSource(WebRTC.VideoTrackSource source)
+        {
+            Source = source;
+            AttachToMediaLines();
+            VideoStreamStarted.Invoke(Source);
+        }
+
+        protected void DisposeSource()
         {
             if (Source != null)
             {
+                VideoStreamStopped.Invoke(Source);
                 DetachFromMediaLines();
 
                 // Video track sources are disposable objects owned by the user (this component)
                 Source.Dispose();
                 Source = null;
-
-                VideoStreamStopped.Invoke(Source);
             }
         }
     }

--- a/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
@@ -313,11 +313,8 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             };
             try
             {
-                Source = await DeviceVideoTrackSource.CreateAsync(deviceConfig);
-                if (Source == null)
-                {
-                    throw new Exception("DeviceVideoTrackSource.CreateAsync() returned a NULL source.");
-                }
+                var source = await DeviceVideoTrackSource.CreateAsync(deviceConfig);
+                AttachSource(source);
             }
             catch (Exception ex)
             {
@@ -325,8 +322,6 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                 Debug.LogException(ex, this);
                 return;
             }
-
-            VideoStreamStarted.Invoke(Source);
         }
 
 #if PLATFORM_ANDROID

--- a/libs/unity/library/Tests/Runtime/MediaLineTests.cs
+++ b/libs/unity/library/Tests/Runtime/MediaLineTests.cs
@@ -52,7 +52,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Library.ReportLiveObjects();
         }
 
-        class DummyAudioSource : MediaTrackSource { public override MediaKind MediaKind => MediaKind.Audio; }
+        class DummyAudioSource : MediaTrackSource
+        {
+            public override MediaKind MediaKind => MediaKind.Audio;
+            public override bool IsLive => true;
+        }
 
         private MediaLine CreateMediaLine(PeerConnection pc)
         {

--- a/libs/unity/library/Tests/Runtime/VideoSenderTests.cs
+++ b/libs/unity/library/Tests/Runtime/VideoSenderTests.cs
@@ -46,21 +46,20 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             ml.Source = source;
             Assert.IsTrue(source.MediaLines.Contains(ml));
 
-            // TODO fix after media source refactoring
             //// Add event handlers to check IsStreaming state
-            //source.VideoStreamStarted.AddListener((IVideoSource self) =>
-            //{
-            //    // Becomes true *before* this handler by design
-            //    Assert.IsTrue(source);
-            //});
-            //source.VideoStreamStopped.AddListener((IVideoSource self) =>
-            //{
-            //    // Still true until *after* this handler by design
-            //    Assert.IsTrue(self.Enabled);
-            //});
+            source.VideoStreamStarted.AddListener((IVideoSource self) =>
+            {
+                // Becomes true *before* this handler by design
+                Assert.IsTrue(source.IsLive);
+            });
+            source.VideoStreamStopped.AddListener((IVideoSource self) =>
+            {
+                // Still true until *after* this handler by design
+                Assert.IsTrue(source.IsLive);
+            });
 
-            //// Confirm the source is not capturing yet because the component is inactive
-            //Assert.IsFalse(source.IsStreaming);
+            // Confirm the source is not capturing yet because the component is inactive
+            Assert.IsFalse(source.IsLive);
 
             // Confirm the sender has no track because the component is inactive
             Assert.IsNull(ml.SenderTrack);
@@ -68,19 +67,17 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             // Activate the game object and the video track source component on it
             pc_go.SetActive(true);
 
-            // TODO fix after media source refactoring
-            //// Confirm the sender is capturing because the component is now active
-            //Assert.IsTrue(source.IsStreaming);
+            // Confirm the sender is capturing because the component is now active
+            Assert.IsTrue(source.IsLive);
 
-            // Confirm the sender still has no track because there's no connection
-            Assert.IsNull(ml.SenderTrack);
+            // Confirm the sender has a track now.
+            Assert.IsNotNull(ml.SenderTrack);
 
             // Deactivate the game object and the video track source component on it
             pc_go.SetActive(false);
 
-            // TODO fix after media source refactoring
-            //// Confirm the source stops streaming
-            //Assert.IsFalse(source.IsStreaming);
+            // Confirm the source stops streaming
+            Assert.IsFalse(source.IsLive);
 
             // Terminate the coroutine.
             yield return null;

--- a/libs/unity/library/Tests/Runtime/VideoSourceTests.cs
+++ b/libs/unity/library/Tests/Runtime/VideoSourceTests.cs
@@ -106,20 +106,17 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Assert.IsTrue(initializedEvent2.Wait(millisecondsTimeout: 50000));
             Assert.IsNotNull(pc2.Peer);
 
-            // TODO fix after media source refactoring
-            //// Confirm the sources are ready
-            //if (withSender1)
-            //{
-            //    Assert.IsTrue(source1.IsStreaming);
-            //}
-            //if (withSender2)
-            //{
-            //    Assert.IsTrue(source2.IsStreaming);
-            //}
-
-            // Confirm the sender track is not created yet; it will be when the connection starts
-            Assert.IsNull(ml1.SenderTrack);
-            Assert.IsNull(ml2.SenderTrack);
+            // Confirm the sources are ready and the sender tracks have been created.
+            if (withSender1)
+            {
+                Assert.IsTrue(source1.IsLive);
+                Assert.IsNotNull(ml1.SenderTrack);
+            }
+            if (withSender2)
+            {
+                Assert.IsTrue(source2.IsLive);
+                Assert.IsNotNull(ml2.SenderTrack);
+            }
 
             // Confirm the receiver track is not added yet, since remote tracks are only instantiated
             // as the result of a session negotiation.
@@ -433,16 +430,14 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
                 if (cfg.peer1.expectSender)
                 {
                     Assert.IsNotNull(cfg.peer1.source, $"Missing source #{i} on Peer #1");
-                    // TODO fix after media source refactoring
-                    //Assert.IsNotNull(cfg.peer1.source.IsStreaming, $"Source #{i} is not ready on Peer #1");
-                    Assert.IsNull(cfg.peer1.mediaLine.SenderTrack); // created during connection
+                    Assert.IsTrue(cfg.peer1.source.IsLive, $"Source #{i} is not ready on Peer #1");
+                    Assert.IsNotNull(cfg.peer1.mediaLine.SenderTrack);
                 }
                 if (cfg.peer2.expectSender)
                 {
                     Assert.IsNotNull(cfg.peer2.source, $"Missing source #{i} on Peer #2");
-                    // TODO fix after media source refactoring
-                    //Assert.IsNotNull(cfg.peer2.source.IsStreaming, $"Source #{i} is not ready on Peer #2");
-                    Assert.IsNull(cfg.peer2.mediaLine.SenderTrack); // created during connection
+                    Assert.IsTrue(cfg.peer2.source.IsLive, $"Source #{i} is not ready on Peer #2");
+                    Assert.IsNotNull(cfg.peer2.mediaLine.SenderTrack);
                 }
             }
 
@@ -641,10 +636,9 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Assert.IsTrue(initializedEvent2.Wait(millisecondsTimeout: 50000));
             Assert.IsNotNull(pc2.Peer);
 
-            // Confirm the source is ready, but the sender track is not created yet
-            // TODO fix after media source refactoring
-            //Assert.IsNotNull(source1.IsStreaming);
-            Assert.IsNull(ml1.SenderTrack);
+            // Confirm the source is ready, and there is a sender track.
+            Assert.IsTrue(source1.IsLive);
+            Assert.IsNotNull(ml1.SenderTrack);
 
             // Connect
             Assert.IsTrue(sig.StartConnection());
@@ -811,10 +805,9 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Assert.IsTrue(initializedEvent2.Wait(millisecondsTimeout: 50000));
             Assert.IsNotNull(pc2.Peer);
 
-            // Confirm the source is ready, but the sender track is not created yet
-            // TODO fix after media source refactoring
-            //Assert.IsNotNull(source1.IsStreaming);
-            Assert.IsNull(ml1.SenderTrack);
+            // Confirm the source is ready, and there is a sender track.
+            Assert.IsTrue(source1.IsLive);
+            Assert.IsNotNull(ml1.SenderTrack);
 
             // Create some dummy out-of-band data channel to force SCTP negotiation
             // during the first offer, and be able to add some in-band data channels


### PR DESCRIPTION
MediaLines now create a sender track when a source is attached *and* live,
and destroy it if any of these is false.

Note that we could delay track creation to when a connection is established,
but this is simpler to do, and local tracks should be lightweight so creating
them eagerly won't make much of a difference.