### PR TITLE
Connect MediaLines only on PeerConnection awake

### DIFF
--- a/libs/unity/library/Runtime/Scripts/Media/MediaReceiver.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MediaReceiver.cs
@@ -43,6 +43,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// <summary>
         /// Media line this receiver is paired with, if any.
         /// </summary>
+        /// <remarks>
+        /// Note that this is set to the connected <see cref="Unity.MediaLine"/> only if the owning
+        /// <see cref="PeerConnection"/> is awake. This will be automatically reset if the
+        /// <see cref="PeerConnection"/> owning the <see cref="Unity.MediaLine"/>is destroyed.
+        /// </remarks>
         public MediaLine MediaLine { get; private set; }
 
         /// <summary>

--- a/libs/unity/library/Runtime/Scripts/Media/MediaTrackSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MediaTrackSource.cs
@@ -26,6 +26,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// <summary>
         /// List of audio media lines using this source.
         /// </summary>
+        /// <remarks>
+        /// Note that a connected <see cref="MediaLine"/> will be added to this only if the owning
+        /// <see cref="PeerConnection"/> is awake. A <see cref="MediaLine"/> will be automatically
+        /// removed if the owning <see cref="PeerConnection"/> is destroyed.
+        /// </remarks>
         public IReadOnlyList<MediaLine> MediaLines => _mediaLines;
         private readonly List<MediaLine> _mediaLines = new List<MediaLine>();
 

--- a/libs/unity/library/Tests/Runtime/PeerConnectionTests.cs
+++ b/libs/unity/library/Tests/Runtime/PeerConnectionTests.cs
@@ -143,10 +143,8 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             for (int i = 0; i < 2; ++i)
             {
                 // Initialize
-                var init1 = InitializeAndWait(pc1);
-                var init2 = InitializeAndWait(pc2);
-                yield return init1;
-                yield return init2;
+                yield return InitializeAndWait(pc1);
+                yield return InitializeAndWait(pc2);
 
                 // Confirm the sources are ready.
                 Assert.IsTrue(source1.IsLive);

--- a/libs/unity/library/Tests/Runtime/VideoSenderTests.cs
+++ b/libs/unity/library/Tests/Runtime/VideoSenderTests.cs
@@ -43,9 +43,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
 
             // Assign the video source to the media line
             ml.Source = source;
-            Assert.IsTrue(source.MediaLines.Contains(ml));
 
-            //// Add event handlers to check IsStreaming state
+            // MediaLine has not been connected yet.
+            Assert.IsEmpty(source.MediaLines);
+
+            // Add event handlers to check IsStreaming state
             source.VideoStreamStarted.AddListener((IVideoSource self) =>
             {
                 // Becomes true *before* this handler by design
@@ -65,6 +67,9 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
 
             // Activate the game object and the video track source component on it
             pc_go.SetActive(true);
+
+            // MediaLine is connected.
+            Assert.AreEqual(source.MediaLines.Single(), ml);
 
             // Confirm the sender is capturing because the component is now active
             Assert.IsTrue(source.IsLive);

--- a/libs/unity/library/Tests/Runtime/VideoSourceTests.cs
+++ b/libs/unity/library/Tests/Runtime/VideoSourceTests.cs
@@ -859,7 +859,6 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             MediaLine ml = pc1.AddMediaLine(MediaKind.Video);
             ml.SenderTrackName = "video_track_1";
             ml.Source = source1;
-            Assert.AreEqual(source1.MediaLines.Single(), ml);
 
             // Create the receiver on peer #2
             {
@@ -884,6 +883,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Assert.AreEqual(pc1.Peer.LocalVideoTracks.Count(), 1);
             Assert.IsNotNull(ml.LocalTrack);
             Assert.AreEqual(((LocalVideoTrack)ml.LocalTrack).Source, source1.Source);
+            Assert.AreEqual(source1.MediaLines.Single(), ml);
 
             // Reset source
             ml.Source = null;
@@ -948,7 +948,6 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
                 MediaLine senderMl = pc1.AddMediaLine(MediaKind.Video);
                 senderMl.SenderTrackName = "video_track_1";
                 senderMl.Source = source;
-
             }
 
             // Create the receivers on peer #2
@@ -956,7 +955,6 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             VideoReceiver receiver2 = pc2_go.AddComponent<VideoReceiver>();
             MediaLine ml = pc2.AddMediaLine(MediaKind.Video);
             ml.Receiver = receiver1;
-            Assert.AreEqual(receiver1.MediaLine, ml);
 
             // Initialize
             yield return PeerConnectionTests.InitializeAndWait(pc1);
@@ -974,6 +972,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Assert.AreEqual(pc2.Peer.RemoteVideoTracks.Count(), 1);
             Assert.IsTrue(receiver1.IsLive);
             Assert.AreEqual(receiver1.Track, ml.Transceiver.RemoteTrack);
+            Assert.AreEqual(receiver1.MediaLine, ml);
 
             // Reset receiver
             ml.Receiver = null;


### PR DESCRIPTION
Connecting in OnAfterDeserialize wasn't correct:
- source/receiver might not be deserialized yet when OnAfterDeserialize is
called
- OnAfterDeserialize is called multiple times for the same object, which
triggered asserts
- OnAfterDeserialize is not called on the update thread (which isn't great
for calling an external callback)

Fixes #446.