### PR TITLE
Fix invalid security alerts in CG report

### DIFF
--- a/tools/ci/release-unity.yaml
+++ b/tools/ci/release-unity.yaml
@@ -36,57 +36,57 @@ stages:
     parameters:
       buildConfig: 'Release'
 
-  # Build all Release variants of mrwebrtc.dll for Windows Desktop
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'Win32'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'x86'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'Win32'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'x64'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
+#   # Build all Release variants of mrwebrtc.dll for Windows Desktop
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'Win32'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'x86'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'Win32'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'x64'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
 
-  # Build all Release variants of mrwebrtc.dll for Windows UWP
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'UWP'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'x86'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'UWP'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'x64'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
-  - template: templates/jobs-mrwebrtc-release-build.yaml
-    parameters:
-      buildPlatform: 'UWP'
-      buildAgent: '$(MRWebRTC.BuildAgent)'
-      buildArch: 'ARM'
-      buildConfig: 'Release'
-      clean: '${{parameters.clean}}'
+#   # Build all Release variants of mrwebrtc.dll for Windows UWP
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'UWP'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'x86'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'UWP'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'x64'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
+#   - template: templates/jobs-mrwebrtc-release-build.yaml
+#     parameters:
+#       buildPlatform: 'UWP'
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
+#       buildArch: 'ARM'
+#       buildConfig: 'Release'
+#       clean: '${{parameters.clean}}'
 
-  # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
-  - template: templates/jobs-cslib-release-build.yaml
-    parameters:
-      buildAgent: '$(MRWebRTC.BuildAgent)'
+#   # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
+#   - template: templates/jobs-cslib-release-build.yaml
+#     parameters:
+#       buildAgent: '$(MRWebRTC.BuildAgent)'
 
-# Package library and samples
-- stage: publish
-  dependsOn: build
-  displayName: 'Publish'
-  jobs:
-  - template: templates/jobs-unity-package.yaml
-    parameters:
-      buildAgent: '$(MRWebRTC.PackageAgent)'
-      upmPackageVersion: '${{parameters.upmPackageVersion}}'
-      withPdbs: '${{parameters.withPdbs}}'
+# # Package library and samples
+# - stage: publish
+#   dependsOn: build
+#   displayName: 'Publish'
+#   jobs:
+#   - template: templates/jobs-unity-package.yaml
+#     parameters:
+#       buildAgent: '$(MRWebRTC.PackageAgent)'
+#       upmPackageVersion: '${{parameters.upmPackageVersion}}'
+#       withPdbs: '${{parameters.withPdbs}}'

--- a/tools/ci/release-unity.yaml
+++ b/tools/ci/release-unity.yaml
@@ -36,57 +36,57 @@ stages:
     parameters:
       buildConfig: 'Release'
 
-#   # Build all Release variants of mrwebrtc.dll for Windows Desktop
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'Win32'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'x86'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'Win32'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'x64'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
+  # Build all Release variants of mrwebrtc.dll for Windows Desktop
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'Win32'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x86'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'Win32'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x64'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
 
-#   # Build all Release variants of mrwebrtc.dll for Windows UWP
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'UWP'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'x86'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'UWP'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'x64'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
-#   - template: templates/jobs-mrwebrtc-release-build.yaml
-#     parameters:
-#       buildPlatform: 'UWP'
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
-#       buildArch: 'ARM'
-#       buildConfig: 'Release'
-#       clean: '${{parameters.clean}}'
+  # Build all Release variants of mrwebrtc.dll for Windows UWP
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x86'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'x64'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
+  - template: templates/jobs-mrwebrtc-release-build.yaml
+    parameters:
+      buildPlatform: 'UWP'
+      buildAgent: '$(MRWebRTC.BuildAgent)'
+      buildArch: 'ARM'
+      buildConfig: 'Release'
+      clean: '${{parameters.clean}}'
 
-#   # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
-#   - template: templates/jobs-cslib-release-build.yaml
-#     parameters:
-#       buildAgent: '$(MRWebRTC.BuildAgent)'
+  # Build the Release variant of Microsoft.MixedReality.WebRTC.dll for release.
+  - template: templates/jobs-cslib-release-build.yaml
+    parameters:
+      buildAgent: '$(MRWebRTC.BuildAgent)'
 
-# # Package library and samples
-# - stage: publish
-#   dependsOn: build
-#   displayName: 'Publish'
-#   jobs:
-#   - template: templates/jobs-unity-package.yaml
-#     parameters:
-#       buildAgent: '$(MRWebRTC.PackageAgent)'
-#       upmPackageVersion: '${{parameters.upmPackageVersion}}'
-#       withPdbs: '${{parameters.withPdbs}}'
+# Package library and samples
+- stage: publish
+  dependsOn: build
+  displayName: 'Publish'
+  jobs:
+  - template: templates/jobs-unity-package.yaml
+    parameters:
+      buildAgent: '$(MRWebRTC.PackageAgent)'
+      upmPackageVersion: '${{parameters.upmPackageVersion}}'
+      withPdbs: '${{parameters.withPdbs}}'

--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -116,7 +116,9 @@ jobs:
   - script: |
       rm -rf depot_tools/external_bin/gsutil
       rm -rf webrtc/src/examples/androidtests
+      mv webrtc/src/third_party/auto/BUILD.gn ./BUILD.gn.auto
       rm -rf webrtc/src/third_party/auto
+      mv ./BUILD.gn.auto webrtc/src/third_party/auto/BUILD.gn
       rm -rf webrtc/src/third_party/blink
       rm -rf webrtc/src/third_party/catapult
       rm -rf webrtc/src/third_party/perfetto

--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -118,6 +118,7 @@ jobs:
       rm -rf webrtc/src/examples/androidtests
       mv webrtc/src/third_party/auto/BUILD.gn ./BUILD.gn.auto
       rm -rf webrtc/src/third_party/auto
+      mkdir -p webrtc/src/third_party/auto
       mv ./BUILD.gn.auto webrtc/src/third_party/auto/BUILD.gn
       rm -rf webrtc/src/third_party/blink
       rm -rf webrtc/src/third_party/catapult

--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -114,12 +114,19 @@ jobs:
 
   # Clean-up unused files
   - script: |
-      rm -rf third_party/blink
-      rm -rf third_party/catapult
-      rm -rf third_party/perfetto
-      rm -rf third_party/pycoverage
-      rm -rf tools/code_coverage
-    workingDirectory: 'external/libwebrtc/webrtc/src'
+      rm -rf depot_tools/external_bin/gsutil
+      rm -rf webrtc/src/examples/androidtests
+      rm -rf webrtc/src/third_party/auto
+      rm -rf webrtc/src/third_party/blink
+      rm -rf webrtc/src/third_party/catapult
+      rm -rf webrtc/src/third_party/perfetto
+      rm -rf webrtc/src/third_party/protobuf/java
+      rm -rf webrtc/src/third_party/protobuf/ruby
+      rm -rf webrtc/src/third_party/pycoverage
+      rm -rf webrtc/src/third_party/WebKit
+      rm -rf webrtc/src/tools/code_coverage
+      rm -rf webrtc/src/tools/android/loading
+    workingDirectory: 'external/libwebrtc'
     displayName: 'Clean-up unused files'
 
   # List available disk space after clean-up

--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -116,10 +116,10 @@ jobs:
   - script: |
       rm -rf depot_tools/external_bin/gsutil
       rm -rf webrtc/src/examples/androidtests
-      mv webrtc/src/third_party/auto/BUILD.gn ./BUILD.gn.auto
-      rm -rf webrtc/src/third_party/auto
-      mkdir -p webrtc/src/third_party/auto
-      mv ./BUILD.gn.auto webrtc/src/third_party/auto/BUILD.gn
+      #mv webrtc/src/third_party/auto/BUILD.gn ./BUILD.gn.auto
+      #rm -rf webrtc/src/third_party/auto
+      #mkdir -p webrtc/src/third_party/auto
+      #mv ./BUILD.gn.auto webrtc/src/third_party/auto/BUILD.gn
       rm -rf webrtc/src/third_party/blink
       rm -rf webrtc/src/third_party/catapult
       rm -rf webrtc/src/third_party/perfetto


### PR DESCRIPTION
Delete unused code before scanning for vulnerabilities to avoid false positives.