### PR TITLE
Handle OnDisable while resource is initializing

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -150,6 +150,10 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         public static unsafe extern uint LibraryUseAudioDeviceModule(AudioDeviceModule adm);
 
         [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
+            EntryPoint = "mrsLibraryGetAudioDeviceModule")]
+        public static unsafe extern AudioDeviceModule LibraryGetAudioDeviceModule();
+
+        [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi,
             EntryPoint = "mrsGetShutdownOptions")]
         public static unsafe extern Library.ShutdownOptionsFlags LibraryGetShutdownOptions();
 

--- a/libs/Microsoft.MixedReality.WebRTC/Library.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Library.cs
@@ -41,23 +41,29 @@ namespace Microsoft.MixedReality.WebRTC
         }
 
         /// <summary>
-        /// Select the audio device module to use on Windows Desktop.
+        /// Audio device module to use on Windows Desktop.
         /// </summary>
-        /// <param name="adm">The module to use.</param>
         /// <remarks>
-        /// The ADM must be configured before any peer connection is created/initialized;
+        /// The ADM can only be changed before any peer connection is created/initialized;
         /// otherwise an <see cref="InvalidOperationException"/> is raised.
-        /// 
+        ///
         /// This has no effect on UWP or non-Windows platforms.
         /// </remarks>
         /// <exception cref="InvalidOperationException">
         /// The peer connection factory was already initialized, therefore the audio device
         /// module cannot be changed anymore.
         /// </exception>
-        public static void UseAudioDeviceModule(AudioDeviceModule adm)
+        public static AudioDeviceModule UsedAudioDeviceModule
         {
-            uint res = Utils.LibraryUseAudioDeviceModule(adm);
-            Utils.ThrowOnErrorCode(res);
+            get
+            {
+                return Utils.LibraryGetAudioDeviceModule();
+            }
+            set
+            {
+                uint res = Utils.LibraryUseAudioDeviceModule(value);
+                Utils.ThrowOnErrorCode(res);
+            }
         }
 
         /// <summary>

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -1220,7 +1220,14 @@ namespace Microsoft.MixedReality.WebRTC
             // Wait for any pending initializing to finish.
             // This must be outside of the lock because the initialization task will
             // eventually need to acquire the lock to complete.
-            initTask.Wait();
+            try
+            {
+                initTask.Wait();
+            }
+            catch (Exception)
+            {
+                // Discard; since we are closing, we don't care if initialization failed.
+            }
 
             // Close the native peer connection, disconnecting from the remote peer if currently connected.
             // This will invalidate all handles to transceivers and remote tracks, as the corresponding

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -44,7 +44,7 @@ enum class mrsAudioDeviceModule : uint8_t {
 /// provides better handling of unsupported devices than its predecessor (ADM1).
 /// https://github.com/microsoft/MixedReality-WebRTC/issues/124
 ///
-/// This function allows overwritting the default selection to force another
+/// This function allows overwriting the default selection to force another
 /// module, mostly as a safety net would ADM2 present some issue.
 ///
 /// The audio device module is a global object used by all peer connections.
@@ -58,6 +58,10 @@ enum class mrsAudioDeviceModule : uint8_t {
 /// succeed if timely called before the library is initialized.
 MRS_API mrsResult MRS_CALL
 mrsLibraryUseAudioDeviceModule(mrsAudioDeviceModule adm) noexcept;
+
+/// Get the audio device module to use on Windows Desktop.
+/// By default the new CoreAudio-based audio device module (ADM2) is used.
+MRS_API mrsAudioDeviceModule MRS_CALL mrsLibraryGetAudioDeviceModule() noexcept;
 
 /// Global MixedReality-WebRTC library shutdown options.
 enum class mrsShutdownOptions : uint32_t {

--- a/libs/mrwebrtc/src/interop/global_factory.cpp
+++ b/libs/mrwebrtc/src/interop/global_factory.cpp
@@ -48,6 +48,10 @@ mrsResult GlobalFactory::UseAudioDeviceModule(
   return mrsResult::kSuccess;
 }
 
+mrsAudioDeviceModule GlobalFactory::GetAudioDeviceModule() noexcept {
+  return s_audioDeviceModule;
+}
+
 mrsShutdownOptions GlobalFactory::GetShutdownOptions() noexcept {
   GlobalFactory* const factory = GetInstance();
   std::lock_guard<std::recursive_mutex> lock(factory->mutex_);

--- a/libs/mrwebrtc/src/interop/global_factory.h
+++ b/libs/mrwebrtc/src/interop/global_factory.h
@@ -37,6 +37,7 @@ class GlobalFactory {
   /// Select the audio device module to use on Windows Desktop. See
   /// |mrsLibraryUseAudioDeviceModule()| for details.
   static mrsResult UseAudioDeviceModule(mrsAudioDeviceModule adm) noexcept;
+  static mrsAudioDeviceModule GetAudioDeviceModule() noexcept;
 
   /// Get the library shutdown options. This function does not initialize the
   /// library, but will store the options for a future initializing. Conversely,

--- a/libs/mrwebrtc/src/interop/interop_api.cpp
+++ b/libs/mrwebrtc/src/interop/interop_api.cpp
@@ -70,6 +70,10 @@ mrsLibraryUseAudioDeviceModule(mrsAudioDeviceModule adm) noexcept {
   return GlobalFactory::UseAudioDeviceModule(adm);
 }
 
+mrsAudioDeviceModule MRS_CALL mrsLibraryGetAudioDeviceModule() noexcept {
+  return GlobalFactory::GetAudioDeviceModule();
+}
+
 mrsShutdownOptions MRS_CALL mrsGetShutdownOptions() noexcept {
   return GlobalFactory::GetShutdownOptions();
 }

--- a/libs/unity/library/Runtime/Scripts/AsyncInitHelper.cs
+++ b/libs/unity/library/Runtime/Scripts/AsyncInitHelper.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.MixedReality.WebRTC.Unity
+{
+    /// <summary>
+    /// Utility for resources in Unity components that need asynchronous initialization,
+    /// and don't match well the Unity synchronous enable/disable workflow.
+    /// </summary>
+    /// <remarks>
+    /// This keeps track of an initialization task, allows callers to poll for the
+    /// initialized object, and handles cancellation/cleanup if the initialization is
+    /// aborted before it has completed.
+    /// </remarks>
+    public class AsyncInitHelper<T> where T : class, IDisposable
+    {
+        private Task<T> _initTask;
+        private CancellationTokenSource _cts;
+
+        /// <summary>
+        /// Starts tracking an initialization task for a resource.
+        /// </summary>
+        /// <param name="cts">
+        /// This will be used to cancel the task if aborted before it has
+        /// finished. Will be disposed at the end of the task.
+        /// </param>
+        public void TrackInitTask(Task<T> initTask, CancellationTokenSource cts = null)
+        {
+            _initTask = initTask;
+            _cts = cts;
+        }
+
+        /// <summary>
+        /// Check if the initialization task has generated a result.
+        /// </summary>
+        /// <returns>
+        /// The result of the initialization task if there is one and it has just successfully completed;
+        /// <c>null</c> if there is no task or if it has thrown an exception.
+        /// </returns>
+        public T Result
+        {
+            get
+            {
+                T result = null;
+                if (_initTask != null && _initTask.IsCompleted)
+                {
+                    if (!_initTask.IsFaulted)
+                    {
+                        result = _initTask.Result;
+                    }
+                    _initTask = null;
+                    _cts?.Dispose();
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Cancel the initialization task and dispose its result when it completes.
+        /// </summary>
+        /// <remarks>
+        /// This waits synchronously for the end of the initialization task. Note that this may
+        /// cause deadlocks if the task requires the same thread to finish.
+        ///
+        /// Any exceptions from the initialization task are silently dropped; the task itself
+        /// must take care of reporting.
+        /// </remarks>
+        public void AbortInitTask()
+        {
+            if (_initTask != null)
+            {
+                try
+                {
+                    _cts?.Cancel();
+                    _initTask.Result?.Dispose();
+                }
+                catch(Exception)
+                {
+                    // Ignore; rely on _initTask itself to do the necessary reporting.
+                }
+            }
+            _cts?.Dispose();
+            _cts = null;
+            _initTask = null;
+        }
+    }
+}

--- a/libs/unity/library/Runtime/Scripts/AsyncInitHelper.cs
+++ b/libs/unity/library/Runtime/Scripts/AsyncInitHelper.cs
@@ -37,25 +37,35 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// <summary>
         /// Check if the initialization task has generated a result.
         /// </summary>
+        /// <remarks>
+        /// If the initialization fails with an exception, this rethrows the exception.
+        /// </remarks>
         /// <returns>
         /// The result of the initialization task if there is one and it has just successfully completed;
-        /// <c>null</c> if there is no task or if it has thrown an exception.
+        /// <c>null</c> if there is no task.
         /// </returns>
         public T Result
         {
             get
             {
-                T result = null;
                 if (_initTask != null && _initTask.IsCompleted)
                 {
-                    if (!_initTask.IsFaulted)
-                    {
-                        result = _initTask.Result;
-                    }
+                    var task = _initTask;
+
+                    // Reset the state.
                     _initTask = null;
                     _cts?.Dispose();
+
+                    if (task.IsFaulted)
+                    {
+                        throw task.Exception.InnerException;
+                    }
+                    else
+                    {
+                        return task.Result;
+                    }
                 }
-                return result;
+                return null;
             }
         }
 
@@ -63,8 +73,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         /// Cancel the initialization task and dispose its result when it completes.
         /// </summary>
         /// <remarks>
-        /// Any exceptions from the initialization task are silently dropped; the task itself
-        /// must take care of reporting.
+        /// Any exceptions from the initialization task are silently dropped.
         /// </remarks>
         /// <returns>
         /// A <see cref="Task"/> that will complete when the initialization task has ended

--- a/libs/unity/library/Runtime/Scripts/AsyncInitHelper.cs.meta
+++ b/libs/unity/library/Runtime/Scripts/AsyncInitHelper.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: f845cb707dda5c84594956f49655100f, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/libs/unity/library/Runtime/Scripts/AsyncInitHelper.cs.meta
+++ b/libs/unity/library/Runtime/Scripts/AsyncInitHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d32d9bb3d083a194abff0902a5ce56a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
@@ -11,7 +11,7 @@ using UnityEngine.Android;
 #endif
 
 #if UNITY_WSA && !UNITY_EDITOR
-using Windows.Media.Capture;
+using global::Windows.Media.Capture;
 #endif
 
 namespace Microsoft.MixedReality.WebRTC.Unity
@@ -46,11 +46,9 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
         protected async Task<WebRTC.AudioTrackSource> InitAsync()
         {
-
-
             // Continue the task outside the Unity app context, in order to avoid deadlock
             // if OnDisable waits on this task.
-            bool accessGranted = await RequestAccessAsync().ConfigureAwait(false);
+            bool accessGranted = await RequestAccessAsync().ConfigureAwait(continueOnCapturedContext: false);
             if (!accessGranted)
             {
                 return null;

--- a/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
@@ -121,7 +121,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
         protected void OnDisable()
         {
-            _initHelper.AbortInitTask();
+            /// Wait synchronously for the end of the initialization task, so that after the component
+            /// has been disabled the device is released and free to be used again.
+            /// Note that the initialization task needs not to be continued on the app thread, or it
+            /// will deadlock.
+            _initHelper.AbortInitTask().Wait();
             DisposeSource();
         }
 

--- a/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/MicrophoneSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.MixedReality.WebRTC.Unity.Editor;
 using UnityEngine;
@@ -32,8 +33,8 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         protected bool _autoGainControl = true;
 
 #if !UNITY_EDITOR && UNITY_ANDROID
-        protected TaskCompletionSource<bool> _androidPermissionRequestTcs;
-        protected float _androidRecordAudioRequestRetryUntilTime = 0f;
+        private TaskCompletionSource<bool> _androidPermissionRequestTcs;
+        private object _androidPermissionRequestLock = new object();
 #endif
 
         private AsyncInitHelper<WebRTC.AudioTrackSource> _initHelper = new AsyncInitHelper<WebRTC.AudioTrackSource>();
@@ -41,10 +42,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         protected void OnEnable()
         {
             Debug.Assert(Source == null);
-            _initHelper.TrackInitTask(InitAsync());
+            var cts = new CancellationTokenSource();
+            _initHelper.TrackInitTask(InitAsync(cts.Token), cts);
         }
 
-        protected async Task<WebRTC.AudioTrackSource> InitAsync()
+        private async Task<WebRTC.AudioTrackSource> InitAsync(CancellationToken token)
         {
             // Cache public properties on the Unity app thread.
             var deviceConfig = new LocalAudioDeviceInitConfig
@@ -54,7 +56,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
             // Continue the task outside the Unity app context, in order to avoid deadlock
             // if OnDisable waits on this task.
-            bool accessGranted = await RequestAccessAsync().ConfigureAwait(continueOnCapturedContext: false);
+            bool accessGranted = await RequestAccessAsync(token).ConfigureAwait(continueOnCapturedContext: false);
             if (!accessGranted)
             {
                 return null;
@@ -98,29 +100,17 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             }
 
             // If focus is restored after a pending request, check the permission again
-            if (_androidPermissionRequestTcs != null)
+            lock(_androidPermissionRequestLock)
             {
-                if (Permission.HasUserAuthorizedPermission(Permission.Microphone))
+                if (_androidPermissionRequestTcs != null)
                 {
-                    // If now authorized, start capture as if just enabled
-                    Debug.Log("User granted authorization to access microphone, starting MicrophoneSource now...");
-                    _androidPermissionRequestTcs.SetResult(true);
-                    _androidPermissionRequestTcs = null;
-                }
-                else if (Time.time > _androidRecordAudioRequestRetryUntilTime)
-                {
-                    // OnApplicationFocus(true) may be called for unrelated reason(s) so do not disable on first call,
-                    // but instead retry during a given period after the request was made, until we're reasonably
-                    // confident that the user dialog was actually answered (that is, that OnApplicationFocus(true) was
-                    // called because of that dialog, and not because of another reason).
-                    // This may lead to false positives (checking permission after the user denied it), but the user
-                    // dialog will not popup again, so this is all in the background and essentially harmless.
-                    // Here some reasonable time passed since we made the permission request, and we still get a denied
-                    // answer, so assume the user actually denied it and stop retrying.
-                    _androidPermissionRequestTcs.SetResult(false);
-                    _androidPermissionRequestTcs = null;
-                    _androidRecordAudioRequestRetryUntilTime = 0f;
-                    Debug.LogError("User denied RecordAudio (microphone) permission; cannot use MicrophoneSource.");
+                    if (Permission.HasUserAuthorizedPermission(Permission.Microphone))
+                    {
+                        // If now authorized, unblock the initialization task.
+                        Debug.Log("User granted authorization to access microphone, starting MicrophoneSource now...");
+                        _androidPermissionRequestTcs.SetResult(true);
+                        _androidPermissionRequestTcs = null;
+                    }
                 }
             }
         }
@@ -136,7 +126,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             DisposeSource();
         }
 
-        private Task<bool> RequestAccessAsync()
+        private Task<bool> RequestAccessAsync(CancellationToken token)
         {
 #if !UNITY_EDITOR && UNITY_ANDROID
             // Ensure Android binding is initialized before accessing the native implementation
@@ -145,19 +135,51 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             // Check for permission to access the camera
             if (!Permission.HasUserAuthorizedPermission(Permission.Microphone))
             {
-                Debug.Assert(_androidPermissionRequestTcs == null);
-
-                // Monitor the OnApplicationFocus(true) event during the next 5 minutes,
-                // and check for permission again each time (see below why).
-                _androidPermissionRequestTcs = new TaskCompletionSource<bool>();
-                _androidRecordAudioRequestRetryUntilTime = Time.time + 300;
-
                 // Display dialog requesting user permission. This will return immediately,
-                // and unfortunately there's no good way to tell when this completes. As a rule
-                // of thumb, application should lose focus, so check when focus resumes should
-                // be sufficient without having to poll every frame.
+                // and unfortunately there's no good way to tell when this completes.
                 Permission.RequestUserPermission(Permission.Microphone);
-                return _androidPermissionRequestTcs.Task;
+
+                // As a rule of thumb, application should lose focus, so check when focus resumes should
+                // be sufficient without having to poll every frame.
+                // Monitor the OnApplicationFocus(true) event during the next 5 minutes,
+                // and check for permission again each time
+                var tcs = new TaskCompletionSource<bool>();
+                lock(_androidPermissionRequestLock)
+                {
+                    Debug.Assert(_androidPermissionRequestTcs == null);
+                    _androidPermissionRequestTcs = tcs;
+                }
+                Task.Delay(TimeSpan.FromMinutes(5)).ContinueWith(_ =>
+                {
+                    lock (_androidPermissionRequestLock)
+                    {
+                        // Check if the component is still waiting on the same permission request.
+                        // If it has been disabled and then re-enabled, _androidPermissionRequestTcs will be different.
+                        if (_androidPermissionRequestTcs == tcs)
+                        {
+                            Debug.LogError("User denied RecordAudio (microphone) permission; cannot use MicrophoneSource.");
+                            _androidPermissionRequestTcs.SetResult(false);
+                            _androidPermissionRequestTcs = null;
+                        }
+                    }
+                });
+
+                // If the initialization is canceled, end the task and reset the TCS.
+                token.Register(() =>
+                {
+                    lock (_androidPermissionRequestLock)
+                    {
+                        // Check if the component is still waiting on the same permission request.
+                        // If the request has completed or timed out, _androidPermissionRequestTcs will be null.
+                        if (_androidPermissionRequestTcs != null)
+                        {
+                            Debug.Assert(_androidPermissionRequestTcs == tcs);
+                            _androidPermissionRequestTcs.SetCanceled();
+                            _androidPermissionRequestTcs = null;
+                        }
+                    }
+                });
+                return tcs.Task;
             }
 
             // Already has permission.

--- a/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using UnityEngine;
+
+#if UNITY_WSA && !UNITY_EDITOR
+using global::Windows.UI.Core;
+using global::Windows.Foundation;
+using global::Windows.Media.Core;
+using global::Windows.Media.Capture;
+using global::Windows.ApplicationModel.Core;
+
+namespace Microsoft.MixedReality.WebRTC.Unity
+{
+    internal static class UwpUtils
+    {
+        internal static async Task<bool> RequestAccessAsync(StreamingCaptureMode mode)
+        {
+            // Note that the UWP UI thread and the main Unity app thread are always different.
+            // https://docs.unity3d.com/Manual/windowsstore-appcallbacks.html
+            Debug.Assert(!UnityEngine.WSA.Application.RunningOnUIThread());
+            var permissionTcs = new TaskCompletionSource<bool>();
+            UnityEngine.WSA.Application.InvokeOnUIThread(() =>
+            {
+                // Request UWP access to audio capture. The OS may show some popup dialog to the
+                // user to request permission. This will succeed only if the user grants permission.
+                try
+                {
+                    // On UWP the app must have the "microphone" capability, and the user must allow microphone
+                    // access. So check that access before trying to initialize the WebRTC library, as this
+                    // may result in a popup window being displayed the first time, which needs to be accepted
+                    // before the microphone can be accessed by WebRTC.
+                    var mediaAccessRequester = new MediaCapture();
+                    var mediaSettings = new MediaCaptureInitializationSettings();
+                    mediaSettings.AudioDeviceId = "";
+                    mediaSettings.VideoDeviceId = "";
+                    mediaSettings.StreamingCaptureMode = mode;
+                    mediaSettings.PhotoCaptureSource = PhotoCaptureSource.VideoPreview;
+                    mediaSettings.SharingMode = MediaCaptureSharingMode.SharedReadOnly; // for MRC and lower res camera
+                    mediaAccessRequester.InitializeAsync(mediaSettings).AsTask().ContinueWith(task =>
+                    {
+                        if (task.Exception != null)
+                        {
+                            Debug.LogError($"Audio access failure: {task.Exception.InnerException.Message}.");
+                            permissionTcs.SetResult(false);
+                        }
+                        else
+                        {
+                            permissionTcs.SetResult(true);
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    // Log an error and prevent activation
+                    Debug.LogError($"Audio access failure: {ex.Message}.");
+                    permissionTcs.SetResult(false);
+                }
+            },
+            waitUntilDone: false);
+            return await permissionTcs.Task.ConfigureAwait(false);
+        }
+    }
+}
+#endif

--- a/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs
@@ -24,14 +24,10 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             var permissionTcs = new TaskCompletionSource<bool>();
             UnityEngine.WSA.Application.InvokeOnUIThread(() =>
             {
-                // Request UWP access to audio capture. The OS may show some popup dialog to the
+                // Request UWP access to audio or video capture. The OS may show some popup dialog to the
                 // user to request permission. This will succeed only if the user grants permission.
                 try
                 {
-                    // On UWP the app must have the "microphone" capability, and the user must allow microphone
-                    // access. So check that access before trying to initialize the WebRTC library, as this
-                    // may result in a popup window being displayed the first time, which needs to be accepted
-                    // before the microphone can be accessed by WebRTC.
                     var mediaAccessRequester = new MediaCapture();
                     var mediaSettings = new MediaCaptureInitializationSettings();
                     mediaSettings.AudioDeviceId = "";
@@ -43,7 +39,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                     {
                         if (task.Exception != null)
                         {
-                            Debug.LogError($"Audio access failure: {task.Exception.InnerException.Message}.");
+                            Debug.LogError($"Media access failure: {task.Exception.InnerException.Message}.");
                             permissionTcs.SetResult(false);
                         }
                         else
@@ -55,7 +51,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                 catch (Exception ex)
                 {
                     // Log an error and prevent activation
-                    Debug.LogError($"Audio access failure: {ex.Message}.");
+                    Debug.LogError($"Media access failure: {ex.Message}.");
                     permissionTcs.SetResult(false);
                 }
             },

--- a/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 {
     internal static class UwpUtils
     {
-        internal static async Task<bool> RequestAccessAsync(StreamingCaptureMode mode)
+        internal static Task<bool> RequestAccessAsync(StreamingCaptureMode mode)
         {
             // Note that the UWP UI thread and the main Unity app thread are always different.
             // https://docs.unity3d.com/Manual/windowsstore-appcallbacks.html
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                 }
             },
             waitUntilDone: false);
-            return await permissionTcs.Task.ConfigureAwait(false);
+            return permissionTcs.Task;
         }
     }
 }

--- a/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs.meta
+++ b/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: f845cb707dda5c84594956f49655100f, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs.meta
+++ b/libs/unity/library/Runtime/Scripts/Media/UwpUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45dccc74a2e70304bbe6f7be5eaa4c1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
@@ -156,7 +156,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
         {
             // Continue the task outside the Unity app context, in order to avoid deadlock
             // if OnDisable waits on this task.
-            bool accessGranted = await RequestAccessAsync().ConfigureAwait(false);
+            bool accessGranted = await RequestAccessAsync().ConfigureAwait(continueOnCapturedContext: false);
             if (!accessGranted)
             {
                 return null;

--- a/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
+++ b/libs/unity/library/Runtime/Scripts/Media/WebcamSource.cs
@@ -343,7 +343,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
         protected void OnDisable()
         {
-            _initHelper.AbortInitTask();
+            /// Wait synchronously for the end of the initialization task, so that after the component
+            /// has been disabled the device is released and free to be used again.
+            /// Note that the initialization task needs not to be continued on the app thread, or it
+            /// will deadlock.
+            _initHelper.AbortInitTask().Wait();
             DisposeSource();
         }
 

--- a/libs/unity/library/Runtime/Scripts/PeerConnection.cs
+++ b/libs/unity/library/Runtime/Scripts/PeerConnection.cs
@@ -688,9 +688,7 @@ namespace Microsoft.MixedReality.WebRTC.Unity
 
             try
             {
-                // Continue the task outside the Unity app context, in order to avoid deadlock
-                // if OnDisable waits on this task.
-                await nativePeer.InitializeAsync(config, token).ConfigureAwait(false);
+                await nativePeer.InitializeAsync(config, token);
                 return nativePeer;
             }
             catch (OperationCanceledException canceled) { throw canceled; }

--- a/libs/unity/library/Tests/Runtime/PeerConnectionTests.cs
+++ b/libs/unity/library/Tests/Runtime/PeerConnectionTests.cs
@@ -187,5 +187,25 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             UnityEngine.Object.Destroy(pc2_go);
             UnityEngine.Object.Destroy(sig_go);
         }
+
+        [UnityTest]
+        public IEnumerator DisableWhileInitializing()
+        {
+            // Create the component
+            var go = new GameObject("test_go");
+            go.SetActive(false); // prevent auto-activation of components
+            var pc = go.AddComponent<PeerConnection>();
+
+            for (int i = 0; i < 2; ++i)
+            {
+                go.SetActive(true);
+                go.SetActive(false);
+            }
+
+            UnityEngine.Object.Destroy(go);
+
+            // Terminate the coroutine.
+            yield return null;
+        }
     }
 }

--- a/libs/unity/library/Tests/Runtime/VideoSourceTests.cs
+++ b/libs/unity/library/Tests/Runtime/VideoSourceTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -1009,5 +1008,50 @@ namespace Microsoft.MixedReality.WebRTC.Unity.Tests.Runtime
             Object.Destroy(pc1_go);
             Object.Destroy(pc2_go);
         }
+
+        // These tests need a local device to work, and will fail on CI agents.
+        // Uncomment to run.
+
+        //[UnityTest]
+        //public IEnumerator DisableWhileInitializingWebcam()
+        //{
+        //    // Create the component
+        //    var go = new GameObject("test_go");
+        //    go.SetActive(false); // prevent auto-activation of components
+        //    var pc = go.AddComponent<WebcamSource>();
+
+        //    for (int i = 0; i < 2; ++i)
+        //    {
+        //        go.SetActive(true);
+        //        go.SetActive(false);
+        //    }
+
+        //    UnityEngine.Object.Destroy(go);
+
+        //    // Terminate the coroutine.
+        //    yield return null;
+        //}
+
+        //[UnityTest]
+        //public IEnumerator DisableWhileInitializingMicrophone()
+        //{
+        //    // Create the component
+        //    var go = new GameObject("test_go");
+        //    go.SetActive(false); // prevent auto-activation of components
+        //    var pc = go.AddComponent<MicrophoneSource>();
+
+        //    for (int i = 0; i < 2; ++i)
+        //    {
+        //        go.SetActive(true);
+        //        go.SetActive(false);
+        //    }
+
+        //    UnityEngine.Object.Destroy(go);
+
+        //    // Terminate the coroutine.
+        //    yield return null;
+        //}
     }
+
+
 }


### PR DESCRIPTION
If a component containing a WebRTC resource with async initialization is
disabled before the resource has finished initializing, now we block the
OnDisable call and properly dispose the resource.

Refactored permission requests on Android to use async methods, so they
integrate better with the rest of the code.

Fixes #464.