### PR TITLE
Expose H.264 encoder configuration 

### DIFF
--- a/examples/TestAppUwp/App.xaml
+++ b/examples/TestAppUwp/App.xaml
@@ -12,5 +12,8 @@
         <local:BooleanInverter x:Key="BooleanInverter"/>
         <local:VisibleIfNotEmptyConverter x:Key="VisibleIfNotEmptyConverter"/>
         <local:StringFormatConverter x:Key="StringFormatConverter"/>
+        <local:QualityValueConverter x:Key="QualityValueConverter"/>
+        <local:ProfileToIndexConverter x:Key="ProfileToIndexConverter"/>
+        <local:RcModeToIndexConverter x:Key="RcModeToIndexConverter"/>
     </Application.Resources>
 </Application>

--- a/examples/TestAppUwp/Model/SessionModel.cs
+++ b/examples/TestAppUwp/Model/SessionModel.cs
@@ -272,6 +272,8 @@ namespace TestAppUwp
             set { SetProperty(ref _preferredVideoCodecExtraParamsRemote, value); }
         }
 
+        public PeerConnection.H264Config H264Config = new PeerConnection.H264Config();
+
         /// <summary>
         /// Helper class to temporarily defer an automated negotiation until this object
         /// is disposed.
@@ -520,6 +522,8 @@ namespace TestAppUwp
             _peerConnection.PreferredVideoCodec = PreferredVideoCodec ?? "";
             _peerConnection.PreferredVideoCodecExtraParamsLocal = PreferredVideoCodecExtraParamsLocal ?? "";
             _peerConnection.PreferredVideoCodecExtraParamsRemote = PreferredVideoCodecExtraParamsRemote ?? "";
+
+            PeerConnection.SetH264Config(H264Config);
 
             // This cannot be inside the lock, otherwise the UI thread has the lock and block on the WebRTC
             // signaling thread, which itself might invoked a callback into the UI thread which might require

--- a/examples/TestAppUwp/SettingsPage.xaml
+++ b/examples/TestAppUwp/SettingsPage.xaml
@@ -102,6 +102,30 @@
                     <TextBox Margin="16,0,0,0" Width="250" PlaceholderText="extra_video_param_remote"
                              Text="{x:Bind SessionModel.PreferredVideoCodecExtraParamsRemote, Mode=TwoWay}"/>
                 </StackPanel>
+                <TextBlock Text="H.264 options" Style="{StaticResource TitleTextBlockStyle}" Margin="0,16,0,0"/>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">Profile:</TextBlock>
+                    <ComboBox Width="200" SelectedIndex="{x:Bind SessionModel.H264Config.Profile, Mode=TwoWay, Converter={StaticResource ProfileToIndexConverter}}">
+                        <ComboBoxItem>ConstrainedBaseline</ComboBoxItem>
+                        <ComboBoxItem>Baseline</ComboBoxItem>
+                        <ComboBoxItem>Main</ComboBoxItem>
+                        <ComboBoxItem>ConstrainedHigh</ComboBoxItem>
+                        <ComboBoxItem>High</ComboBoxItem>
+                    </ComboBox>
+                    <TextBlock VerticalAlignment="Center" Margin="16,0,16,0">RC mode:</TextBlock>
+                    <ComboBox Width="150" SelectedIndex="{x:Bind SessionModel.H264Config.RcMode, Mode=TwoWay, Converter={StaticResource RcModeToIndexConverter}}">
+                        <ComboBoxItem>Default</ComboBoxItem>
+                        <ComboBoxItem>CBR</ComboBoxItem>
+                        <ComboBoxItem>VBR</ComboBoxItem>
+                        <ComboBoxItem>Quality</ComboBoxItem>
+                    </ComboBox>
+                    <TextBlock VerticalAlignment="Center" Margin="16,0,0,0">Max QP:</TextBlock>
+                    <TextBox Margin="16,0,0,0"  PlaceholderText="-1"
+                             Text="{x:Bind SessionModel.H264Config.MaxQp, Mode=TwoWay, Converter={StaticResource QualityValueConverter}, ConverterParameter=51}"/>
+                    <TextBlock VerticalAlignment="Center" Margin="16,0,0,0">Quality:</TextBlock>
+                    <TextBox Margin="16,0,0,0" PlaceholderText="-1"
+                             Text="{x:Bind SessionModel.H264Config.Quality, Mode=TwoWay, Converter={StaticResource QualityValueConverter}, ConverterParameter=100}"/>
+                </StackPanel>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/examples/TestAppUwp/ViewModel/Converters.cs
+++ b/examples/TestAppUwp/ViewModel/Converters.cs
@@ -39,7 +39,7 @@ namespace TestAppUwp
     /// as the default implicit converter:
     /// - <c>true</c> <=> <c>Visibility.Collapsed</c>
     /// - <c>false</c> <=> <c>Visibility.Visible</c>
-    /// 
+    ///
     /// Useful for mapping a property <c>IsHidden</c> to the visibility of a control.
     /// </summary>
     public class BooleanToVisibilityInvertedConverter : IValueConverter
@@ -200,6 +200,70 @@ namespace TestAppUwp
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             throw new NotImplementedException("StringFormatConverter is a one-way converter by design.");
+        }
+    }
+
+    public class QualityValueConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            // Unset = -1.
+            if (value == null)
+            {
+                return "-1";
+            }
+
+            return value.ToString();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            var s = (string)value;
+            int parsed;
+            try
+            {
+                parsed = int.Parse(s);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            // parameter is the max value for this.
+            var max = int.Parse((string)parameter);
+            if (parsed < 0 || parsed > max)
+            {
+                return null;
+            }
+            return parsed;
+        }
+    }
+
+    public class ProfileToIndexConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return (int)value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            return (PeerConnection.H264Profile)value;
+        }
+    }
+
+    public class RcModeToIndexConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            // null = unset (0). Bump the other values by 1.
+            return value == null ? 0 : ((int)value + 1);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            // 0 = unset (null). Offset the other values by -1.
+            return ((int)value == 0) ? null : (PeerConnection.H264RcMode?)((int)value - 1);
         }
     }
 }

--- a/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
+++ b/examples/TestAppUwp/ViewModel/MediaPlayerViewModel.cs
@@ -193,7 +193,14 @@ namespace TestAppUwp
             // Detach old source
             if (_playbackVideoTrack?.Track != null)
             {
-                _playbackVideoTrack.Track.I420AVideoFrameReady -= VideoTrack_I420AFrameReady;
+                try
+                {
+                    _playbackVideoTrack.Track.I420AVideoFrameReady -= VideoTrack_I420AFrameReady;
+                }
+                catch (ObjectDisposedException)
+                {
+                    // This may happen if the track is remote and has already been disposed. Ignore.
+                }
                 _videoWidth = 0;
                 _videoHeight = 0;
                 _videoStatsTimer.Stop();

--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -291,5 +291,25 @@ namespace Microsoft.MixedReality.WebRTC.Interop
             }
             return string.Join(";", streamIDs.ToArray());
         }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct H264Config
+        {
+            internal int Profile;
+            internal int RcMode;
+            internal int MaxQp;
+            internal int Quality;
+
+            internal H264Config(PeerConnection.H264Config config)
+            {
+                Profile = (int)config.Profile;
+                RcMode = config.RcMode.HasValue ? (int)config.RcMode : -1;
+                MaxQp = config.MaxQp.GetValueOrDefault(-1);
+                Quality = config.Quality.GetValueOrDefault(-1);
+            }
+        };
+
+        [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, EntryPoint = "mrsSetH264Config")]
+        internal static unsafe extern void SetH264Config(H264Config value);
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -2006,6 +2006,105 @@ namespace Microsoft.MixedReality.WebRTC
             Utils.SetFrameHeightRoundMode(value);
         }
 
+        /// <summary>
+        /// H.264 Encoding profile.
+        /// </summary>
+        public enum H264Profile
+        {
+            /// <summary>
+            /// Constrained Baseline profile.
+            /// </summary>
+            ConstrainedBaseline,
+
+            /// <summary>
+            /// Baseline profile.
+            /// </summary>
+            Baseline,
+
+            /// <summary>
+            /// Main profile.
+            /// </summary>
+            Main,
+
+            /// <summary>
+            /// Constrained High profile.
+            /// </summary>
+            ConstrainedHigh,
+
+            /// <summary>
+            /// High profile.
+            /// </summary>
+            High
+        };
+
+        /// <summary>
+        /// Rate control mode for the Media Foundation H.264.
+        /// See https://docs.microsoft.com/en-us/windows/win32/medfound/h-264-video-encoder for details.
+        /// </summary>
+        public enum H264RcMode
+        {
+            /// <summary>
+            /// Constant Bit Rate.
+            /// </summary>
+            CBR,
+
+            /// <summary>
+            /// Variable Bit Rate.
+            /// </summary>
+            VBR,
+
+            /// <summary>
+            /// Constant quality.
+            /// </summary>
+            Quality
+        };
+
+        /// <summary>
+        /// Configuration for the Media Foundation H.264 encoder.
+        /// </summary>
+        public struct H264Config
+        {
+            /// <summary>
+            /// H.264 profile.
+            /// Note : by default we should use what's passed by WebRTC on codec
+            /// initialization (which seems to be always ConstrainedBaseline), but we use
+            /// Baseline to avoid changing behavior compared to earlier versions.
+            /// </summary>
+            public H264Profile Profile;
+
+            /// <summary>
+            /// Rate control mode.
+            /// </summary>
+            public H264RcMode? RcMode;
+
+            /// <summary>
+            /// If set to a value between 0 and 51, determines the max QP to use for
+            /// encoding.
+            /// </summary>
+            public int? MaxQp;
+
+            /// <summary>
+            /// If set to a value between 0 and 100, determines the target quality value.
+            /// The effect of this depends on the encoder and on the rate control mode
+            /// chosen. In the Quality RC mode this will be the target for the whole
+            /// stream, while in VBR it might be used as a target for individual frames
+            /// while the average quality of the stream is determined by the target
+            /// bitrate.
+            /// </summary>
+            public int? Quality;
+        };
+
+        /// <summary>
+        /// Set the configuration used by the H.264 encoder.
+        /// The passed value will apply to all tracks that start streaming, from any
+        /// PeerConnection created by the application, after the call to this function.
+        /// </summary>
+        /// <param name="config"></param>
+        public static void SetH264Config(H264Config config)
+        {
+            Utils.SetH264Config(new Utils.H264Config(config));
+        }
+
         internal void OnConnected()
         {
             MainEventSource.Log.Connected();

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -1114,4 +1114,56 @@ mrsStatsReportGetObjects(mrsStatsReportHandle report_handle,
 MRS_API mrsResult MRS_CALL
 mrsStatsReportRemoveRef(mrsStatsReportHandle stats_report);
 
+
+/// H.264 encoding profile.
+enum class mrsH264Profile : int32_t {
+  kProfileConstrainedBaseline,
+  kProfileBaseline,
+  kProfileMain,
+  kProfileConstrainedHigh,
+  kProfileHigh,
+};
+
+/// Rate control mode for the Media Foundation H.264 encoder. See
+/// https://docs.microsoft.com/en-us/windows/win32/medfound/h-264-video-encoder
+/// for details.
+enum class mrsH264RcMode : int32_t {
+  kUnset = -1,
+  kCBR = 0,
+  kVBR = 1,
+  kQuality = 2
+};
+
+/// Configuration for the Media Foundation H.264 encoder.
+struct mrsH264Config {
+
+  /// H.264 profile.
+  /// Note: by default we should use what's passed by WebRTC on codec
+  /// initialization (which seems to be always ConstrainedBaseline), but we use
+  /// Baseline to avoid changing behavior compared to earlier versions.
+  mrsH264Profile profile = mrsH264Profile::kProfileBaseline;
+
+  /// Rate control mode.
+  mrsH264RcMode rc_mode = mrsH264RcMode::kUnset;
+
+  /// If set to a value between 0 and 51, determines the max QP to use for
+  /// encoding.
+  int max_qp = -1;
+
+  /// If set to a value between 0 and 100, determines the target quality value.
+  /// The effect of this depends on the encoder and on the rate control mode
+  /// chosen. In the Quality RC mode this will be the target for the whole
+  /// stream, while in VBR it might be used as a target for individual frames
+  /// while the average quality of the stream is determined by the target
+  /// bitrate.
+  int quality = -1;
+};
+
+/// Set the configuration used by the H.264 encoder.
+///
+/// The passed value will apply to all tracks that start streaming, from any
+/// PeerConnection created by the application, after the call to this function.
+MRS_API void MRS_CALL mrsSetH264Config(const mrsH264Config* config);
+
+
 }  // extern "C"

--- a/libs/mrwebrtc/src/interop/interop_api.cpp
+++ b/libs/mrwebrtc/src/interop/interop_api.cpp
@@ -6,6 +6,7 @@
 #include "pch.h"
 
 #include "api/stats/rtcstats_objects.h"
+#include "third_party/winuwp_h264/H264Encoder/H264Encoder.h"
 
 #include "audio_track_source_interop.h"
 #include "data_channel.h"
@@ -736,4 +737,31 @@ mrsResult MRS_CALL mrsStatsReportRemoveRef(mrsStatsReportHandle stats_report) {
     return Result::kSuccess;
   }
   return Result::kInvalidNativeHandle;
+}
+
+void MRS_CALL mrsSetH264Config(const mrsH264Config* config) {
+#define CHECK_ENUM_VALUE(NAME)                                        \
+  static_assert((int)webrtc::H264::NAME == (int)mrsH264Profile::NAME, \
+                "webrtc::H264::Profile does not match mrsH264Profile")
+  CHECK_ENUM_VALUE(kProfileConstrainedBaseline);
+  CHECK_ENUM_VALUE(kProfileBaseline);
+  CHECK_ENUM_VALUE(kProfileMain);
+  CHECK_ENUM_VALUE(kProfileConstrainedHigh);
+  CHECK_ENUM_VALUE(kProfileHigh);
+#undef CHECK_ENUM_VALUE
+
+#define CHECK_ENUM_VALUE(NAME)                                        \
+  static_assert((int)mrsH264RcMode::k##NAME ==                               \
+                    (int)webrtc::WinUWPH264EncoderImpl::RcMode::k##NAME, \
+                "WinUWPH264EncoderImpl::RcMode does not match mrsH264RcMode")
+  CHECK_ENUM_VALUE(Unset);
+  CHECK_ENUM_VALUE(CBR);
+  CHECK_ENUM_VALUE(VBR);
+  CHECK_ENUM_VALUE(Quality);
+#undef CHECK_ENUM_VALUE
+
+  webrtc::WinUWPH264EncoderImpl::global_profile.store((webrtc::H264::Profile)config->profile);
+  webrtc::WinUWPH264EncoderImpl::global_rc_mode.store((webrtc::WinUWPH264EncoderImpl::RcMode)config->rc_mode);
+  webrtc::WinUWPH264EncoderImpl::global_max_qp.store(config->max_qp);
+  webrtc::WinUWPH264EncoderImpl::global_quality.store(config->quality);
 }


### PR DESCRIPTION
The configuration can be tweaked to get improved video quality. This is a
mitigation for #153.

Important: using a profile different from (Constrained) Baseline requires
specifying the correct `profile-level-id` parameter in the corresponding SDP
codec entry for other peers to correctly accept/reject the codec. This change
does not change SDP offer from the default (unspecified, equivalent to
Baseline). If using a higher profile, you must ensure that all peers support
encoding/decoding at that profile, or the behavior will be undefined.