### PR TITLE
Publish PDBs separately in release pipelines

### DIFF
--- a/tools/ci/release-unity.yaml
+++ b/tools/ci/release-unity.yaml
@@ -18,7 +18,7 @@ parameters:
 - name: withPdbs
   displayName: 'Include PDBs in UPM packages'
   type: boolean
-  default: true
+  default: false
 - name: clean
   displayName: 'Clean build'
   type: boolean

--- a/tools/ci/templates/jobs-mrwebrtc-release-pack.yaml
+++ b/tools/ci/templates/jobs-mrwebrtc-release-pack.yaml
@@ -278,7 +278,7 @@ jobs:
       artifact: 'nuget_mrwebrtc_${{parameters.packagePlatform}}'
 
   # Publish PDBs
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: 'Publish PDBs'
     inputs:
       path: '$(Build.ArtifactStagingDirectory)/pdbs/$(packageName).${{parameters.nugetPackageVersion}}'

--- a/tools/ci/templates/jobs-mrwebrtc-release-pack.yaml
+++ b/tools/ci/templates/jobs-mrwebrtc-release-pack.yaml
@@ -170,14 +170,14 @@ jobs:
   - task: CopyFiles@2
     inputs:
       sourceFolder: '$(Build.BinariesDirectory)/$(packageName).${{parameters.nugetPackageVersion}}'
-      content: '**/*.pdb'
+      content: '**\*.pdb'
       targetFolder: '$(Build.ArtifactStagingDirectory)/pdbs/$(packageName).${{parameters.nugetPackageVersion}}'
       overWrite: 'true'
       flattenFolders: 'false'
   - task: DeleteFiles@1
     inputs:
       SourceFolder: '$(Build.BinariesDirectory)/$(packageName).${{parameters.nugetPackageVersion}}'
-      content: '**/*.pdb'
+      content: '**\*.pdb'
       RemoveSourceFolder: 'false'
 
   # For debugging, list the package content before signing

--- a/tools/ci/templates/jobs-mrwebrtc-release-pack.yaml
+++ b/tools/ci/templates/jobs-mrwebrtc-release-pack.yaml
@@ -170,14 +170,14 @@ jobs:
   - task: CopyFiles@2
     inputs:
       sourceFolder: '$(Build.BinariesDirectory)/$(packageName).${{parameters.nugetPackageVersion}}'
-      content: '**\*.pdb'
+      contents: '**/*.pdb'
       targetFolder: '$(Build.ArtifactStagingDirectory)/pdbs/$(packageName).${{parameters.nugetPackageVersion}}'
       overWrite: 'true'
       flattenFolders: 'false'
   - task: DeleteFiles@1
     inputs:
       SourceFolder: '$(Build.BinariesDirectory)/$(packageName).${{parameters.nugetPackageVersion}}'
-      content: '**\*.pdb'
+      contents: '**/*.pdb'
       RemoveSourceFolder: 'false'
 
   # For debugging, list the package content before signing

--- a/tools/ci/templates/jobs-mrwebrtc-release-pack.yaml
+++ b/tools/ci/templates/jobs-mrwebrtc-release-pack.yaml
@@ -166,6 +166,20 @@ jobs:
      Copy-Item $srcFile $dstDir -Force
     displayName: 'Copy API headers'
 
+  # Move PDBs into their own hierarchy
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: '$(Build.BinariesDirectory)/$(packageName).${{parameters.nugetPackageVersion}}'
+      content: '**/*.pdb'
+      targetFolder: '$(Build.ArtifactStagingDirectory)/pdbs/$(packageName).${{parameters.nugetPackageVersion}}'
+      overWrite: 'true'
+      flattenFolders: 'false'
+  - task: DeleteFiles@1
+    inputs:
+      SourceFolder: '$(Build.BinariesDirectory)/$(packageName).${{parameters.nugetPackageVersion}}'
+      content: '**/*.pdb'
+      RemoveSourceFolder: 'false'
+
   # For debugging, list the package content before signing
   - powershell: |
      foreach ($f in $(Get-ChildItem -Path $(Build.BinariesDirectory) -Recurse)) {
@@ -258,7 +272,14 @@ jobs:
 
   # Publish the signed NuGet package for the Release pipeline
   - task: PublishPipelineArtifact@1
-    displayName: 'Publish'
+    displayName: 'Publish NuGet'
     inputs:
       path: '$(Build.ArtifactStagingDirectory)/signed/$(packageName).${{parameters.nugetPackageVersion}}'
       artifact: 'nuget_mrwebrtc_${{parameters.packagePlatform}}'
+
+  # Publish PDBs
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish PDBs'
+    inputs:
+      path: '$(Build.ArtifactStagingDirectory)/pdbs/$(packageName).${{parameters.nugetPackageVersion}}'
+      artifact: 'pdbs_mrwebrtc_${{parameters.packagePlatform}}'

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -103,7 +103,7 @@ jobs:
     - task: CopyFiles@2
       inputs:
         sourceFolder: '$(Build.SourcesDirectory)/libs/unity/library'
-        content: '**/*.pdb'
+        content: '**\*.pdb'
         targetFolder: '$(Build.ArtifactStagingDirectory)/pdbs/'
         overWrite: 'true'
         flattenFolders: 'false'
@@ -112,8 +112,8 @@ jobs:
       inputs:
         SourceFolder: '$(Build.SourcesDirectory)/libs/unity/library'
         content: |
-          '**/*.pdb'
-          '**/*.pdb.meta'
+          '**\*.pdb'
+          '**\*.pdb.meta'
         RemoveSourceFolder: 'false'
       displayName: 'Delete PDBs from NPM package'
 

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -100,20 +100,22 @@ jobs:
 
   # Delete PDBs if not needed
   - ${{ if eq(parameters.withPdbs, false) }}:
-    - pwsh: |
-        Write-Host "Removing PDBs from Unity package Plugins/ folder..."
-        Get-ChildItem -Recurse '$(Build.SourcesDirectory)/libs/unity/library/Runtime/Plugins/*.pdb' | ForEach-Object {
-          $file = $_
-          Write-Host $file
-          Remove-Item -Path $file -Force
-        }
-        Write-Host "Removing PDB .meta files from Unity package Plugins/ folder..."
-        Get-ChildItem -Recurse '$(Build.SourcesDirectory)/libs/unity/library/Runtime/Plugins/*.pdb.meta' | ForEach-Object {
-          $file = $_
-          Write-Host $file
-          Remove-Item -Path $file -Force
-        }
-      displayName: 'Delete PDBs'
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Build.SourcesDirectory)/libs/unity/library'
+        content: '**/*.pdb'
+        targetFolder: '$(Build.ArtifactStagingDirectory)/pdbs/'
+        overWrite: 'true'
+        flattenFolders: 'false'
+      displayName: 'Move PDBs into separate package'
+    - task: DeleteFiles@1
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/libs/unity/library'
+        content: |
+          '**/*.pdb'
+          '**/*.pdb.meta'
+        RemoveSourceFolder: 'false'
+      displayName: 'Delete PDBs from NPM package'
 
   # For debugging, list the packages content before signing
   - powershell: |
@@ -212,6 +214,13 @@ jobs:
     inputs:
       path: '$(Build.SourcesDirectory)/libs/unity/samples/$(PackedSamplesFilename)'
       artifact: 'upm_samples'
+
+  # Publish PDBs
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish PDBs'
+    inputs:
+      path: '$(Build.ArtifactStagingDirectory)/pdbs'
+      artifact: 'upm_pdbs'
 
   # The tasks below can replace the publish tasks above to publish directly to an NPM register
   # instead of as an Azure Pipeline Artifact. Unfortunately Azure DevOps currently does not

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -103,7 +103,7 @@ jobs:
     - task: CopyFiles@2
       inputs:
         sourceFolder: '$(Build.SourcesDirectory)/libs/unity/library'
-        content: '**\*.pdb'
+        contents: '**/*.pdb'
         targetFolder: '$(Build.ArtifactStagingDirectory)/pdbs/'
         overWrite: 'true'
         flattenFolders: 'false'
@@ -111,9 +111,9 @@ jobs:
     - task: DeleteFiles@1
       inputs:
         SourceFolder: '$(Build.SourcesDirectory)/libs/unity/library'
-        content: |
-          '**\*.pdb'
-          '**\*.pdb.meta'
+        contents: |
+          '**/*.pdb'
+          '**/*.pdb.meta'
         RemoveSourceFolder: 'false'
       displayName: 'Delete PDBs from NPM package'
 

--- a/tools/ci/templates/jobs-unity-package.yaml
+++ b/tools/ci/templates/jobs-unity-package.yaml
@@ -216,7 +216,7 @@ jobs:
       artifact: 'upm_samples'
 
   # Publish PDBs
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: 'Publish PDBs'
     inputs:
       path: '$(Build.ArtifactStagingDirectory)/pdbs'


### PR DESCRIPTION
Allow the release pipelines for Windows NuGet and Unity UPM to publish internally some artifact with all PDBs of the release build, with the intention of later being able to make them public if possible (TBD).