### PR TITLE
Do not reset impl when closing PeerConnection

### DIFF
--- a/libs/unity/library/Tests/Runtime/MediaLineTests.cs
+++ b/libs/unity/library/Tests/Runtime/MediaLineTests.cs
@@ -120,8 +120,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Assert.IsNotNull(mediaLine.Transceiver);
             Assert.AreEqual(mediaLine.Transceiver.MediaKind, mediaLine.MediaKind);
 
-            // TODO Destroy just after StartConnection will crash (#463)
-            // UnityEngine.Object.Destroy(pc_go);
+            UnityEngine.Object.Destroy(pc_go);
         }
 
         [UnityTest(/*Description = "Add a media line to a peer connection before it is initialized"*/)]


### PR DESCRIPTION
This avoids crashing callbacks/observers if the pointer is reset while they are
running. Any callback (including the ones that might add objects) will complete
when peer_->Close() is called and its results will be cleaned up with all the
rest.

Note that this assumes that there are no multi-threaded calls to our API - but
this should be the case already.

Fixes #463.