### PR TITLE
Fix merge-archives.sh Android build under Windows WSL2

### DIFF
--- a/tools/build/android/webrtc-native/build.gradle
+++ b/tools/build/android/webrtc-native/build.gradle
@@ -78,8 +78,15 @@ dependencies {
 // Merge the libwebrtc.aar containing the Java interop classes for WebRTC
 // into the mrwebrtc.aar archive containing the native JNI library.
 task mergeLibwebrtcArchive(type: Exec) {
-   workingDir "$projectDir"
-   commandLine 'bash','./merge-archives.sh','-m',"$projectDir/build/outputs/aar/mrwebrtc.aar",'-o','./build/outputs/aar/merged/mrwebrtc.aar'
+    workingDir "$projectDir"   
+    println "Merge-archive.sh: Current working directory is $projectDir"
+
+    // For a Windows based path amount of backslashes is irrelevant, adding some more to escape
+    String WslRobustPath = "$projectDir".replaceAll("\\\\","\\\\\\\\")
+
+    commandLine 'bash','./merge-archives.sh','-m',
+                       "$WslRobustPath/build/outputs/aar/mrwebrtc.aar",'-o',
+                       './build/outputs/aar/merged/mrwebrtc.aar'
 }
 
 // Copy the final AAR archive to the Plugins folder of the Unity library.

--- a/tools/build/android/webrtc-native/merge-archives.sh
+++ b/tools/build/android/webrtc-native/merge-archives.sh
@@ -131,6 +131,20 @@ while getopts l:m:o:vh OPTION; do
     esac
 done
 
+# Update path for libwebrtc build under WSL2
+if grep -q microsoft /proc/version; then
+    echo "WSL-path-adaption: Detected WSL, adapting path now ..."
+    echo "Raw: ${MRWEBRTC_AAR}"
+    echo "Adapt to format: /mnt/\$driveletter\\windows_subdir\\..."
+    MRWEBRTC_AAR="$(sed -r 's/(^\w):/\/mnt\/\L\1/' <<< ${MRWEBRTC_AAR})"
+    echo "Intermediate path adaption result: ${MRWEBRTC_AAR}"
+    echo "Now adapt to format: /mnt/\$driveletter/windows_subdir/..."
+    MRWEBRTC_AAR="$(sed -r 's/\\/\//g' <<< ${MRWEBRTC_AAR})"
+    echo "Final path adaption result: ${MRWEBRTC_AAR}"
+else
+    echo "WSL-path-adaption: Detected native Linux, skipping path adaption!"
+fi
+
 # Ensure all arguments have reasonable values
 verify-arguments
 


### PR DESCRIPTION
This covers #571 and successfully builds for Android under Windows with `libwebrtc` being built under WSL2 while at the same time leaving native Linux builds unaffected.

This is achieved by updating `build.gradle` with a robust (escaped) `$projectDir` path and then conditional on WSL2 kernels applying some regular expression for transforming it into a `/mnt/c/...` path format that is WSL2 compliant.

@fibann annd @djee-ms If you have some preferences regarding the print outs or other comments, please let me know and I am happy to update them accordingly. It would also be great if we can double check that native Linux is actually unaffected since I haven't tested this yet. 