### PR TITLE
Fix component governance alerts in Unity build

### DIFF
--- a/tools/ci/release-unity.yaml
+++ b/tools/ci/release-unity.yaml
@@ -36,57 +36,57 @@ stages:
     parameters:
       buildConfig: 'Release'
 
-  # Build all Release variants of mrwebrtc.dll for Windows Desktop
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'Win32'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'x86'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'Win32'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'x64'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
+#   # Build all Release variants of mrwebrtc.dll for Windows Desktop
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'Win32'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'x86'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'Win32'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'x64'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
 
-  # Build all Release variants of mrwebrtc.dll for Windows UWP
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'UWP'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'x86'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'UWP'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'x64'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'UWP'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'ARM'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
+#   # Build all Release variants of mrwebrtc.dll for Windows UWP
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'UWP'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'x86'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'UWP'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'x64'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'UWP'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'ARM'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
 
-  # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
-  - template: templates/jobs-cslib-release-build.yaml
-    parameters:
-      buildAgent: '$(MRWebRTC.BuildAgent)'
+#   # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
+#   - template: templates/jobs-cslib-release-build.yaml
+#     parameters:
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
 
-# Package library and samples
-- stage: publish
-  dependsOn: build
-  displayName: 'Publish'
-  jobs:
-  - template: templates/jobs-unity-package.yaml
-    parameters:
-      buildAgent: '$(MRWebRTC.PackageAgent)'
-      upmPackageVersion: '${{parameters.upmPackageVersion}}'
-      withPdbs: '${{parameters.withPdbs}}'
+# # Package library and samples
+# - stage: publish
+#   dependsOn: build
+#   displayName: 'Publish'
+#   jobs:
+#   - template: templates/jobs-unity-package.yaml
+#     parameters:
+#       buildAgent: '$(MRWebRTC.PackageAgent)'
+#       upmPackageVersion: '${{parameters.upmPackageVersion}}'
+#       withPdbs: '${{parameters.withPdbs}}'

--- a/tools/ci/release-unity.yaml
+++ b/tools/ci/release-unity.yaml
@@ -36,57 +36,57 @@ stages:
     parameters:
       buildConfig: 'Release'
 
-#   # Build all Release variants of mrwebrtc.dll for Windows Desktop
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'Win32'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'x86'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'Win32'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'x64'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
+  # Build all Release variants of mrwebrtc.dll for Windows Desktop
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'Win32'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x86'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'Win32'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x64'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
 
-#   # Build all Release variants of mrwebrtc.dll for Windows UWP
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'UWP'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'x86'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'UWP'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'x64'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'UWP'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'ARM'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
+  # Build all Release variants of mrwebrtc.dll for Windows UWP
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x86'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x64'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'ARM'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
 
-#   # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
-#   - template: templates/jobs-cslib-release-build.yaml
-#     parameters:
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
+  # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
+  - template: templates/jobs-cslib-release-build.yaml
+    parameters:
+      buildAgent: '$(MRWebRTC.BuildAgent)'
 
-# # Package library and samples
-# - stage: publish
-#   dependsOn: build
-#   displayName: 'Publish'
-#   jobs:
-#   - template: templates/jobs-unity-package.yaml
-#     parameters:
-#       buildAgent: '$(MRWebRTC.PackageAgent)'
-#       upmPackageVersion: '${{parameters.upmPackageVersion}}'
-#       withPdbs: '${{parameters.withPdbs}}'
+# Package library and samples
+- stage: publish
+  dependsOn: build
+  displayName: 'Publish'
+  jobs:
+  - template: templates/jobs-unity-package.yaml
+    parameters:
+      buildAgent: '$(MRWebRTC.PackageAgent)'
+      upmPackageVersion: '${{parameters.upmPackageVersion}}'
+      withPdbs: '${{parameters.withPdbs}}'

--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -103,9 +103,31 @@ jobs:
       ./checkout.sh -v
     displayName: 'Checkout libwebrtc'
 
+  # Prepare libwebrtc build
+  - script: |
+      # Unset JAVA_HOME, which points to the install removed by the image clean step
+      unset JAVA_HOME
+      # Build
+      cd $(toolsDir)/libwebrtc
+      ./build.sh -v -c ${{parameters.buildConfig}} -p
+    displayName: 'Prepare libwebrtc'
+
+  # Clean-up unused files
+  - script: |
+      rm -rf "blink"
+      rm -rf "catapult"
+    workingDirectory: 'external/libwebrtc/webrtc/src'
+    displayName: 'Clean-up unused files'
+
   # List available disk space after clean-up
   - bash: df -h
     displayName: 'Available Disk Space'
+
+  # Run component detection
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    inputs:
+      sourceScanPath: '$(Build.SourcesDirectory)'
 
   # Build libwebrtc
   - script: |
@@ -113,7 +135,7 @@ jobs:
       unset JAVA_HOME
       # Build
       cd $(toolsDir)/libwebrtc
-      ./build.sh -v -c ${{parameters.buildConfig}}
+      ./build.sh -v -c ${{parameters.buildConfig}} -b
     displayName: 'Build libwebrtc'
 
   # Build mrwebrtc

--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -116,7 +116,7 @@ jobs:
   - script: |
       rm -rf "blink"
       rm -rf "catapult"
-    workingDirectory: 'external/libwebrtc/webrtc/src'
+    workingDirectory: 'external/libwebrtc/webrtc/src/third_party'
     displayName: 'Clean-up unused files'
 
   # List available disk space after clean-up

--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -114,9 +114,12 @@ jobs:
 
   # Clean-up unused files
   - script: |
-      rm -rf "blink"
-      rm -rf "catapult"
-    workingDirectory: 'external/libwebrtc/webrtc/src/third_party'
+      rm -rf third_party/blink
+      rm -rf third_party/catapult
+      rm -rf third_party/perfetto
+      rm -rf third_party/pycoverage
+      rm -rf tools/code_coverage
+    workingDirectory: 'external/libwebrtc/webrtc/src'
     displayName: 'Clean-up unused files'
 
   # List available disk space after clean-up

--- a/tools/ci/templates/jobs-mrwebrtc-release-build.yaml
+++ b/tools/ci/templates/jobs-mrwebrtc-release-build.yaml
@@ -135,6 +135,8 @@ jobs:
   - script: |
       del /F /S /Q "depot_tools/external_bin/gsutil"
       del /F /S /Q "chromium/third_party/protobuf/java"
+      del /F /S /Q "chromium/third_party/protobuf/ruby"
+      del /F /S /Q "chromium/third_party/pycoverage"
       del /F /S /Q "chromium/tools/android"
       del /F /S /Q "chromium/tools/code_coverage"
     workingDirectory: 'external/webrtc-uwp-sdk/webrtc/xplatform'


### PR DESCRIPTION
Delete unused files after checkout and before building, to avoid compliance alerts in unused code.