### PR TITLE
Enumerate video profiles and filter capture formats

### DIFF
--- a/examples/TestAppUwp/AddVideoTrackPage.xaml
+++ b/examples/TestAppUwp/AddVideoTrackPage.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:winmc="using:Windows.Media.Capture"
+    xmlns:mrwebrtc="using:Microsoft.MixedReality.WebRTC"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     NavigationCacheMode="Required">
@@ -19,8 +20,8 @@
                 </StackPanel>
             </StackPanel>
         </DataTemplate>
-        <DataTemplate x:Key="VideoProfileTemplate" x:DataType="winmc:MediaCaptureVideoProfile">
-            <TextBlock Text="{x:Bind Id}" VerticalAlignment="Center"/>
+        <DataTemplate x:Key="VideoProfileTemplate" x:DataType="mrwebrtc:VideoProfile">
+            <TextBlock Text="{x:Bind uniqueId}" VerticalAlignment="Center"/>
         </DataTemplate>
         <DataTemplate x:Key="RecordMediaDescTemplate" x:DataType="winmc:MediaCaptureVideoProfileMediaDescription">
             <StackPanel Orientation="Horizontal">

--- a/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
@@ -206,7 +206,7 @@ namespace TestAppUwp
             }
         }
 
-        public void RefreshVideoProfiles(VideoCaptureDeviceInfo item, VideoProfileKind kind)
+        public async void RefreshVideoProfiles(VideoCaptureDeviceInfo item, VideoProfileKind kind)
         {
             var videoProfiles = new CollectionViewModel<MediaCaptureVideoProfile>();
             if (item != null)
@@ -215,6 +215,13 @@ namespace TestAppUwp
                 if (kind == VideoProfileKind.Unspecified)
                 {
                     profiles = MediaCapture.FindAllVideoProfiles(item.Id);
+
+                    // TEMP
+                    var list = await DeviceVideoTrackSource.GetDeviceProfilesAsync(item.Id);
+                    foreach (var pr in list)
+                    {
+                        Console.WriteLine(pr.uniqueId);
+                    }
                 }
                 else
                 {
@@ -265,7 +272,7 @@ namespace TestAppUwp
                 else
                 {
                     // Device doesn't support video profiles; fall back on flat list of capture formats.
-                    List<VideoCaptureFormat> formatsList = await DeviceVideoTrackSource.GetCaptureFormatsAsync(item.Id);
+                    IReadOnlyList<VideoCaptureFormat> formatsList = await DeviceVideoTrackSource.GetCaptureFormatsAsync(item.Id);
                     foreach (var format in formatsList)
                     {
                         formats.Add(new VideoCaptureFormatViewModel

--- a/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/VideoCaptureViewModel.cs
@@ -98,7 +98,7 @@ namespace TestAppUwp
         /// Collection of video profiles for the currently selected video capture device
         /// and video profile kind.
         /// </summary>
-        public CollectionViewModel<MediaCaptureVideoProfile> VideoProfiles
+        public CollectionViewModel<VideoProfile> VideoProfiles
         {
             get { return _videoProfiles; }
             private set
@@ -138,8 +138,8 @@ namespace TestAppUwp
             = new CollectionViewModel<VideoCaptureDeviceInfo>();
         private CollectionViewModel<VideoCaptureFormatViewModel> _videoCaptureFormats
             = new CollectionViewModel<VideoCaptureFormatViewModel>();
-        private CollectionViewModel<MediaCaptureVideoProfile> _videoProfiles
-            = new CollectionViewModel<MediaCaptureVideoProfile>();
+        private CollectionViewModel<VideoProfile> _videoProfiles
+            = new CollectionViewModel<VideoProfile>();
         private VideoProfileKind _selectedVideoProfileKind = VideoProfileKind.Unspecified;
         private bool _canCreateTrack = false;
         private string _errorMessage;
@@ -208,28 +208,14 @@ namespace TestAppUwp
 
         public async void RefreshVideoProfiles(VideoCaptureDeviceInfo item, VideoProfileKind kind)
         {
-            var videoProfiles = new CollectionViewModel<MediaCaptureVideoProfile>();
+            // Clear formats, which are profile-dependent. This ensures the former list doesn't
+            // stay visible if the current profile kind is not supported (does not return any profile).
+            VideoCaptureFormats.Clear();
+
+            var videoProfiles = new CollectionViewModel<VideoProfile>();
             if (item != null)
             {
-                IReadOnlyList<MediaCaptureVideoProfile> profiles;
-                if (kind == VideoProfileKind.Unspecified)
-                {
-                    profiles = MediaCapture.FindAllVideoProfiles(item.Id);
-
-                    // TEMP
-                    var list = await DeviceVideoTrackSource.GetDeviceProfilesAsync(item.Id);
-                    foreach (var pr in list)
-                    {
-                        Console.WriteLine(pr.uniqueId);
-                    }
-                }
-                else
-                {
-                    // VideoProfileKind and KnownVideoProfile are the same with the exception of
-                    // `Unspecified` that takes value 0.
-                    var profile = (KnownVideoProfile)((int)kind - 1);
-                    profiles = MediaCapture.FindKnownVideoProfiles(item.Id, profile);
-                }
+                IReadOnlyList<VideoProfile> profiles = await DeviceVideoTrackSource.GetCaptureProfilesAsync(item.Id, kind);
                 foreach (var profile in profiles)
                 {
                     videoProfiles.Add(profile);
@@ -256,31 +242,25 @@ namespace TestAppUwp
             var formats = new CollectionViewModel<VideoCaptureFormatViewModel>();
             if (item != null)
             {
-                if (MediaCapture.IsVideoProfileSupported(item.Id))
+                IReadOnlyList<VideoCaptureFormat> formatsList;
+                string profileId = VideoProfiles.SelectedItem?.uniqueId;
+                if (string.IsNullOrEmpty(profileId))
                 {
-                    foreach (var desc in VideoProfiles.SelectedItem?.SupportedRecordMediaDescription)
-                    {
-                        var formatVM = new VideoCaptureFormatViewModel();
-                        formatVM.Format.width = desc.Width;
-                        formatVM.Format.height = desc.Height;
-                        formatVM.Format.framerate = desc.FrameRate;
-                        //formatVM.Format.fourcc = desc.Subtype; // TODO: string => FOURCC
-                        formatVM.FormatEncodingDisplayName = desc.Subtype;
-                        formats.Add(formatVM);
-                    }
+                    // Device doesn't support video profiles; fall back on flat list of capture formats.
+                    formatsList = await DeviceVideoTrackSource.GetCaptureFormatsAsync(item.Id);
                 }
                 else
                 {
-                    // Device doesn't support video profiles; fall back on flat list of capture formats.
-                    IReadOnlyList<VideoCaptureFormat> formatsList = await DeviceVideoTrackSource.GetCaptureFormatsAsync(item.Id);
-                    foreach (var format in formatsList)
+                    // Enumerate formats for the specified profile only
+                    formatsList = await DeviceVideoTrackSource.GetCaptureFormatsAsync(item.Id, profileId);
+                }
+                foreach (var format in formatsList)
+                {
+                    formats.Add(new VideoCaptureFormatViewModel
                     {
-                        formats.Add(new VideoCaptureFormatViewModel
-                        {
-                            Format = format,
-                            FormatEncodingDisplayName = FourCCToString(format.fourcc)
-                        });
-                    }
+                        Format = format,
+                        FormatEncodingDisplayName = FourCCToString(format.fourcc)
+                    });
                 }
             }
             VideoCaptureFormats = formats;
@@ -312,8 +292,8 @@ namespace TestAppUwp
             }
             if (deviceInfo.SupportsVideoProfiles)
             {
-                MediaCaptureVideoProfile profile = VideoProfiles.SelectedItem;
-                deviceConfig.videoProfileId = profile?.Id;
+                VideoProfile profile = VideoProfiles.SelectedItem;
+                deviceConfig.videoProfileId = profile?.uniqueId;
                 deviceConfig.videoProfileKind = SelectedVideoProfileKind;
             }
             var source = await DeviceVideoTrackSource.CreateAsync(deviceConfig);

--- a/libs/Microsoft.MixedReality.WebRTC/DeviceVideoTrackSource.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/DeviceVideoTrackSource.cs
@@ -178,7 +178,7 @@ namespace Microsoft.MixedReality.WebRTC
         /// 
         /// This is equivalent to:
         /// <code>
-        /// GetCaptureProfilesAsync(deviceId, VideoProfileKind.Unknown);
+        /// GetCaptureProfilesAsync(deviceId, VideoProfileKind.Unspecified);
         /// </code>
         /// </remarks>
         /// <seealso cref="GetCaptureProfilesAsync(string, VideoProfileKind)"/>

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/DeviceVideoTrackSourceInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/DeviceVideoTrackSourceInterop.cs
@@ -25,6 +25,15 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         }
 
         /// <summary>
+        /// Marshaling struct for enumerating a video profile.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        internal ref struct VideoProfileMarshalInfo
+        {
+            public string Id;
+        }
+
+        /// <summary>
         /// Marshaling struct for enumerating a video capture format.
         /// </summary>
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
@@ -39,10 +48,12 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         // Callbacks for internal enumeration implementation only
         public delegate void VideoCaptureDeviceEnumCallbackImpl(in VideoCaptureDevice device);
         public delegate void VideoCaptureDeviceEnumCompletedCallbackImpl(Exception ex);
+        public delegate void VideoProfileEnumCallbackImpl(in VideoProfile device);
+        public delegate void VideoProfileEnumCompletedCallbackImpl(Exception ex);
         public delegate void VideoCaptureFormatEnumCallbackImpl(in VideoCaptureFormat format);
         public delegate void VideoCaptureFormatEnumCompletedCallbackImpl(Exception ex);
 
-        public class EnumVideoCaptureDeviceWrapper
+        public class EnumVideoCaptureDevicesWrapper
         {
             public VideoCaptureDeviceEnumCallbackImpl enumCallback;
             public VideoCaptureDeviceEnumCompletedCallbackImpl completedCallback;
@@ -54,7 +65,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         [MonoPInvokeCallback(typeof(VideoCaptureDeviceEnumCallback))]
         public static void VideoCaptureDevice_EnumCallback(IntPtr userData, in VideoCaptureDeviceMarshalInfo deviceInfo)
         {
-            var wrapper = Utils.ToWrapper<EnumVideoCaptureDeviceWrapper>(userData);
+            var wrapper = Utils.ToWrapper<EnumVideoCaptureDevicesWrapper>(userData);
             var device = new VideoCaptureDevice();
             device.id = deviceInfo.Id;
             device.name = deviceInfo.Name;
@@ -65,7 +76,33 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         public static void VideoCaptureDevice_EnumCompletedCallback(IntPtr userData, uint resultCode)
         {
             var exception = Utils.GetExceptionForErrorCode(resultCode);
-            var wrapper = Utils.ToWrapper<EnumVideoCaptureDeviceWrapper>(userData);
+            var wrapper = Utils.ToWrapper<EnumVideoCaptureDevicesWrapper>(userData);
+            wrapper.completedCallback(exception); // this is optional, allows to be null
+        }
+
+        public class EnumVideoProfilesWrapper
+        {
+            public VideoProfileEnumCallbackImpl enumCallback;
+            public VideoProfileEnumCompletedCallbackImpl completedCallback;
+            // Keep delegates alive!
+            public VideoProfileEnumCallback EnumTrampoline;
+            public VideoProfileEnumCompletedCallback CompletedTrampoline;
+        }
+
+        [MonoPInvokeCallback(typeof(VideoProfileEnumCallback))]
+        public static void VideoProfile_EnumCallback(IntPtr userData, in VideoProfileMarshalInfo profileInfo)
+        {
+            var wrapper = Utils.ToWrapper<EnumVideoProfilesWrapper>(userData);
+            var profile = new VideoProfile();
+            profile.uniqueId = profileInfo.Id;
+            wrapper.enumCallback(profile); // this is mandatory, never null
+        }
+
+        [MonoPInvokeCallback(typeof(VideoProfileEnumCompletedCallback))]
+        public static void VideoProfile_EnumCompletedCallback(IntPtr userData, uint resultCode)
+        {
+            var exception = Utils.GetExceptionForErrorCode(resultCode);
+            var wrapper = Utils.ToWrapper<EnumVideoProfilesWrapper>(userData);
             wrapper.completedCallback(exception); // this is optional, allows to be null
         }
 
@@ -205,6 +242,12 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         public delegate void VideoCaptureDeviceEnumCompletedCallback(IntPtr userData, uint resultCode);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        public delegate void VideoProfileEnumCallback(IntPtr userData, in VideoProfileMarshalInfo profileInfo);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        public delegate void VideoProfileEnumCompletedCallback(IntPtr userData, uint resultCode);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         public delegate void VideoCaptureFormatEnumCallback(IntPtr userData, in VideoCaptureFormatMarshalInfo formatInfo);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
@@ -219,6 +262,11 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             EntryPoint = "mrsEnumVideoCaptureDevicesAsync")]
         public static extern uint EnumVideoCaptureDevicesAsync(VideoCaptureDeviceEnumCallback enumCallback, IntPtr userData,
             VideoCaptureDeviceEnumCompletedCallback completedCallback, IntPtr completedUserData);
+
+        [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsEnumVideoProfilesAsync")]
+        public static extern uint EnumVideoProfilesAsync(string deviceId, VideoProfileEnumCallback enumCallback, IntPtr userData,
+            VideoProfileEnumCompletedCallback completedCallback, IntPtr completedUserData);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsEnumVideoCaptureFormatsAsync")]

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/DeviceVideoTrackSourceInterop.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/DeviceVideoTrackSourceInterop.cs
@@ -265,13 +265,15 @@ namespace Microsoft.MixedReality.WebRTC.Interop
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsEnumVideoProfilesAsync")]
-        public static extern uint EnumVideoProfilesAsync(string deviceId, VideoProfileEnumCallback enumCallback, IntPtr userData,
+        public static extern uint EnumVideoProfilesAsync(string deviceId, VideoProfileKind profileKind,
+            VideoProfileEnumCallback enumCallback, IntPtr userData,
             VideoProfileEnumCompletedCallback completedCallback, IntPtr completedUserData);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsEnumVideoCaptureFormatsAsync")]
-        public static extern uint EnumVideoCaptureFormatsAsync(string deviceId, VideoCaptureFormatEnumCallback enumCallback,
-            IntPtr userData, VideoCaptureFormatEnumCompletedCallback completedCallback, IntPtr completedUserData);
+        public static extern uint EnumVideoCaptureFormatsAsync(string deviceId, string profileId, VideoProfileKind profileKind,
+            VideoCaptureFormatEnumCallback enumCallback, IntPtr userData,
+            VideoCaptureFormatEnumCompletedCallback completedCallback, IntPtr completedUserData);
 
         [DllImport(Utils.dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsDeviceVideoTrackSourceCreate")]

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -137,6 +137,12 @@ struct mrsVideoCaptureDeviceInfo {
   const char* name;
 };
 
+/// Video profile info.
+struct mrsVideoProfileInfo {
+  // Unique identifier of the video profile.
+  const char* id;
+};
+
 /// Video capture format info.
 struct mrsVideoCaptureFormatInfo {
   // Capture width, in pixels.
@@ -183,6 +189,37 @@ MRS_API mrsResult MRS_CALL mrsEnumVideoCaptureDevicesAsync(
     mrsVideoCaptureDeviceEnumCallback enumCallback,
     void* enumCallbackUserData,
     mrsVideoCaptureDeviceEnumCompletedCallback completedCallback,
+    void* completedCallbackUserData) noexcept;
+
+/// Callback invoked for each enumerated video capture device.
+using mrsVideoProfileEnumCallback =
+    void(MRS_CALL*)(void* user_data, const mrsVideoProfileInfo* profile_info);
+
+/// Callback invoked on video profile enumeration completed. If the result is
+/// not |mrsResult::kSuccess| then some or all of the profiles might not have
+/// been enumerated.
+using mrsVideoProfileEnumCompletedCallback = void(MRS_CALL*)(void* user_data,
+                                                             mrsResult result);
+
+/// Enumerate the video profiles for the given capture device asynchronously.
+///
+/// If the enumeration starts successfully, that is the function returns
+/// |mrsResult::kSuccess|, then for each video profile found for the given
+/// capture device the implementation invokes the mandatory |enumCallback|. At
+/// the end of the enumeration, it invokes the optional |completedCallback| if
+/// it was provided (non-null). Note that those calls are asynchonous and not
+/// necessarily done before |mrsEnumVideoProfilesAsync()| returned.
+///
+/// If the enumeration fails to start, the function returns an error code; in
+/// that case no callback is invoked.
+///
+/// On UWP this must *not* be called from the main UI thread, otherwise a
+/// |mrsResult::kWrongThread| error might be returned.
+MRS_API mrsResult MRS_CALL mrsEnumVideoProfilesAsync(
+    const char* device_id,
+    mrsVideoProfileEnumCallback enumCallback,
+    void* enumCallbackUserData,
+    mrsVideoProfileEnumCompletedCallback completedCallback,
     void* completedCallbackUserData) noexcept;
 
 /// Callback invoked for each enumerated video capture format.

--- a/libs/mrwebrtc/src/interop/interop_api.cpp
+++ b/libs/mrwebrtc/src/interop/interop_api.cpp
@@ -109,6 +109,7 @@ mrsResult MRS_CALL mrsEnumVideoCaptureDevicesAsync(
 
 mrsResult MRS_CALL mrsEnumVideoProfilesAsync(
     const char* device_id,
+    mrsVideoProfileKind profile_kind,
     mrsVideoProfileEnumCallback enumCallback,
     void* enumCallbackUserData,
     mrsVideoProfileEnumCompletedCallback completedCallback,
@@ -122,7 +123,7 @@ mrsResult MRS_CALL mrsEnumVideoProfilesAsync(
   RTC_LOG(LS_INFO) << "Enumerating video profiles for device '" << device_id
                    << "'";
   Error res = DeviceVideoTrackSource::GetVideoProfiles(
-      device_id, {enumCallback, enumCallbackUserData},
+      device_id, profile_kind, {enumCallback, enumCallbackUserData},
       {completedCallback, completedCallbackUserData});
   if (!res.ok()) {
     RTC_LOG(LS_ERROR) << "Failed to enumerate video profiles for device '"
@@ -134,6 +135,8 @@ mrsResult MRS_CALL mrsEnumVideoProfilesAsync(
 
 mrsResult MRS_CALL mrsEnumVideoCaptureFormatsAsync(
     const char* device_id,
+    const char* profile_id,
+    mrsVideoProfileKind profile_kind,
     mrsVideoCaptureFormatEnumCallback enumCallback,
     void* enumCallbackUserData,
     mrsVideoCaptureFormatEnumCompletedCallback completedCallback,
@@ -147,7 +150,7 @@ mrsResult MRS_CALL mrsEnumVideoCaptureFormatsAsync(
   RTC_LOG(LS_INFO) << "Enumerating video capture formats for device '"
                    << device_id << "'";
   Error res = DeviceVideoTrackSource::GetVideoCaptureFormats(
-      device_id, {enumCallback, enumCallbackUserData},
+      device_id, profile_id, profile_kind, {enumCallback, enumCallbackUserData},
       {completedCallback, completedCallbackUserData});
   if (!res.ok()) {
     RTC_LOG(LS_ERROR) << "Failed to enumerate video capture formats: "

--- a/libs/mrwebrtc/src/interop/interop_api.cpp
+++ b/libs/mrwebrtc/src/interop/interop_api.cpp
@@ -107,6 +107,31 @@ mrsResult MRS_CALL mrsEnumVideoCaptureDevicesAsync(
   return Result::kSuccess;
 }
 
+mrsResult MRS_CALL mrsEnumVideoProfilesAsync(
+    const char* device_id,
+    mrsVideoProfileEnumCallback enumCallback,
+    void* enumCallbackUserData,
+    mrsVideoProfileEnumCompletedCallback completedCallback,
+    void* completedCallbackUserData) noexcept {
+  if (IsStringNullOrEmpty(device_id)) {
+    return Result::kInvalidParameter;
+  }
+  if (!enumCallback) {
+    return Result::kInvalidParameter;
+  }
+  RTC_LOG(LS_INFO) << "Enumerating video profiles for device '" << device_id
+                   << "'";
+  Error res = DeviceVideoTrackSource::GetVideoProfiles(
+      device_id, {enumCallback, enumCallbackUserData},
+      {completedCallback, completedCallbackUserData});
+  if (!res.ok()) {
+    RTC_LOG(LS_ERROR) << "Failed to enumerate video profiles for device '"
+                      << device_id << "': " << res.message();
+    return res.result();
+  }
+  return Result::kSuccess;
+}
+
 mrsResult MRS_CALL mrsEnumVideoCaptureFormatsAsync(
     const char* device_id,
     mrsVideoCaptureFormatEnumCallback enumCallback,

--- a/libs/mrwebrtc/src/media/device_video_track_source.h
+++ b/libs/mrwebrtc/src/media/device_video_track_source.h
@@ -28,10 +28,13 @@ class DeviceVideoTrackSource : public VideoTrackSource {
       Callback<mrsResult> end_callback) noexcept;
   static Error GetVideoProfiles(
       absl::string_view device_id,
+      mrsVideoProfileKind profile_kind,
       Callback<const mrsVideoProfileInfo*> enum_callback,
       Callback<mrsResult> end_callback) noexcept;
   static Error GetVideoCaptureFormats(
       absl::string_view device_id,
+      absl::string_view profile_id,
+      mrsVideoProfileKind profile_kind,
       Callback<const mrsVideoCaptureFormatInfo*> enum_callback,
       Callback<mrsResult> end_callback) noexcept;
 
@@ -48,7 +51,7 @@ class DeviceVideoTrackSource : public VideoTrackSource {
   /// object.
   jobject java_video_capturer_{nullptr};
 
-#else   // defined(MR_SHARING_ANDROID)
+#else  // defined(MR_SHARING_ANDROID)
 
   DeviceVideoTrackSource(
       RefPtr<GlobalFactory> global_factory,

--- a/libs/mrwebrtc/src/media/device_video_track_source.h
+++ b/libs/mrwebrtc/src/media/device_video_track_source.h
@@ -26,6 +26,10 @@ class DeviceVideoTrackSource : public VideoTrackSource {
   static Error GetVideoCaptureDevices(
       Callback<const mrsVideoCaptureDeviceInfo*> enum_callback,
       Callback<mrsResult> end_callback) noexcept;
+  static Error GetVideoProfiles(
+      absl::string_view device_id,
+      Callback<const mrsVideoProfileInfo*> enum_callback,
+      Callback<mrsResult> end_callback) noexcept;
   static Error GetVideoCaptureFormats(
       absl::string_view device_id,
       Callback<const mrsVideoCaptureFormatInfo*> enum_callback,


### PR DESCRIPTION
Add the ability to enumerate the video profiles of a video capture device, and
to retrieve the video capture formats for any profile. This fixes an issue
where only video capture formats for the default profile were returned, by
allowing the user to specifically enumerate profiles and their associated
capture formats.

Bug: #159
