### PR TITLE
Switch to ADM2 on Windows Desktop

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -146,6 +146,10 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         public static unsafe extern uint LibraryReportLiveObjects();
 
         [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsLibraryUseAudioDeviceModule")]
+        public static unsafe extern uint LibraryUseAudioDeviceModule(AudioDeviceModule adm);
+
+        [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsGetShutdownOptions")]
         public static unsafe extern Library.ShutdownOptionsFlags LibraryGetShutdownOptions();
 

--- a/libs/Microsoft.MixedReality.WebRTC/Library.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Library.cs
@@ -7,6 +7,23 @@ using System;
 namespace Microsoft.MixedReality.WebRTC
 {
     /// <summary>
+    /// Audio device module for Windows Desktop platform.
+    /// </summary>
+    public enum AudioDeviceModule : byte
+    {
+        /// <summary>
+        /// Legacy audio device module (ADM1); not recommended unless there is an issue
+        /// with the new default one.
+        /// </summary>
+        LegacyModule = 1,
+
+        /// <summary>
+        /// New CoreAudio based audio device module (ADM2). This is the default.
+        /// </summary>
+        DefaultModule = 2
+    }
+
+    /// <summary>
     /// Container for library-wise global settings of MixedReality-WebRTC.
     /// </summary>
     public static class Library
@@ -21,6 +38,26 @@ namespace Microsoft.MixedReality.WebRTC
         public static uint ReportLiveObjects()
         {
             return Utils.LibraryReportLiveObjects();
+        }
+
+        /// <summary>
+        /// Select the audio device module to use on Windows Desktop.
+        /// </summary>
+        /// <param name="adm">The module to use.</param>
+        /// <remarks>
+        /// The ADM must be configured before any peer connection is created/initialized;
+        /// otherwise an <see cref="InvalidOperationException"/> is raised.
+        /// 
+        /// This has no effect on UWP or non-Windows platforms.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// The peer connection factory was already initialized, therefore the audio device
+        /// module cannot be changed anymore.
+        /// </exception>
+        public static void UseAudioDeviceModule(AudioDeviceModule adm)
+        {
+            uint res = Utils.LibraryUseAudioDeviceModule(adm);
+            Utils.ThrowOnErrorCode(res);
         }
 
         /// <summary>

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -24,6 +24,24 @@ enum class mrsOptBool : int8_t { kTrue = -1, kFalse = 0, kUnset = 0b01010101 };
 /// Report live objects to debug output, and return the number of live objects.
 MRS_API uint32_t MRS_CALL mrsReportLiveObjects() noexcept;
 
+/// Enable or disable the use of the new Audio Device Module (ADM2) on Windows
+/// Desktop.
+///
+/// This mainly enables working around some unsupported devices plugged in which
+/// make the legacy module (ADM1) fail its initialization even if said devices
+/// are not later used. Therefore ADM2 is used by default, and this function is
+/// mainly used to disable it and fall back to the legacy ADM1 if needed.
+/// https://github.com/microsoft/MixedReality-WebRTC/issues/124
+///
+/// This function needs to be called before the peer connection factory is
+/// initialized, and therefore before any other library call, as most calls will
+/// initialize the peer connection factory. This cannot be toggled ON and OFF
+/// after that, and will fail if called too late.
+///
+/// This has no effect on UWP and non-Windows platforms, and will always
+/// succeed if called appropriately.
+MRS_API mrsResult MRS_CALL mrsLibraryUseAudioDeviceModule2(bool use) noexcept;
+
 /// Global MixedReality-WebRTC library shutdown options.
 enum class mrsShutdownOptions : uint32_t {
   kNone = 0,

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -24,6 +24,17 @@ enum class mrsOptBool : int8_t { kTrue = -1, kFalse = 0, kUnset = 0b01010101 };
 /// Report live objects to debug output, and return the number of live objects.
 MRS_API uint32_t MRS_CALL mrsReportLiveObjects() noexcept;
 
+/// Audio device modules for Windows Desktop.
+enum class mrsAudioDeviceModule : uint8_t {
+  /// Legacy module for backward compatibility. This is not recommended, unless
+  /// there is an issue with ADM2.
+  kADM1 = 1,
+
+  /// New CoreAudio module. This is the default and recommended audio module on
+  /// Windows Desktop.
+  kADM2 = 2
+};
+
 /// Enable or disable the use of the new Audio Device Module (ADM2) on Windows
 /// Desktop.
 ///
@@ -40,7 +51,8 @@ MRS_API uint32_t MRS_CALL mrsReportLiveObjects() noexcept;
 ///
 /// This has no effect on UWP and non-Windows platforms, and will always
 /// succeed if called appropriately.
-MRS_API mrsResult MRS_CALL mrsLibraryUseAudioDeviceModule2(bool use) noexcept;
+MRS_API mrsResult MRS_CALL
+mrsLibraryUseAudioDeviceModule(mrsAudioDeviceModule adm) noexcept;
 
 /// Global MixedReality-WebRTC library shutdown options.
 enum class mrsShutdownOptions : uint32_t {

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -24,33 +24,38 @@ enum class mrsOptBool : int8_t { kTrue = -1, kFalse = 0, kUnset = 0b01010101 };
 /// Report live objects to debug output, and return the number of live objects.
 MRS_API uint32_t MRS_CALL mrsReportLiveObjects() noexcept;
 
-/// Audio device modules for Windows Desktop.
+/// Available audio device modules for Windows Desktop. The audio device module
+/// is the internal audio component responsible for audio capture and playback.
+/// Those options are only meaningful for Windows Desktop; other platforms use a
+/// predefined platform-dependent built-in module.
 enum class mrsAudioDeviceModule : uint8_t {
-  /// Legacy module for backward compatibility. This is not recommended, unless
-  /// there is an issue with ADM2.
-  kADM1 = 1,
+  /// Legacy audio device module (ADM1) for backward compatibility. This is not
+  /// recommended, unless there is an issue with the default new module (ADM2).
+  kLegacy = 1,
 
-  /// New CoreAudio module. This is the default and recommended audio module on
-  /// Windows Desktop.
-  kADM2 = 2
+  /// New CoreAudio-based audio device module (ADM2). This is the default and
+  /// recommended audio module on Windows Desktop.
+  kDefault = 2
 };
 
-/// Enable or disable the use of the new Audio Device Module (ADM2) on Windows
-/// Desktop.
+/// Select the audio device module to use on Windows Desktop.
 ///
-/// This mainly enables working around some unsupported devices plugged in which
-/// make the legacy module (ADM1) fail its initialization even if said devices
-/// are not later used. Therefore ADM2 is used by default, and this function is
-/// mainly used to disable it and fall back to the legacy ADM1 if needed.
+/// By default the new CoreAudio-based audio device module (ADM2) is used, which
+/// provides better handling of unsupported devices than its predecessor (ADM1).
 /// https://github.com/microsoft/MixedReality-WebRTC/issues/124
 ///
+/// This function allows overwritting the default selection to force another
+/// module, mostly as a safety net would ADM2 present some issue.
+///
+/// The audio device module is a global object used by all peer connections.
 /// This function needs to be called before the peer connection factory is
 /// initialized, and therefore before any other library call, as most calls will
-/// initialize the peer connection factory. This cannot be toggled ON and OFF
-/// after that, and will fail if called too late.
+/// initialize the peer connection factory internally. Therefore, the audio
+/// device module cannot be changed after the library is initialized, and this
+/// call will fail with |mrsResult::kInvalidOperation| if invoked too late.
 ///
 /// This has no effect on UWP and non-Windows platforms, and will always
-/// succeed if called appropriately.
+/// succeed if timely called before the library is initialized.
 MRS_API mrsResult MRS_CALL
 mrsLibraryUseAudioDeviceModule(mrsAudioDeviceModule adm) noexcept;
 

--- a/libs/mrwebrtc/src/interop/global_factory.cpp
+++ b/libs/mrwebrtc/src/interop/global_factory.cpp
@@ -25,7 +25,7 @@ namespace MixedReality {
 namespace WebRTC {
 
 mrsAudioDeviceModule GlobalFactory::s_audioDeviceModule =
-    mrsAudioDeviceModule::kADM2;
+    mrsAudioDeviceModule::kDefault;
 
 uint32_t GlobalFactory::StaticReportLiveObjects() noexcept {
   // Lock the instance to prevent shutdown if it already exists, while
@@ -278,7 +278,7 @@ mrsResult GlobalFactory::InitializeImplNoLock() {
   // Use a null value to use the default platform implementation
   rtc::scoped_refptr<webrtc::AudioDeviceModule> adm{nullptr};
 #if defined(MR_SHARING_WIN)
-  if (s_audioDeviceModule == mrsAudioDeviceModule::kADM2) {
+  if (s_audioDeviceModule == mrsAudioDeviceModule::kDefault) {
     // Default to use the CoreAudio 2 ADM, which supports more devices like
     // Azure Kinect DK. The ADM needs to be created on the worker thread where
     // it will be used, and requires COM to be initialized.
@@ -302,7 +302,7 @@ mrsResult GlobalFactory::InitializeImplNoLock() {
     RTC_LOG(LS_INFO) << "Using new CoreAudio ADM2 on Windows for audio capture "
                         "and playback.";
   } else {
-    RTC_DCHECK(s_audioDeviceModule == mrsAudioDeviceModule::kADM1);
+    RTC_DCHECK(s_audioDeviceModule == mrsAudioDeviceModule::kLegacy);
     RTC_LOG(LS_INFO)
         << "Using legacy ADM1 on Windows for audio capture and playback.";
   }

--- a/libs/mrwebrtc/src/interop/global_factory.cpp
+++ b/libs/mrwebrtc/src/interop/global_factory.cpp
@@ -24,7 +24,8 @@ namespace Microsoft {
 namespace MixedReality {
 namespace WebRTC {
 
-bool GlobalFactory::s_useAudioDeviceModule2 = true;
+mrsAudioDeviceModule GlobalFactory::s_audioDeviceModule =
+    mrsAudioDeviceModule::kADM2;
 
 uint32_t GlobalFactory::StaticReportLiveObjects() noexcept {
   // Lock the instance to prevent shutdown if it already exists, while
@@ -36,13 +37,14 @@ uint32_t GlobalFactory::StaticReportLiveObjects() noexcept {
   return 0;
 }
 
-mrsResult GlobalFactory::UseAudioDeviceModule2(bool use) noexcept {
+mrsResult GlobalFactory::UseAudioDeviceModule(
+    mrsAudioDeviceModule adm) noexcept {
   if (GetInstancePtrImpl(/* ensure_initialized = */ false)) {
     RTC_LOG(LS_ERROR)
         << "Cannot enable or disable ADM2 after the library is initialized.";
     return mrsResult::kInvalidOperation;
   }
-  s_useAudioDeviceModule2 = use;
+  s_audioDeviceModule = adm;
   return mrsResult::kSuccess;
 }
 
@@ -276,7 +278,7 @@ mrsResult GlobalFactory::InitializeImplNoLock() {
   // Use a null value to use the default platform implementation
   rtc::scoped_refptr<webrtc::AudioDeviceModule> adm{nullptr};
 #if defined(MR_SHARING_WIN)
-  if (s_useAudioDeviceModule2) {
+  if (s_audioDeviceModule == mrsAudioDeviceModule::kADM2) {
     // Default to use the CoreAudio 2 ADM, which supports more devices like
     // Azure Kinect DK. The ADM needs to be created on the worker thread where
     // it will be used, and requires COM to be initialized.
@@ -300,6 +302,7 @@ mrsResult GlobalFactory::InitializeImplNoLock() {
     RTC_LOG(LS_INFO) << "Using new CoreAudio ADM2 on Windows for audio capture "
                         "and playback.";
   } else {
+    RTC_DCHECK(s_audioDeviceModule == mrsAudioDeviceModule::kADM1);
     RTC_LOG(LS_INFO)
         << "Using legacy ADM1 on Windows for audio capture and playback.";
   }

--- a/libs/mrwebrtc/src/interop/global_factory.h
+++ b/libs/mrwebrtc/src/interop/global_factory.h
@@ -34,9 +34,9 @@ class GlobalFactory {
   /// returns 0. This is multithread-safe.
   static uint32_t StaticReportLiveObjects() noexcept;
 
-  /// Enable or disable the use of the new Audio Device Module (ADM2) on Windows
-  /// Desktop. See |mrsLibraryUseAudioDeviceModule2()| for details.
-  static mrsResult UseAudioDeviceModule2(bool use) noexcept;
+  /// Select the audio device module to use on Windows Desktop. See
+  /// |mrsLibraryUseAudioDeviceModule()| for details.
+  static mrsResult UseAudioDeviceModule(mrsAudioDeviceModule adm) noexcept;
 
   /// Get the library shutdown options. This function does not initialize the
   /// library, but will store the options for a future initializing. Conversely,
@@ -245,11 +245,10 @@ class GlobalFactory {
   rtc::scoped_refptr<ToggleAudioMixer> custom_audio_mixer_;
 
  private:
-  /// On Windows, use the new Audio Device Module (ADM2) instead of the legacy
-  /// one (ADM1), to work around issues with unsupported devices in the ADM1
-  /// initializing code. This defaults to |true|.
+  /// On Windows Desktop, configure the Audio Device Module (ADM) to use. This
+  /// defaults to |mrsAudioDeviceModule::kADM2|.
   /// https://bugs.chromium.org/p/webrtc/issues/detail?id=11081
-  static bool s_useAudioDeviceModule2;
+  static mrsAudioDeviceModule s_audioDeviceModule;
 };
 
 }  // namespace WebRTC

--- a/libs/mrwebrtc/src/interop/interop_api.cpp
+++ b/libs/mrwebrtc/src/interop/interop_api.cpp
@@ -65,8 +65,9 @@ uint32_t MRS_CALL mrsReportLiveObjects() noexcept {
   return GlobalFactory::StaticReportLiveObjects();
 }
 
-mrsResult MRS_CALL mrsLibraryUseAudioDeviceModule2(bool use) noexcept {
-  return GlobalFactory::UseAudioDeviceModule2(use);
+mrsResult MRS_CALL
+mrsLibraryUseAudioDeviceModule(mrsAudioDeviceModule adm) noexcept {
+  return GlobalFactory::UseAudioDeviceModule(adm);
 }
 
 mrsShutdownOptions MRS_CALL mrsGetShutdownOptions() noexcept {

--- a/libs/mrwebrtc/src/interop/interop_api.cpp
+++ b/libs/mrwebrtc/src/interop/interop_api.cpp
@@ -65,6 +65,10 @@ uint32_t MRS_CALL mrsReportLiveObjects() noexcept {
   return GlobalFactory::StaticReportLiveObjects();
 }
 
+mrsResult MRS_CALL mrsLibraryUseAudioDeviceModule2(bool use) noexcept {
+  return GlobalFactory::UseAudioDeviceModule2(use);
+}
+
 mrsShutdownOptions MRS_CALL mrsGetShutdownOptions() noexcept {
   return GlobalFactory::GetShutdownOptions();
 }

--- a/libs/mrwebrtc/src/pch.h
+++ b/libs/mrwebrtc/src/pch.h
@@ -63,14 +63,15 @@
 #include "media/engine/webrtcvideodecoderfactory.h"
 #include "media/engine/webrtcvideoencoderfactory.h"
 #include "modules/audio_device/include/audio_device.h"
+#include "modules/audio_device/include/audio_device_factory.h"
 #include "modules/audio_mixer/audio_mixer_impl.h"
 #include "modules/audio_processing/include/audio_processing.h"
 #include "modules/video_capture/video_capture_factory.h"
 #include "rtc_base/bind.h"
 #include "rtc_base/memory/aligned_malloc.h"
 #if defined(MR_SHARING_ANDROID)
-#include "sdk/android/native_api/jni/class_loader.h"
 #include "modules/utility/include/helpers_android.h"
+#include "sdk/android/native_api/jni/class_loader.h"
 #include "sdk/android/src/jni/androidvideotracksource.h"
 #include "sdk/android/src/jni/jni_helpers.h"
 #endif


### PR DESCRIPTION
Switch audio implementation on Windows Desktop to the new Core Audio
based audio device module (ADM2), which avoids a crash in ADM1 when one
device is not supported by that module (even if unused), like Azure
Kinect DK.

Add a new function |mrsLibraryUseAudioDeviceModule2()| to enable users
to switch back to ADM1 in case there would be issues with ADM2, as
support and maturity of ADM2 are unclear, and the module is not always
well tested, though is the recommended way from Google going forward.

Bug: #124