### PR TITLE
[Unity] Fix wrong return type in format enum

### DIFF
--- a/libs/unity/library/Runtime/Scripts/PeerConnection.cs
+++ b/libs/unity/library/Runtime/Scripts/PeerConnection.cs
@@ -251,7 +251,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// Enumerate the video capture devices available as a WebRTC local video feed source.
         /// </summary>
         /// <returns>The list of local video capture devices available to WebRTC.</returns>
-        public static Task<List<VideoCaptureDevice>> GetVideoCaptureDevicesAsync()
+        public static Task<IReadOnlyList<VideoCaptureDevice>> GetVideoCaptureDevicesAsync()
         {
             return DeviceVideoTrackSource.GetCaptureDevicesAsync();
         }


### PR DESCRIPTION
The return type changed with 4b7e8854