### PR TITLE
Update mrwebrtc CI to build without NuGet Core

### DIFF
--- a/libs/mrwebrtc/src/interop/logging_interop.cpp
+++ b/libs/mrwebrtc/src/interop/logging_interop.cpp
@@ -109,7 +109,8 @@ void MRS_CALL mrsLoggingRemoveSink(mrsLogSinkHandle handle) noexcept {
   }
 }
 
-void mrsLogMessage(mrsLogSeverity severity, const char* message) noexcept {
+void MRS_CALL mrsLogMessage(mrsLogSeverity severity,
+                            const char* message) noexcept {
   if ((severity >= mrsLogSeverity::kVerbose) &&
       (severity <= mrsLogSeverity::kError)) {
     const rtc::LoggingSeverity sev = (rtc::LoggingSeverity)severity;

--- a/tools/ci/ci-cpp.yaml
+++ b/tools/ci/ci-cpp.yaml
@@ -28,11 +28,6 @@ parameters:
   displayName: 'Build Agent Pool'
   type: string
   default: 'Hosted VS2017' # vs2017-win2016
-# Restore PDBs of libwebrtc from Core build
-- name: restoreCorePdbs
-  displayName: 'Restore core PDBs'
-  type: boolean
-  default: false
 # Run Component Governance detection and submit results.
 - name: runComponentDetection
   displayName: 'Run component detection'
@@ -46,7 +41,6 @@ jobs:
     buildPlatform: 'Win32'
     buildArch: 'x86'
     buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false
@@ -56,7 +50,6 @@ jobs:
     buildPlatform: 'Win32'
     buildArch: 'x86'
     buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false
@@ -66,7 +59,6 @@ jobs:
     buildPlatform: 'Win32'
     buildArch: 'x64'
     buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: true
@@ -76,7 +68,6 @@ jobs:
     buildPlatform: 'Win32'
     buildArch: 'x64'
     buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false
@@ -86,7 +77,6 @@ jobs:
     buildPlatform: 'UWP'
     buildArch: 'x86'
     buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false
@@ -96,7 +86,6 @@ jobs:
     buildPlatform: 'UWP'
     buildArch: 'x86'
     buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false
@@ -106,7 +95,6 @@ jobs:
     buildPlatform: 'UWP'
     buildArch: 'x64'
     buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: true
@@ -116,7 +104,6 @@ jobs:
     buildPlatform: 'UWP'
     buildArch: 'x64'
     buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: true
@@ -126,7 +113,6 @@ jobs:
     buildPlatform: 'UWP'
     buildArch: 'ARM'
     buildConfig: 'Debug'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false
@@ -136,7 +122,6 @@ jobs:
     buildPlatform: 'UWP'
     buildArch: 'ARM'
     buildConfig: 'Release'
-    restoreCorePdbs: ${{parameters.restoreCorePdbs}}
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false

--- a/tools/ci/ci-cpp.yaml
+++ b/tools/ci/ci-cpp.yaml
@@ -35,15 +35,15 @@ parameters:
   default: true
 
 jobs:
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'Win32'
-    buildArch: 'x86'
-    buildConfig: 'Debug'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: false
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'Win32'
+#     buildArch: 'x86'
+#     buildConfig: 'Debug'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: false
 # - template: templates/jobs-cpp.yaml
 #   parameters:
 #     buildAgent: ${{parameters.buildAgent}}
@@ -71,15 +71,15 @@ jobs:
 #     runComponentDetection: ${{parameters.runComponentDetection}}
 #     withTesting: true
 #     publishArtifacts: false
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'x86'
-#     buildConfig: 'Debug'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: false
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'x86'
+    buildConfig: 'Debug'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: false
 # - template: templates/jobs-cpp.yaml
 #   parameters:
 #     buildAgent: ${{parameters.buildAgent}}

--- a/tools/ci/ci-cpp.yaml
+++ b/tools/ci/ci-cpp.yaml
@@ -44,84 +44,84 @@ jobs:
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'Win32'
-    buildArch: 'x86'
-    buildConfig: 'Release'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: false
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'Win32'
-    buildArch: 'x64'
-    buildConfig: 'Debug'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: true
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'Win32'
-    buildArch: 'x64'
-    buildConfig: 'Release'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: false
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'x86'
-    buildConfig: 'Debug'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: false
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'x86'
-    buildConfig: 'Release'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: false
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'x64'
-    buildConfig: 'Debug'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: true
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'x64'
-    buildConfig: 'Release'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: true
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'ARM'
-    buildConfig: 'Debug'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: false
-- template: templates/jobs-cpp.yaml
-  parameters:
-    buildAgent: ${{parameters.buildAgent}}
-    buildPlatform: 'UWP'
-    buildArch: 'ARM'
-    buildConfig: 'Release'
-    runComponentDetection: ${{parameters.runComponentDetection}}
-    withTesting: true
-    publishArtifacts: false
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'Win32'
+#     buildArch: 'x86'
+#     buildConfig: 'Release'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: false
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'Win32'
+#     buildArch: 'x64'
+#     buildConfig: 'Debug'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: true
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'Win32'
+#     buildArch: 'x64'
+#     buildConfig: 'Release'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: false
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'x86'
+#     buildConfig: 'Debug'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: false
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'x86'
+#     buildConfig: 'Release'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: false
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'x64'
+#     buildConfig: 'Debug'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: true
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'x64'
+#     buildConfig: 'Release'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: true
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'ARM'
+#     buildConfig: 'Debug'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: false
+# - template: templates/jobs-cpp.yaml
+#   parameters:
+#     buildAgent: ${{parameters.buildAgent}}
+#     buildPlatform: 'UWP'
+#     buildArch: 'ARM'
+#     buildConfig: 'Release'
+#     runComponentDetection: ${{parameters.runComponentDetection}}
+#     withTesting: true
+#     publishArtifacts: false

--- a/tools/ci/ci-cpp.yaml
+++ b/tools/ci/ci-cpp.yaml
@@ -35,42 +35,42 @@ parameters:
   default: true
 
 jobs:
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'Win32'
-#     buildArch: 'x86'
-#     buildConfig: 'Debug'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: false
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'Win32'
-#     buildArch: 'x86'
-#     buildConfig: 'Release'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: false
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'Win32'
-#     buildArch: 'x64'
-#     buildConfig: 'Debug'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: true
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'Win32'
-#     buildArch: 'x64'
-#     buildConfig: 'Release'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: false
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'Win32'
+    buildArch: 'x86'
+    buildConfig: 'Debug'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: false
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'Win32'
+    buildArch: 'x86'
+    buildConfig: 'Release'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: false
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'Win32'
+    buildArch: 'x64'
+    buildConfig: 'Debug'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: true
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'Win32'
+    buildArch: 'x64'
+    buildConfig: 'Release'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: false
 - template: templates/jobs-cpp.yaml
   parameters:
     buildAgent: ${{parameters.buildAgent}}
@@ -80,48 +80,48 @@ jobs:
     runComponentDetection: ${{parameters.runComponentDetection}}
     withTesting: true
     publishArtifacts: false
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'x86'
-#     buildConfig: 'Release'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: false
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'x64'
-#     buildConfig: 'Debug'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: true
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'x64'
-#     buildConfig: 'Release'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: true
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'ARM'
-#     buildConfig: 'Debug'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: false
-# - template: templates/jobs-cpp.yaml
-#   parameters:
-#     buildAgent: ${{parameters.buildAgent}}
-#     buildPlatform: 'UWP'
-#     buildArch: 'ARM'
-#     buildConfig: 'Release'
-#     runComponentDetection: ${{parameters.runComponentDetection}}
-#     withTesting: true
-#     publishArtifacts: false
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'x86'
+    buildConfig: 'Release'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: false
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'x64'
+    buildConfig: 'Debug'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: true
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'x64'
+    buildConfig: 'Release'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: true
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'ARM'
+    buildConfig: 'Debug'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: false
+- template: templates/jobs-cpp.yaml
+  parameters:
+    buildAgent: ${{parameters.buildAgent}}
+    buildPlatform: 'UWP'
+    buildArch: 'ARM'
+    buildConfig: 'Release'
+    runComponentDetection: ${{parameters.runComponentDetection}}
+    withTesting: true
+    publishArtifacts: false

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -125,7 +125,7 @@ jobs:
     - task: MSBuild@1
       displayName: 'Build UWP wrappers'
       inputs:
-        solution: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Org.WebRtc.WrapperGlue.Universal.vcxproj'
+        solution: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Org.WebRtc.WrapperGlue.vcxproj'
         msbuildVersion: 15.0
         msbuildArchitecture: x64
         platform: '$(msbuildPlatform)'

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -117,7 +117,7 @@ jobs:
     inputs:
       scriptSource: 'filePath'
       scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
-      arguments: '-a build -p $(scriptPlatform) --cpus $(scriptArch) -c $(scriptConfig)'
+      arguments: '-a prepare build -t webrtc -p $(scriptPlatform) --cpus $(scriptArch) -c $(scriptConfig) --noColor --noWrapper --cpp17'
     timeoutInMinutes: 120
 
   # Clean-up unused files

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -111,6 +111,22 @@ jobs:
       versionSpec: '>=2.7.16 <2.8.0'
     timeoutInMinutes: 5
 
+  # Clean-up unused files
+  - script: |
+      del /F /S /Q "depot_tools/external_bin/gsutil"
+      del /F /S /Q "chromium/third_party/protobuf"
+      del /F /S /Q "chromium/third_party/pycoverage"
+      del /F /S /Q "chromium/tools/android"
+      del /F /S /Q "chromium/tools/code_coverage"
+    workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'
+    displayName: 'Clean-up unused files'
+
+  # Run component detection
+  - ${{ if eq(parameters.runComponentDetection, 'true') }}:
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'
+      timeoutInMinutes: 15
+
   # Build libwebrtc with the script from Google
   - task: PythonScript@0
     displayName: 'Build libwebrtc'
@@ -131,21 +147,6 @@ jobs:
         platform: '$(msbuildPlatform)'
         configuration: '${{parameters.buildConfig}}'
       timeoutInMinutes: 60
-
-  # Clean-up unused files
-  - script: |
-      del /F /S /Q "depot_tools/external_bin/gsutil"
-      del /F /S /Q "chromium/third_party/protobuf/java"
-      del /F /S /Q "chromium/tools/android"
-      del /F /S /Q "chromium/tools/code_coverage"
-    workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'
-    displayName: 'Clean-up unused files'
-
-  # Run component detection
-  - ${{ if eq(parameters.runComponentDetection, 'true') }}:
-    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-      displayName: 'Component Detection'
-      timeoutInMinutes: 15
 
   # Build mrwebrtc.dll
   - task: MSBuild@1

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -9,11 +9,6 @@ parameters:
   displayName: 'Build Agent Pool'
   type: string
   default: ''
-# Restore PDBs of libwebrtc from Core build
-- name: restoreCorePdbs
-  displayName: 'Restore core PDBs'
-  type: boolean
-  default: true
 # Run Component Governance detection and submit results
 - name: runComponentDetection
   displayName: 'Run component detection'
@@ -109,64 +104,6 @@ jobs:
       versionSpec: 5.2.0
     timeoutInMinutes: 5
 
-  # Compute the PDB package variables
-  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
-    - task: PowerShell@2
-      displayName: 'Compute libwebrtc PDB package variables'
-      inputs:
-        targetType: 'filePath'
-        filePath: '$(Build.SourcesDirectory)/tools/ci/computePdbPackageVars.ps1'
-      env:
-        # Read $(MRWebRTC_PdbPackageVersion) from pipeline variables
-        WRITE_VERSION: 'false'
-      timeoutInMinutes: 5
-
-  # Download the PDBs for libwebrtc
-  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
-    - task: UniversalPackages@0
-      displayName: 'Download libwebrtc PDBs'
-      inputs:
-        command: download
-        vstsFeed: $(MRWebRTC_PdbFeed)
-        vstsFeedPackage: $(MRWebRTC_PdbPackageName)
-        vstsPackageVersion: $(MRWebRTC_PdbPackageVersion)
-        downloadDirectory: '$(Build.SourcesDirectory)\_pdbs'
-      timeoutInMinutes: 10
-
-  # Move PDBs back into their original location for the linker to find them
-  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
-    - task: PowerShell@2
-      displayName: 'Move libwebrtc PDBs back in place'
-      inputs:
-        targetType: 'filePath'
-        filePath: '$(Build.SourcesDirectory)/tools/ci/copyPdbsForBuilding.ps1'
-        arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -SourcePath "$(Build.SourcesDirectory)/_pdbs" -OutputPath "bin/${{parameters.buildPlatform}}/${{parameters.buildArch}}/${{parameters.buildConfig}}"'
-      timeoutInMinutes: 10
-
-  # Generate custom packages.config to restore only the necessary packages for the current build triple.
-  # This helps both with decreasing restore time and with minimizing disk space to avoid the 10GB limit.
-  # This task sets $(PackagesConfigFile) to the filename of the generated 'packages.config' file.
-  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
-    - task: PowerShell@2
-      displayName: 'Generate packages.config for build triple'
-      inputs:
-        targetType: 'filePath'
-        filePath: '$(Build.SourcesDirectory)/tools/ci/generateCppPackagesConfig.ps1'
-        arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -BuildArch ${{parameters.buildArch}} -InputFile "$(Build.SourcesDirectory)/tools/build/mrwebrtc/${{parameters.buildPlatform}}/packages.config" -OutputFile "bin/${{parameters.buildPlatform}}/${{parameters.buildArch}}/${{parameters.buildConfig}}/packages.config"'
-      timeoutInMinutes: 5
-
-  # Restore the NuGet packages containing prebuilt libwebrtc (for mrwebrtc build)
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand@2
-    displayName: 'NuGet restore mrwebrtc'
-    inputs:
-      command: 'restore'
-      restoreSolution: '$(PackagesConfigFile)'
-      restoreDirectory: '$(Build.SourcesDirectory)/packages'
-      includeNuGetOrg: true
-      feedsToUse: 'config'
-      nugetConfigPath: '$(NuGetConfigPath)'
-    timeoutInMinutes: 30
-
   # Ensure that Python 2.7.16+ is the default; the Google scripts don't work with Python 3.x
   - task: UsePythonVersion@0
     displayName: 'Use Python 2.7.16+ x64 for Google GN'
@@ -174,14 +111,14 @@ jobs:
       versionSpec: '>=2.7.16 <2.8.0'
     timeoutInMinutes: 5
 
-  # Prepare the environment with the setup script from Google
+  # Build libwebrtc with the script from Google
   - task: PythonScript@0
-    displayName: 'Prepare WebRTC env'
+    displayName: 'Build libwebrtc'
     inputs:
       scriptSource: 'filePath'
       scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
-      arguments: '-a prepare -p $(scriptPlatform) --cpus $(scriptArch) -c $(scriptConfig)'
-    timeoutInMinutes: 10
+      arguments: '-a prepare,build -p $(scriptPlatform) --cpus $(scriptArch) -c $(scriptConfig)'
+    timeoutInMinutes: 120
 
   # Clean-up unused files
   - script: |
@@ -191,15 +128,6 @@ jobs:
       del /F /S /Q "chromium/tools/code_coverage"
     workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'
     displayName: 'Clean-up unused files'
-
-  # Generate custom .vcxproj to import only the necessary packages for the current build triple
-  - ${{ if eq(parameters.restoreCorePdbs, 'true') }}:
-    - task: PowerShell@2
-      displayName: 'Modify .vcxproj for build triple'
-      inputs:
-        targetType: filePath
-        filePath: tools/ci/modifyCppProject.ps1
-        arguments: '-BuildConfig ${{parameters.buildConfig}} -BuildPlatform ${{parameters.buildPlatform}} -BuildArch ${{parameters.buildArch}} -ProjectFile "tools/build/mrwebrtc/${{parameters.buildPlatform}}/mrwebrtc-${{parameters.buildPlatform}}.vcxproj"'
 
   # Run component detection
   - ${{ if eq(parameters.runComponentDetection, 'true') }}:

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -117,7 +117,7 @@ jobs:
     inputs:
       scriptSource: 'filePath'
       scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
-      arguments: '-a prepare,build -p $(scriptPlatform) --cpus $(scriptArch) -c $(scriptConfig)'
+      arguments: '-a build -p $(scriptPlatform) --cpus $(scriptArch) -c $(scriptConfig)'
     timeoutInMinutes: 120
 
   # Clean-up unused files

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -118,7 +118,19 @@ jobs:
       scriptSource: 'filePath'
       scriptPath: 'external/webrtc-uwp-sdk/scripts/run.py'
       arguments: '-a prepare build -t webrtc -p $(scriptPlatform) --cpus $(scriptArch) -c $(scriptConfig) --noColor --noWrapper --cpp17'
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
+
+  # Build Org.WebRtc.WrapperGlub.lib
+  - ${{ if eq(parameters.buildPlatform, 'UWP') }}:
+    - task: MSBuild@1
+      displayName: 'Build UWP wrappers'
+      inputs:
+        solution: 'external/webrtc-uwp-sdk/webrtc/windows/projects/msvc/Org.WebRtc.WrapperGlue.Universal/Org.WebRtc.WrapperGlue.Universal.vcxproj'
+        msbuildVersion: 15.0
+        msbuildArchitecture: x64
+        platform: '$(msbuildPlatform)'
+        configuration: '${{parameters.buildConfig}}'
+      timeoutInMinutes: 60
 
   # Clean-up unused files
   - script: |
@@ -137,7 +149,7 @@ jobs:
 
   # Build mrwebrtc.dll
   - task: MSBuild@1
-    displayName: 'Build mrwebrtc ($(buildTriple))'
+    displayName: 'Build mrwebrtc'
     inputs:
       solution: 'tools/build/mrwebrtc/${{parameters.buildPlatform}}/mrwebrtc-${{parameters.buildPlatform}}.vcxproj'
       msbuildVersion: 15.0

--- a/tools/ci/templates/jobs-cpp.yaml
+++ b/tools/ci/templates/jobs-cpp.yaml
@@ -114,7 +114,8 @@ jobs:
   # Clean-up unused files
   - script: |
       del /F /S /Q "depot_tools/external_bin/gsutil"
-      del /F /S /Q "chromium/third_party/protobuf"
+      del /F /S /Q "chromium/third_party/protobuf/java"
+      del /F /S /Q "chromium/third_party/protobuf/ruby"
       del /F /S /Q "chromium/third_party/pycoverage"
       del /F /S /Q "chromium/tools/android"
       del /F /S /Q "chromium/tools/code_coverage"


### PR DESCRIPTION
Update the CI pipeline to build mrwebrtc on Windows from sources, without the
use of the deprecated Core NuGet packages.

Also fix some minor issues with some method signature on x86 and some Component
Governance alert.
