### PR TITLE
Add basic Android CI

### DIFF
--- a/tools/ci/ci-android.yaml
+++ b/tools/ci/ci-android.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# MixedReality-WebRTC build pipeline for Android CI
+
+# Trigger CI on push changes
+trigger:
+  branches:
+    include:
+    - master
+    - release/*
+    exclude:
+    - docs/*
+
+# Do not trigger CI on PRs
+pr: none
+
+# Give a unique name to the build each time it runs
+name: ci-android-$(SourceBranchName)-$(Date:yyyyMMdd)-$(Rev:r)
+
+parameters:
+- name: clean
+  displayName: 'Clean build'
+  type: boolean
+  default: true
+
+stages:
+
+# Compile mrwebrtc
+- stage: build
+  displayName: 'Build mrwebrtc'
+  jobs:
+
+  # Build mrwebrtc.aar for Android
+  - template: templates/jobs-libwebrtc-android.yaml
+    parameters:
+      buildConfig: 'Debug'

--- a/tools/ci/ci-android.yaml
+++ b/tools/ci/ci-android.yaml
@@ -5,6 +5,7 @@
 
 # Trigger CI on push changes
 trigger:
+  batch: true # Android build is very slow (>1 hour) so batch changes
   branches:
     include:
     - master

--- a/tools/ci/templates/jobs-libwebrtc-android.yaml
+++ b/tools/ci/templates/jobs-libwebrtc-android.yaml
@@ -169,7 +169,7 @@ jobs:
       contents: 'mrwebrtc.aar'
       targetFolder: '$(Build.ArtifactStagingDirectory)'
 
-  # Publish mrwebrtc.dll and mrwebrtc.pdb
+  # Publish mrwebrtc.aar
   - task: PublishPipelineArtifact@0
     displayName: 'Publish mrwebrtc'
     inputs:


### PR DESCRIPTION
Add some very basic Android CI building `mrwebrtc.aar` in Debug. This takes an awful amount of time (~1 hour) so batching changes (run at most 1 agent at once, with all commits since last run, instead of 1 run per commit). Hopefully this will catch at least some building regressions more quickly before they hit users.