### PR TITLE
Fix issues with Android build

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -310,6 +310,6 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         };
 
         [DllImport(dllPath, CallingConvention = CallingConvention.StdCall, EntryPoint = "mrsSetH264Config")]
-        internal static unsafe extern void SetH264Config(H264Config value);
+        internal static unsafe extern uint SetH264Config(H264Config value);
     }
 }

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -2102,7 +2102,8 @@ namespace Microsoft.MixedReality.WebRTC
         /// <param name="config"></param>
         public static void SetH264Config(H264Config config)
         {
-            Utils.SetH264Config(new Utils.H264Config(config));
+            uint res = Utils.SetH264Config(new Utils.H264Config(config));
+            Utils.ThrowOnErrorCode(res);
         }
 
         internal void OnConnected()

--- a/libs/mrwebrtc/include/interop_api.h
+++ b/libs/mrwebrtc/include/interop_api.h
@@ -1163,7 +1163,7 @@ struct mrsH264Config {
 ///
 /// The passed value will apply to all tracks that start streaming, from any
 /// PeerConnection created by the application, after the call to this function.
-MRS_API void MRS_CALL mrsSetH264Config(const mrsH264Config* config);
+MRS_API mrsResult MRS_CALL mrsSetH264Config(const mrsH264Config* config);
 
 
 }  // extern "C"

--- a/libs/mrwebrtc/src/interop/global_factory.cpp
+++ b/libs/mrwebrtc/src/interop/global_factory.cpp
@@ -373,7 +373,9 @@ bool GlobalFactory::ShutdownImplNoLock(ShutdownAction shutdown_action) {
   network_thread_.reset();
   worker_thread_.reset();
   signaling_thread_.reset();
+#if defined(MR_SHARING_WIN)
   worker_com_initializer_.reset();
+#endif  // defined(MR_SHARING_WIN)
 #endif  // defined(WINUWP)
   return true;
 }

--- a/libs/mrwebrtc/src/interop/global_factory.h
+++ b/libs/mrwebrtc/src/interop/global_factory.h
@@ -221,9 +221,10 @@ class GlobalFactory {
   /// require |mutex_| for access, but |init_mutex_| instead.
   std::unique_ptr<rtc::Thread> signaling_thread_ RTC_GUARDED_BY(init_mutex_);
 
+#if defined(MR_SHARING_WIN)
   /// COM initializer for worker thread (for ADM2).
   std::unique_ptr<webrtc::ScopedCOMInitializer> worker_com_initializer_;
-
+#endif  // defined(MR_SHARING_WIN)
 #endif  // defined(WINUWP)
 
   /// Reference count to the library, for automated shutdown.

--- a/libs/mrwebrtc/src/media/device_video_track_source.cpp
+++ b/libs/mrwebrtc/src/media/device_video_track_source.cpp
@@ -984,7 +984,7 @@ DeviceVideoTrackSource::~DeviceVideoTrackSource() {
     JNIEnv* env = webrtc::jni::GetEnv();
     RTC_DCHECK(env);
     webrtc::ScopedJavaLocalRef<jclass> pc_factory_class =
-        webrtc::GetClass(env, "org/webrtc/UnityUtility");
+        webrtc::GetClass(env, "com/microsoft/mixedreality/webrtc/AndroidCameraInterop");
     jmethodID stop_camera_method =
         webrtc::GetStaticMethodID(env, pc_factory_class.obj(), "StopCamera",
                                   "(Lorg/webrtc/VideoCapturer;)V");


### PR DESCRIPTION
UnityUtility has been changed into AndroidCameraInterop, so use that.