### PR TITLE
Fix issues with frame ready callbacks

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/IVideoSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/IVideoSource.cs
@@ -40,11 +40,12 @@ namespace Microsoft.MixedReality.WebRTC
         /// it received it from the remote peer (<see cref="RemoteVideoTrack"/>).
         /// </summary>
         /// <remarks>
-        /// Handlers must process the
-        /// frame as fast as possible without blocking the caller thread, and cannot remove themselves
-        /// from the event nor add other handlers to the event, otherwise the caller thread will deadlock.
-        ///
         /// The event delivers to the handlers an I420-encoded video frame.
+        ///
+        /// This event is invoked on the WebRTC worker thread. Handlers can be added/removed safely
+        /// while the event is invoked, but access to any resource used by its handlers must be
+        /// synchronized manually. Note that a handler might be invoked (at most once) after it has
+        /// been removed from the event.
         /// </remarks>
         event I420AVideoFrameDelegate I420AVideoFrameReady;
 
@@ -54,11 +55,12 @@ namespace Microsoft.MixedReality.WebRTC
         /// it received it from the remote peer (<see cref="RemoteVideoTrack"/>).
         /// </summary>
         /// <remarks>
-        /// Handlers must process the
-        /// frame as fast as possible without blocking the caller thread, and cannot remove themselves
-        /// from the event nor add other handlers to the event, otherwise the caller thread will deadlock.
-        ///
         /// The event delivers to the handlers an ARGB32-encoded video frame.
+        ///
+        /// This event is invoked on the WebRTC worker thread. Handlers can be added/removed safely
+        /// while the event is invoked, but access to any resource used by its handlers must be
+        /// synchronized manually. Note that a handler might be invoked (at most once) after it has
+        /// been removed from the event.
         /// </remarks>
         event Argb32VideoFrameDelegate Argb32VideoFrameReady;
 

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/LocalVideoTrackInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/LocalVideoTrackInterop.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
     /// </summary>
     internal sealed class LocalVideoTrackHandle : RefCountedObjectHandle { }
 
-    internal class LocalVideoTrackInterop
+    internal static class LocalVideoTrackInterop
     {
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
         internal ref struct TrackInitConfig
@@ -19,18 +19,6 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             [MarshalAs(UnmanagedType.LPStr)]
             public string TrackName;
         }
-
-        #region Unmanaged delegates
-
-        // Note - none of those method arguments can be SafeHandle; use IntPtr instead.
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
-        public delegate void I420AVideoFrameUnmanagedCallback(IntPtr userData, in I420AVideoFrame frame);
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
-        public delegate void Argb32VideoFrameUnmanagedCallback(IntPtr userData, in Argb32VideoFrame frame);
-
-        #endregion
 
 
         #region Native functions
@@ -43,12 +31,12 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsLocalVideoTrackRegisterI420AFrameCallback")]
         public static extern void LocalVideoTrack_RegisterI420AFrameCallback(LocalVideoTrackHandle trackHandle,
-            I420AVideoFrameUnmanagedCallback callback, IntPtr userData);
+            VideoTrackSourceInterop.I420AVideoFrameUnmanagedCallback callback, IntPtr userData);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsLocalVideoTrackRegisterArgb32FrameCallback")]
         public static extern void LocalVideoTrack_RegisterArgb32FrameCallback(LocalVideoTrackHandle trackHandle,
-            Argb32VideoFrameUnmanagedCallback callback, IntPtr userData);
+            VideoTrackSourceInterop.Argb32VideoFrameUnmanagedCallback callback, IntPtr userData);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsLocalVideoTrackIsEnabled")]
@@ -59,26 +47,5 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         public static extern uint LocalVideoTrack_SetEnabled(LocalVideoTrackHandle trackHandle, int enabled);
 
         #endregion
-
-        public class InteropCallbackArgs
-        {
-            public LocalVideoTrack Track;
-            public I420AVideoFrameUnmanagedCallback I420AFrameCallback;
-            public Argb32VideoFrameUnmanagedCallback Argb32FrameCallback;
-        }
-
-        [MonoPInvokeCallback(typeof(I420AVideoFrameUnmanagedCallback))]
-        public static void I420AFrameCallback(IntPtr userData, in I420AVideoFrame frame)
-        {
-            var track = Utils.ToWrapper<LocalVideoTrack>(userData);
-            track.OnI420AFrameReady(frame);
-        }
-
-        [MonoPInvokeCallback(typeof(Argb32VideoFrameUnmanagedCallback))]
-        public static void Argb32FrameCallback(IntPtr userData, in Argb32VideoFrame frame)
-        {
-            var track = Utils.ToWrapper<LocalVideoTrack>(userData);
-            track.OnArgb32FrameReady(frame);
-        }
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/RemoteVideoTrackInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/RemoteVideoTrackInterop.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.MixedReality.WebRTC.Interop
 {
-    internal class RemoteVideoTrackInterop
+    internal static class RemoteVideoTrackInterop
     {
         internal sealed class RemoteVideoTrackHandle : ObjectHandle
         {
@@ -18,56 +18,18 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsRemoteVideoTrackRegisterI420AFrameCallback")]
         public static extern void RemoteVideoTrack_RegisterI420AFrameCallback(RemoteVideoTrackHandle trackHandle,
-            LocalVideoTrackInterop.I420AVideoFrameUnmanagedCallback callback, IntPtr userData);
+            VideoTrackSourceInterop.I420AVideoFrameUnmanagedCallback callback, IntPtr userData);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsRemoteVideoTrackRegisterArgb32FrameCallback")]
         public static extern void RemoteVideoTrack_RegisterArgb32FrameCallback(RemoteVideoTrackHandle trackHandle,
-            LocalVideoTrackInterop.Argb32VideoFrameUnmanagedCallback callback, IntPtr userData);
+            VideoTrackSourceInterop.Argb32VideoFrameUnmanagedCallback callback, IntPtr userData);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsRemoteVideoTrackIsEnabled")]
         public static extern int RemoteVideoTrack_IsEnabled(RemoteVideoTrackHandle trackHandle);
 
         #endregion
-
-
-        #region Marshaling data structures
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-        public struct CreateConfig
-        {
-            public string TrackName;
-        }
-
-        #endregion
-
-
-        #region Native callbacks
-
-        public class InteropCallbackArgs
-        {
-            public RemoteVideoTrack Track;
-            public LocalVideoTrackInterop.I420AVideoFrameUnmanagedCallback I420AFrameCallback;
-            public LocalVideoTrackInterop.Argb32VideoFrameUnmanagedCallback Argb32FrameCallback;
-        }
-
-        [MonoPInvokeCallback(typeof(LocalVideoTrackInterop.I420AVideoFrameUnmanagedCallback))]
-        public static void I420AFrameCallback(IntPtr userData, in I420AVideoFrame frame)
-        {
-            var track = Utils.ToWrapper<RemoteVideoTrack>(userData);
-            track.OnI420AFrameReady(frame);
-        }
-
-        [MonoPInvokeCallback(typeof(LocalVideoTrackInterop.Argb32VideoFrameUnmanagedCallback))]
-        public static void Argb32FrameCallback(IntPtr userData, in Argb32VideoFrame frame)
-        {
-            var track = Utils.ToWrapper<RemoteVideoTrack>(userData);
-            track.OnArgb32FrameReady(frame);
-        }
-
-        #endregion
-
 
         #region Utilities
 

--- a/libs/Microsoft.MixedReality.WebRTC/LocalVideoTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/LocalVideoTrack.cs
@@ -309,19 +309,13 @@ namespace Microsoft.MixedReality.WebRTC
         void VideoTrackSourceInterop.IVideoSource.OnI420AFrameReady(I420AVideoFrame frame)
         {
             MainEventSource.Log.I420ALocalVideoFrameReady(frame.width, frame.height);
-            lock(_videoFrameReadyLock)
-            {
-                _videoFrameReady?.Invoke(frame);
-            }
+            _videoFrameReady?.Invoke(frame);
         }
 
         void VideoTrackSourceInterop.IVideoSource.OnArgb32FrameReady(Argb32VideoFrame frame)
         {
             MainEventSource.Log.Argb32LocalVideoFrameReady(frame.width, frame.height);
-            lock (_videoFrameReadyLock)
-            {
-                _argb32VideoFrameReady?.Invoke(frame);
-            }
+            _argb32VideoFrameReady?.Invoke(frame);
         }
 
         internal override void OnMute(bool muted)

--- a/libs/Microsoft.MixedReality.WebRTC/RemoteVideoTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/RemoteVideoTrack.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.WebRTC
     /// <summary>
     /// Video track receiving video frames from the remote peer.
     /// </summary>
-    public class RemoteVideoTrack : MediaTrack, IVideoSource
+    public class RemoteVideoTrack : MediaTrack, IVideoSource, VideoTrackSourceInterop.IVideoSource
     {
         /// <summary>
         /// Enabled status of the track. If enabled, receives video frames from the remote peer as
@@ -34,10 +34,76 @@ namespace Microsoft.MixedReality.WebRTC
         public VideoEncoding FrameEncoding => VideoEncoding.I420A;
 
         /// <inheritdoc/>
-        public event I420AVideoFrameDelegate I420AVideoFrameReady;
+        public event I420AVideoFrameDelegate I420AVideoFrameReady
+        {
+            add
+            {
+                bool isFirstHandler;
+                lock (_videoFrameReadyLock)
+                {
+                    isFirstHandler = (_videoFrameReady == null);
+                    _videoFrameReady += value;
+                }
+                // Do out of lock since this dispatches to the worker thread.
+                if (isFirstHandler)
+                {
+                    RemoteVideoTrackInterop.RemoteVideoTrack_RegisterI420AFrameCallback(
+                        _nativeHandle, VideoTrackSourceInterop.I420AFrameCallback, _selfHandle);
+                }
+            }
+            remove
+            {
+                bool isLastHandler;
+                lock (_videoFrameReadyLock)
+                {
+                    _videoFrameReady -= value;
+                    isLastHandler = (_videoFrameReady == null);
+                }
+                // Do out of lock since this dispatches to the worker thread.
+                if (isLastHandler)
+                {
+                    RemoteVideoTrackInterop.RemoteVideoTrack_RegisterI420AFrameCallback(
+                        _nativeHandle, null, IntPtr.Zero);
+                }
+            }
+        }
 
         /// <inheritdoc/>
-        public event Argb32VideoFrameDelegate Argb32VideoFrameReady;
+        public event Argb32VideoFrameDelegate Argb32VideoFrameReady
+        {
+            // TODO - Remove ARGB callbacks, use I420 callbacks only and expose some conversion
+            // utility to convert from ARGB to I420 when needed (to be called by the user).
+            add
+            {
+                bool isFirstHandler;
+                lock (_videoFrameReadyLock)
+                {
+                    isFirstHandler = (_argb32VideoFrameReady == null);
+                    _argb32VideoFrameReady += value;
+                }
+                // Do out of lock since this dispatches to the worker thread.
+                if (isFirstHandler)
+                {
+                    RemoteVideoTrackInterop.RemoteVideoTrack_RegisterArgb32FrameCallback(
+                        _nativeHandle, VideoTrackSourceInterop.Argb32FrameCallback, _selfHandle);
+                }
+            }
+            remove
+            {
+                bool isLastHandler;
+                lock (_videoFrameReadyLock)
+                {
+                    _argb32VideoFrameReady -= value;
+                    isLastHandler = (_argb32VideoFrameReady == null);
+                }
+                // Do out of lock since this dispatches to the worker thread.
+                if (isLastHandler)
+                {
+                    RemoteVideoTrackInterop.RemoteVideoTrack_RegisterArgb32FrameCallback(
+                        _nativeHandle, null, IntPtr.Zero);
+                }
+            }
+        }
 
         /// <summary>
         /// Handle to the native RemoteVideoTrack object.
@@ -53,10 +119,10 @@ namespace Microsoft.MixedReality.WebRTC
         /// </summary>
         private IntPtr _selfHandle = IntPtr.Zero;
 
-        /// <summary>
-        /// Callback arguments to ensure delegates registered with the native layer don't go out of scope.
-        /// </summary>
-        private RemoteVideoTrackInterop.InteropCallbackArgs _interopCallbackArgs;
+        // Frame internal event handlers.
+        private readonly object _videoFrameReadyLock = new object();
+        private event I420AVideoFrameDelegate _videoFrameReady;
+        private event Argb32VideoFrameDelegate _argb32VideoFrameReady;
 
         // Constructor for interop-based creation; SetHandle() will be called later
         internal RemoteVideoTrack(RemoteVideoTrackInterop.RemoteVideoTrackHandle handle, PeerConnection peer, string trackName)
@@ -64,34 +130,8 @@ namespace Microsoft.MixedReality.WebRTC
         {
             Debug.Assert(!handle.IsClosed);
             _nativeHandle = handle;
-            RegisterInteropCallbacks();
-        }
-
-        private void RegisterInteropCallbacks()
-        {
-            _interopCallbackArgs = new RemoteVideoTrackInterop.InteropCallbackArgs()
-            {
-                Track = this,
-                I420AFrameCallback = RemoteVideoTrackInterop.I420AFrameCallback,
-                Argb32FrameCallback = RemoteVideoTrackInterop.Argb32FrameCallback,
-            };
+            // Note that this prevents the object from being garbage-collected until it is disposed.
             _selfHandle = Utils.MakeWrapperRef(this);
-            RemoteVideoTrackInterop.RemoteVideoTrack_RegisterI420AFrameCallback(
-                _nativeHandle, _interopCallbackArgs.I420AFrameCallback, _selfHandle);
-            RemoteVideoTrackInterop.RemoteVideoTrack_RegisterArgb32FrameCallback(
-                _nativeHandle, _interopCallbackArgs.Argb32FrameCallback, _selfHandle);
-        }
-
-        private void UnregisterInteropCallbacks()
-        {
-            if (_selfHandle != IntPtr.Zero)
-            {
-                RemoteVideoTrackInterop.RemoteVideoTrack_RegisterI420AFrameCallback(_nativeHandle, null, IntPtr.Zero);
-                RemoteVideoTrackInterop.RemoteVideoTrack_RegisterArgb32FrameCallback(_nativeHandle, null, IntPtr.Zero);
-                Utils.ReleaseWrapperRef(_selfHandle);
-                _selfHandle = IntPtr.Zero;
-                _interopCallbackArgs = null;
-            }
         }
 
         /// <summary>
@@ -106,21 +146,31 @@ namespace Microsoft.MixedReality.WebRTC
 
             Debug.Assert(PeerConnection == null); // see OnTrackRemoved
 
-            UnregisterInteropCallbacks();
+            // Unregister interop callbacks
+            _videoFrameReady = null;
+            _argb32VideoFrameReady = null;
+            Utils.ReleaseWrapperRef(_selfHandle);
+            _selfHandle = IntPtr.Zero;
 
             _nativeHandle.Dispose();
         }
 
-        internal void OnI420AFrameReady(I420AVideoFrame frame)
+        void VideoTrackSourceInterop.IVideoSource.OnI420AFrameReady(I420AVideoFrame frame)
         {
             MainEventSource.Log.I420ARemoteVideoFrameReady(frame.width, frame.height);
-            I420AVideoFrameReady?.Invoke(frame);
+            lock(_videoFrameReadyLock)
+            {
+                _videoFrameReady?.Invoke(frame);
+            }
         }
 
-        internal void OnArgb32FrameReady(Argb32VideoFrame frame)
+        void VideoTrackSourceInterop.IVideoSource.OnArgb32FrameReady(Argb32VideoFrame frame)
         {
             MainEventSource.Log.Argb32RemoteVideoFrameReady(frame.width, frame.height);
-            Argb32VideoFrameReady?.Invoke(frame);
+            lock (_videoFrameReadyLock)
+            {
+                _argb32VideoFrameReady?.Invoke(frame);
+            }
         }
 
         internal override void OnMute(bool muted)

--- a/libs/Microsoft.MixedReality.WebRTC/RemoteVideoTrack.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/RemoteVideoTrack.cs
@@ -158,19 +158,13 @@ namespace Microsoft.MixedReality.WebRTC
         void VideoTrackSourceInterop.IVideoSource.OnI420AFrameReady(I420AVideoFrame frame)
         {
             MainEventSource.Log.I420ARemoteVideoFrameReady(frame.width, frame.height);
-            lock(_videoFrameReadyLock)
-            {
-                _videoFrameReady?.Invoke(frame);
-            }
+            _videoFrameReady?.Invoke(frame);
         }
 
         void VideoTrackSourceInterop.IVideoSource.OnArgb32FrameReady(Argb32VideoFrame frame)
         {
             MainEventSource.Log.Argb32RemoteVideoFrameReady(frame.width, frame.height);
-            lock (_videoFrameReadyLock)
-            {
-                _argb32VideoFrameReady?.Invoke(frame);
-            }
+            _argb32VideoFrameReady?.Invoke(frame);
         }
 
         internal override void OnMute(bool muted)

--- a/libs/Microsoft.MixedReality.WebRTC/VideoTrackSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/VideoTrackSource.cs
@@ -257,19 +257,13 @@ namespace Microsoft.MixedReality.WebRTC
         void VideoTrackSourceInterop.IVideoSource.OnI420AFrameReady(I420AVideoFrame frame)
         {
             MainEventSource.Log.I420ALocalVideoFrameReady(frame.width, frame.height);
-            lock (_videoFrameReadyLock)
-            {
-                _videoFrameReady?.Invoke(frame);
-            }
+            _videoFrameReady?.Invoke(frame);
         }
 
         void VideoTrackSourceInterop.IVideoSource.OnArgb32FrameReady(Argb32VideoFrame frame)
         {
             MainEventSource.Log.Argb32LocalVideoFrameReady(frame.width, frame.height);
-            lock (_videoFrameReadyLock)
-            {
-                _argb32VideoFrameReady?.Invoke(frame);
-            }
+            _argb32VideoFrameReady?.Invoke(frame);
         }
 
         /// <inheritdoc/>

--- a/libs/mrwebrtc/src/media/video_track_source.cpp
+++ b/libs/mrwebrtc/src/media/video_track_source.cpp
@@ -80,7 +80,7 @@ void VideoTrackSource::SetCallbackImpl(T callback) noexcept {
     if (observer_) {
       // Reset the callback.
       observer_->SetCallback(callback);
-      if (!observer_->HasCallbacks()) {
+      if (!observer_->HasAnyCallbacks()) {
         // Detach the observer.
         // Track sources need to be manipulated from the worker thread
         rtc::Thread* const worker_thread =

--- a/libs/mrwebrtc/src/media/video_track_source.h
+++ b/libs/mrwebrtc/src/media/video_track_source.h
@@ -76,10 +76,14 @@ class VideoTrackSource : public TrackedObject {
   void SetCallback(I420AFrameReadyCallback callback) noexcept;
   void SetCallback(Argb32FrameReadyCallback callback) noexcept;
 
-  inline rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> impl() const
-      noexcept {
+  inline rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> impl()
+      const noexcept {
     return source_;
   }
+
+ private:
+  template <class T>
+  void SetCallbackImpl(T callback) noexcept;
 
  protected:
   rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> source_;

--- a/libs/mrwebrtc/src/video_frame_observer.h
+++ b/libs/mrwebrtc/src/video_frame_observer.h
@@ -127,6 +127,8 @@ class VideoFrameObserver : public rtc::VideoSinkInterface<webrtc::VideoFrame> {
   /// This is not exclusive and can be used along another I420 callback.
   void SetCallback(Argb32FrameReadyCallback callback) noexcept;
 
+  bool HasCallbacks() const { return i420a_callback_ || argb_callback_; }
+
  protected:
   /// Get a temporary scratch buffer for an ARGB32 frame of the given
   /// dimensions. The returned buffer does not need to be deallocated, but can

--- a/libs/mrwebrtc/src/video_frame_observer.h
+++ b/libs/mrwebrtc/src/video_frame_observer.h
@@ -127,7 +127,7 @@ class VideoFrameObserver : public rtc::VideoSinkInterface<webrtc::VideoFrame> {
   /// This is not exclusive and can be used along another I420 callback.
   void SetCallback(Argb32FrameReadyCallback callback) noexcept;
 
-  bool HasCallbacks() const { return i420a_callback_ || argb_callback_; }
+  bool HasAnyCallbacks() const { return i420a_callback_ || argb_callback_; }
 
  protected:
   /// Get a temporary scratch buffer for an ARGB32 frame of the given

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/LocalVideoTrackTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/LocalVideoTrackTests.cs
@@ -417,9 +417,11 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             };
             using (var source = ExternalVideoTrackSource.CreateFromI420ACallback(
                 VideoTrackSourceTests.CustomI420AFrameCallback))
-            using (var track = LocalVideoTrack.CreateFromSource(source, track_config))
             {
-                VideoTrackSourceTests.TestFrameReadyCallbacks(track);
+                using (var track = LocalVideoTrack.CreateFromSource(source, track_config))
+                {
+                    VideoTrackSourceTests.TestFrameReadyCallbacks(track);
+                }
             }
         }
 

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/RemoteTrackTest.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/RemoteTrackTest.cs
@@ -42,26 +42,28 @@ namespace Microsoft.MixedReality.WebRTC.Tests
             // Add a local video track.
             using (var source = ExternalVideoTrackSource.CreateFromI420ACallback(
                 VideoTrackSourceTests.CustomI420AFrameCallback))
-            using (var localTrack = LocalVideoTrack.CreateFromSource(source, track_config))
             {
-                transceiver1.LocalVideoTrack = localTrack;
+                using (var localTrack = LocalVideoTrack.CreateFromSource(source, track_config))
+                {
+                    transceiver1.LocalVideoTrack = localTrack;
 
-                // Connect
-                await DoNegotiationStartFrom(pc1_);
+                    // Connect
+                    await DoNegotiationStartFrom(pc1_);
 
-                // Find the remote track
-                Assert.AreEqual(1, pc2_.Transceivers.Count);
-                var transceiver2 = pc2_.Transceivers[0];
-                var remoteTrack = transceiver2.RemoteVideoTrack;
-                Assert.IsNotNull(remoteTrack);
-                Assert.AreEqual(transceiver2, remoteTrack.Transceiver);
-                Assert.AreEqual(pc2_, remoteTrack.PeerConnection);
+                    // Find the remote track
+                    Assert.AreEqual(1, pc2_.Transceivers.Count);
+                    var transceiver2 = pc2_.Transceivers[0];
+                    var remoteTrack = transceiver2.RemoteVideoTrack;
+                    Assert.IsNotNull(remoteTrack);
+                    Assert.AreEqual(transceiver2, remoteTrack.Transceiver);
+                    Assert.AreEqual(pc2_, remoteTrack.PeerConnection);
 
-                // Remote track receives frames.
-                VideoTrackSourceTests.TestFrameReadyCallbacks(remoteTrack);
+                    // Remote track receives frames.
+                    VideoTrackSourceTests.TestFrameReadyCallbacks(remoteTrack);
 
-                // Cleanup.
-                transceiver1.LocalVideoTrack = null;
+                    // Cleanup.
+                    transceiver1.LocalVideoTrack = null;
+                }
             }
         }
     }

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/RemoteTrackTest.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/RemoteTrackTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Microsoft.MixedReality.WebRTC.Tests
+{
+    [TestFixture(SdpSemantic.PlanB)]
+    [TestFixture(SdpSemantic.UnifiedPlan)]
+    internal class RemoteTrackTests : PeerConnectionTestBase
+    {
+        public RemoteTrackTests(SdpSemantic sdpSemantic) : base(sdpSemantic)
+        {
+        }
+
+        [Test]
+        public async Task VideoCall()
+        {
+            // This test use manual offers
+            suspendOffer1_ = true;
+
+            // Create video transceiver on #1. This triggers a renegotiation needed event.
+            string name1 = "video_feed";
+            var initSettings = new TransceiverInitSettings
+            {
+                Name = name1,
+                InitialDesiredDirection = Transceiver.Direction.SendOnly,
+                StreamIDs = new List<string> { "id1", "id2" }
+            };
+
+            var transceiver1 = pc1_.AddTransceiver(MediaKind.Video, initSettings);
+
+            var track_config = new LocalVideoTrackInitConfig
+            {
+                trackName = "custom_i420a"
+            };
+
+            // Add a local video track.
+            using (var source = ExternalVideoTrackSource.CreateFromI420ACallback(
+                VideoTrackSourceTests.CustomI420AFrameCallback))
+            using (var localTrack = LocalVideoTrack.CreateFromSource(source, track_config))
+            {
+                transceiver1.LocalVideoTrack = localTrack;
+
+                // Connect
+                await DoNegotiationStartFrom(pc1_);
+
+                // Find the remote track
+                Assert.AreEqual(1, pc2_.Transceivers.Count);
+                var transceiver2 = pc2_.Transceivers[0];
+                var remoteTrack = transceiver2.RemoteVideoTrack;
+                Assert.IsNotNull(remoteTrack);
+                Assert.AreEqual(transceiver2, remoteTrack.Transceiver);
+                Assert.AreEqual(pc2_, remoteTrack.PeerConnection);
+
+                // Remote track receives frames.
+                VideoTrackSourceTests.TestFrameReadyCallbacks(remoteTrack);
+
+                // Cleanup.
+                transceiver1.LocalVideoTrack = null;
+            }
+        }
+    }
+}

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/VideoEnum.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/VideoEnum.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
@@ -20,7 +21,7 @@ namespace Microsoft.MixedReality.WebRTC.Tests
         /// any device then its ID and name are not empty.
         /// </summary>
         [Test]
-        public async void EnumVideoDevices()
+        public async Task EnumVideoDevices()
         {
             List<VideoCaptureDevice> devices = await DeviceVideoTrackSource.GetCaptureDevicesAsync();
             foreach (var device in devices)
@@ -35,7 +36,7 @@ namespace Microsoft.MixedReality.WebRTC.Tests
         /// GetVideoCaptureFormatsAsync() returns some valid formats.
         /// </summary>
         [Test]
-        public async void EnumVideoFormats()
+        public async Task EnumVideoFormats()
         {
             List<VideoCaptureDevice> devices = await DeviceVideoTrackSource.GetCaptureDevicesAsync();
             if (devices.Count == 0)

--- a/tests/Microsoft.MixedReality.WebRTC.Tests/VideoTrackSourceTests.cs
+++ b/tests/Microsoft.MixedReality.WebRTC.Tests/VideoTrackSourceTests.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -13,6 +16,149 @@ namespace Microsoft.MixedReality.WebRTC.Tests
     {
         public VideoTrackSourceTests(SdpSemantic sdpSemantic) : base(sdpSemantic)
         {
+        }
+
+        public static unsafe void CustomI420AFrameCallback(in FrameRequest request)
+        {
+            var data = stackalloc byte[32 * 16 + 16 * 8 * 2];
+            int k = 0;
+            // Y plane (full resolution)
+            for (int j = 0; j < 16; ++j)
+            {
+                for (int i = 0; i < 32; ++i)
+                {
+                    data[k++] = 0x7F;
+                }
+            }
+            // U plane (halved chroma in both directions)
+            for (int j = 0; j < 8; ++j)
+            {
+                for (int i = 0; i < 16; ++i)
+                {
+                    data[k++] = 0x30;
+                }
+            }
+            // V plane (halved chroma in both directions)
+            for (int j = 0; j < 8; ++j)
+            {
+                for (int i = 0; i < 16; ++i)
+                {
+                    data[k++] = 0xB2;
+                }
+            }
+            var dataY = new IntPtr(data);
+            var frame = new I420AVideoFrame
+            {
+                dataY = dataY,
+                dataU = dataY + (32 * 16),
+                dataV = dataY + (32 * 16) + (16 * 8),
+                dataA = IntPtr.Zero,
+                strideY = 32,
+                strideU = 16,
+                strideV = 16,
+                strideA = 0,
+                width = 32,
+                height = 16
+            };
+            request.CompleteRequest(frame);
+        }
+
+        public static unsafe void CustomArgb32FrameCallback(in FrameRequest request)
+        {
+            var data = stackalloc uint[32 * 16];
+            int k = 0;
+            // Create 2x2 checker pattern with 4 different colors
+            for (int j = 0; j < 8; ++j)
+            {
+                for (int i = 0; i < 16; ++i)
+                {
+                    data[k++] = 0xFF0000FF;
+                }
+                for (int i = 16; i < 32; ++i)
+                {
+                    data[k++] = 0xFF00FF00;
+                }
+            }
+            for (int j = 8; j < 16; ++j)
+            {
+                for (int i = 0; i < 16; ++i)
+                {
+                    data[k++] = 0xFFFF0000;
+                }
+                for (int i = 16; i < 32; ++i)
+                {
+                    data[k++] = 0xFF00FFFF;
+                }
+            }
+            var frame = new Argb32VideoFrame
+            {
+                data = new IntPtr(data),
+                stride = 128,
+                width = 32,
+                height = 16
+            };
+            request.CompleteRequest(frame);
+        }
+
+        public static void TestFrameReadyCallbacks(IVideoSource source)
+        {
+            bool shouldReceiveI420 = true;
+            int i420Counter = 0;
+            var enoughI420Frames = new ManualResetEventSlim(false);
+            void i420Handler(I420AVideoFrame frame)
+            {
+                Assert.IsTrue(shouldReceiveI420);
+                Assert.AreEqual(32, frame.width);
+                Assert.AreEqual(16, frame.height);
+                if (i420Counter == 10)
+                {
+                    enoughI420Frames.Set();
+                }
+                else if (i420Counter < 10)
+                {
+                    ++i420Counter;
+                }
+            }
+
+            bool shouldReceiveArgb32 = true;
+            int argb32Counter = 0;
+            var enoughArgb32Frames = new ManualResetEventSlim(false);
+            void argb32Handler(Argb32VideoFrame frame)
+            {
+                Assert.IsTrue(shouldReceiveArgb32);
+                Assert.AreEqual(32, frame.width);
+                Assert.AreEqual(16, frame.height);
+                if (argb32Counter == 10)
+                {
+                    enoughArgb32Frames.Set();
+                }
+                else if (argb32Counter < 10)
+                {
+                    ++argb32Counter;
+                }
+            }
+
+            // Receive I420 frames.
+            source.I420AVideoFrameReady += i420Handler;
+            Assert.IsTrue(enoughI420Frames.Wait(TimeSpan.FromSeconds(10)));
+
+            // Receive both.
+            source.Argb32VideoFrameReady += argb32Handler;
+            enoughI420Frames.Reset();
+            i420Counter = 0;
+            Assert.IsTrue(enoughI420Frames.Wait(TimeSpan.FromSeconds(10)));
+            Assert.IsTrue(enoughArgb32Frames.Wait(TimeSpan.FromSeconds(10)));
+
+            // Receive ARGB32 frames.
+            source.I420AVideoFrameReady -= i420Handler;
+            enoughArgb32Frames.Reset();
+            argb32Counter = 0;
+            shouldReceiveI420 = false;
+            Assert.IsTrue(enoughArgb32Frames.Wait(TimeSpan.FromSeconds(10)));
+
+            // Stop all callbacks.
+            source.Argb32VideoFrameReady -= argb32Handler;
+            shouldReceiveArgb32 = false;
         }
 
 #if !MRSW_EXCLUDE_DEVICE_TESTS
@@ -43,5 +189,15 @@ namespace Microsoft.MixedReality.WebRTC.Tests
         }
 
 #endif // MRSW_EXCLUDE_DEVICE_TESTS
+
+        [Test]
+        public void FrameReadyCallbacks()
+        {
+            using (var source = ExternalVideoTrackSource.CreateFromI420ACallback(
+                CustomI420AFrameCallback))
+            {
+                TestFrameReadyCallbacks(source);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #151, a deadlock caused by subscription and frame-ready event trying to acquire the callback lock and the WebRTC worker thread at the same time, wrong behavior when using both I420A and ARGB32 callbacks, and a non-compiling test.