### PR TITLE
Fix Unity release Android artifact staging path

### DIFF
--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -130,7 +130,7 @@ jobs:
   - task: CopyFiles@2
     displayName: 'Stage mrwebrtc artifacts'
     inputs:
-      sourceFolder: '$(toolsDir)/android/webrtc-native/build/outputs/aar'
+      sourceFolder: '$(toolsDir)/android/webrtc-native/build/outputs/aar/merged'
       contents: 'mrwebrtc.aar'
       targetFolder: '$(Build.ArtifactStagingDirectory)'
 


### PR DESCRIPTION
Ensure the correct mrwebrtc.aar artifact is staged for packing by
pointing the staging task to the merged archive (containing both
MixedReality-WebRTC and libwebrtc Java classes) instead of the unmerged
one (missing the latter).