### PR TITLE
Fix NuGet packages icon

### DIFF
--- a/tools/nuget/Desktop/Microsoft.MixedReality.WebRTC.nuspec
+++ b/tools/nuget/Desktop/Microsoft.MixedReality.WebRTC.nuspec
@@ -13,7 +13,7 @@ This package contains the C# and native C++ libraries (x86, x64) for Windows Des
         <license type="expression">MIT</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <repository type="git" url="https://github.com/microsoft/MixedReality-WebRTC.git" branch="master" commit="__SOURCE_COMMIT_ID__" />
-        <iconUrl>https://github.com/microsoft/MixedReality-WebRTC/blob/master/docs/mr-webrtc_icon.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/MixedReality-WebRTC/master/docs/mr-webrtc_icon.png</iconUrl>
         <tags>WebRTC video audio data streaming realtime communication dotnet .NET C#</tags>
         <summary>MixedReality-WebRTC is a collection of components to help mixed reality app developers integrate audio, video, and data real-time communication into their application and improve their collaborative experience.
 

--- a/tools/nuget/Desktop/mrwebrtc.nuspec
+++ b/tools/nuget/Desktop/mrwebrtc.nuspec
@@ -13,7 +13,7 @@ This package contains the native shared libraries (x86, x64) and C++ headers for
         <license type="expression">MIT</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <repository type="git" url="https://github.com/microsoft/MixedReality-WebRTC.git" branch="master" commit="__SOURCE_COMMIT_ID__" />
-        <iconUrl>https://github.com/microsoft/MixedReality-WebRTC/blob/master/docs/mr-webrtc_icon.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/MixedReality-WebRTC/master/docs/mr-webrtc_icon.png</iconUrl>
         <tags>native WebRTC video audio data streaming realtime communication C++ cpp</tags>
         <summary>MixedReality-WebRTC is a collection of components to help mixed reality app developers integrate audio, video, and data real-time communication into their application and improve their collaborative experience.
 

--- a/tools/nuget/UWP/Microsoft.MixedReality.WebRTC.UWP.nuspec
+++ b/tools/nuget/UWP/Microsoft.MixedReality.WebRTC.UWP.nuspec
@@ -13,7 +13,7 @@ This package contains the C# and native C++ libraries (x86, x64, ARM) for UWP (U
         <license type="expression">MIT</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <repository type="git" url="https://github.com/microsoft/MixedReality-WebRTC.git" branch="master" commit="__SOURCE_COMMIT_ID__" />
-        <iconUrl>https://github.com/microsoft/MixedReality-WebRTC/blob/master/docs/mr-webrtc_icon.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/MixedReality-WebRTC/master/docs/mr-webrtc_icon.png</iconUrl>
         <tags>WebRTC video audio data streaming realtime communication dotnet .NET C# UWP</tags>
         <summary>MixedReality-WebRTC is a collection of components to help mixed reality app developers integrate audio, video, and data real-time communication into their application and improve their collaborative experience.
 

--- a/tools/nuget/UWP/mrwebrtc_uwp.nuspec
+++ b/tools/nuget/UWP/mrwebrtc_uwp.nuspec
@@ -13,7 +13,7 @@ This package contains the native shared libraries (x86, x64, ARM) and C++ header
         <license type="expression">MIT</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <repository type="git" url="https://github.com/microsoft/MixedReality-WebRTC.git" branch="master" commit="__SOURCE_COMMIT_ID__" />
-        <iconUrl>https://github.com/microsoft/MixedReality-WebRTC/blob/master/docs/mr-webrtc_icon.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/microsoft/MixedReality-WebRTC/master/docs/mr-webrtc_icon.png</iconUrl>
         <tags>native WebRTC video audio data streaming realtime communication C++ cpp UWP</tags>
         <summary>MixedReality-WebRTC is a collection of components to help mixed reality app developers integrate audio, video, and data real-time communication into their application and improve their collaborative experience.
 


### PR DESCRIPTION
Fix the URL of the NuGet packages icon, which was pointing to the
generic GitHub page for the file (HMTL) instead of the raw file content
(PNG). This should make the icon appear on nuget.org and in the various
NuGet clients (e.g. Visual Studio NuGet package manager).