### PR TITLE
Handle audio resampling failure with error code

### DIFF
--- a/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/Interop/InteropUtils.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         // See https://github.com/dotnet/runtime/issues/7223
         internal const string dllPath = "mrwebrtc";
 
-        // Error codes returned by the interop API -- see mrs_errors.h
+        // Error codes returned by the interop API -- see result.h
         internal const uint MRS_SUCCESS = 0u;
         internal const uint MRS_E_UNKNOWN = 0x80000000u;
         internal const uint MRS_E_INVALID_PARAMETER = 0x80000001u;
@@ -113,6 +113,8 @@ namespace Microsoft.MixedReality.WebRTC.Interop
         internal const uint MRS_E_PEER_CONNECTION_CLOSED = 0x80000101u;
         internal const uint MRS_E_SCTP_NOT_NEGOTIATED = 0x80000301u;
         internal const uint MRS_E_INVALID_DATA_CHANNEL_ID = 0x80000302u;
+        internal const uint MRS_E_INVALID_MEDIA_KIND = 0x80000401u;
+        internal const uint MRS_E_AUDIO_RESAMPLING_NOT_SUPPORTED = 0x80000402u;
 
         public static IntPtr MakeWrapperRef(object wrapper)
         {
@@ -263,6 +265,12 @@ namespace Microsoft.MixedReality.WebRTC.Interop
 
             case MRS_E_INVALID_DATA_CHANNEL_ID:
                 return new ArgumentOutOfRangeException("Invalid ID passed to AddDataChannelAsync().");
+
+            case MRS_E_INVALID_MEDIA_KIND:
+                return new InvalidOperationException("Some audio-only function was called on a video-only object or vice-versa.");
+
+            case MRS_E_AUDIO_RESAMPLING_NOT_SUPPORTED:
+                return new NotSupportedException("Audio resampling for the given input/output frequencies is not supported. Try requesting a different output frequency.");
             }
         }
 

--- a/libs/mrwebrtc/include/result.h
+++ b/libs/mrwebrtc/include/result.h
@@ -89,6 +89,11 @@ enum class Result : std::uint32_t {
   /// Some audio-only function was called on a video-only object or vice-versa.
   /// For example, trying to get the local audio track of a video transceiver.
   kInvalidMediaKind = 0x80000401,
+
+  /// The internal audio resampler used in the audio track read buffer doesn't
+  /// support the specified input/output frequency ratio. Use a different output
+  /// frequency for the current audio source to solve the issue.
+  kAudioResamplingNotSupported = 0x80000402,
 };
 
 }  // namespace WebRTC

--- a/libs/mrwebrtc/src/interop/remote_audio_track_interop.cpp
+++ b/libs/mrwebrtc/src/interop/remote_audio_track_interop.cpp
@@ -118,10 +118,10 @@ mrsAudioTrackReadBufferRead(mrsAudioTrackReadBufferHandle buffer,
 
   auto stream = static_cast<AudioTrackReadBuffer*>(buffer);
   bool has_overrun;
-  stream->Read(sample_rate, num_channels, pad_behavior, samples_out,
+  Result res = stream->Read(sample_rate, num_channels, pad_behavior, samples_out,
                num_samples_max, num_samples_read_out, &has_overrun);
   *has_overrun_out = has_overrun ? mrsBool::kTrue : mrsBool::kFalse;
-  return Result::kSuccess;
+  return res;
 }
 
 void MRS_CALL

--- a/libs/mrwebrtc/src/media/audio_track_read_buffer.cpp
+++ b/libs/mrwebrtc/src/media/audio_track_read_buffer.cpp
@@ -60,9 +60,9 @@ AudioTrackReadBuffer::Buffer::Buffer() {
 }
 AudioTrackReadBuffer::Buffer::~Buffer() {}
 
-void AudioTrackReadBuffer::Buffer::addFrame(const Frame& frame,
-                                            int dst_sample_rate,
-                                            int dst_channels) {
+Result AudioTrackReadBuffer::Buffer::addFrame(const Frame& frame,
+                                              int dst_sample_rate,
+                                              int dst_channels) {
   assert(frame.number_of_channels == 1 || frame.number_of_channels == 2);
   assert(dst_channels == 1 || dst_channels == 2);
 
@@ -71,11 +71,11 @@ void AudioTrackReadBuffer::Buffer::addFrame(const Frame& frame,
   std::vector<short> buffer_front;
   std::vector<short> buffer_back;
 
-  const short* curr_data; //< Current version of the processed data.
-  size_t src_count;  //< Includes samples from *all* channels.
+  const short* curr_data;  //< Current version of the processed data.
+  size_t src_count;        //< Includes samples from *all* channels.
   int curr_channels = frame.number_of_channels;
 
-  // ensure source is 16 bit
+  // Ensure source is s16 (16-bit signed)
   if (frame.bits_per_sample == 16) {
     curr_data = (short*)frame.audio_data.data();
     src_count = frame.number_of_frames * frame.number_of_channels;
@@ -83,17 +83,21 @@ void AudioTrackReadBuffer::Buffer::addFrame(const Frame& frame,
     buffer_front.resize(frame.audio_data.size());
     short* data = buffer_front.data();
     // 8 bit data is unsigned8, 16 bit is signed16
-    for (int i = 0; i < (int)frame.audio_data.size(); ++i) {
-      data[i] = ((int)frame.audio_data[i] * 256) - 32768;
+    for (size_t i = 0; i < frame.audio_data.size(); ++i) {
+      //   0 * 257 - 32768 == -32768
+      // 255 * 257 - 32768 ==  32767
+      data[i] = ((int)frame.audio_data[i] * 257) - 32768;
     }
     curr_data = data;
     src_count = buffer_front.size();
     swap(buffer_front, buffer_back);
   } else {
-    FATAL();
-    return;
+    RTC_LOG(LS_ERROR) << "Unsupported audio bit size (not 8-bit nor 16-bit). "
+                         "Dropping audio frame.";
+    return Result::kInvalidParameter;
   }
 
+  // Stereo -> Mono
   if (frame.number_of_channels == 2 && dst_channels == 1) {
     // average L&R
     buffer_front.resize(src_count / 2);
@@ -108,14 +112,32 @@ void AudioTrackReadBuffer::Buffer::addFrame(const Frame& frame,
     swap(buffer_front, buffer_back);
   }
 
+  // Resample
   if ((int)frame.sample_rate != dst_sample_rate) {
-    // match sample rate
     buffer_front.resize((src_count * dst_sample_rate / frame.sample_rate) + 1);
     short* data = buffer_front.data();
-    resampler_->ResetIfNeeded(frame.sample_rate, dst_sample_rate, curr_channels);
+    int res = resampler_->ResetIfNeeded(frame.sample_rate, dst_sample_rate,
+                                        curr_channels);
+    if (res != 0) {
+      RTC_LOG(LS_ERROR)
+          << "Resampler does not implement conversion of sample rate "
+          << frame.sample_rate << " -> " << dst_sample_rate
+          << ". Dropping audio frame.";
+      data_.clear();
+      used_ = 0;
+      return Result::kAudioResamplingNotSupported;
+    }
     size_t count;
-    int res = resampler_->Push(curr_data, src_count, data, buffer_front.size(), count);
-    RTC_DCHECK(res == 0);
+    res = resampler_->Push(curr_data, src_count, data, buffer_front.size(),
+                           count);
+    if (res != 0) {
+      RTC_LOG(LS_ERROR) << "Resampler failed to adjust for sample rate ("
+                        << frame.sample_rate << " -> " << dst_sample_rate
+                        << "). Dropping audio frame.";
+      data_.clear();
+      used_ = 0;
+      return Result::kUnknownError;
+    }
 
     curr_data = data;
     src_count = count;
@@ -126,7 +148,7 @@ void AudioTrackReadBuffer::Buffer::addFrame(const Frame& frame,
   if (curr_channels == 1 && dst_channels == 2) {
     // duplicate
     data_.resize(src_count * 2);
-    for (int i = 0; i < (int)src_count; ++i) {
+    for (size_t i = 0; i < src_count; ++i) {
       float val = (float)curr_data[i] / 32768.0f;
       data_[2 * i + 0] = val;
       data_[2 * i + 1] = val;
@@ -140,15 +162,17 @@ void AudioTrackReadBuffer::Buffer::addFrame(const Frame& frame,
   used_ = 0;
   channels_ = dst_channels;
   rate_ = dst_sample_rate;
+  return Result::kSuccess;
 }
 
-void AudioTrackReadBuffer::Read(int sample_rate,
-                                int num_channels,
-                                mrsAudioTrackReadBufferPadBehavior pad_behavior,
-                                float* samples_out,
-                                int num_samples_max,
-                                int* num_samples_read_out,
-                                bool* has_overrun_out) noexcept {
+Result AudioTrackReadBuffer::Read(
+    int sample_rate,
+    int num_channels,
+    mrsAudioTrackReadBufferPadBehavior pad_behavior,
+    float* samples_out,
+    int num_samples_max,
+    int* num_samples_read_out,
+    bool* has_overrun_out) noexcept {
   float* dst = samples_out;
   int dst_len = num_samples_max;  // number of points remaining
 
@@ -183,9 +207,14 @@ void AudioTrackReadBuffer::Read(int sample_rate,
       }
 
       if (frame) {
-        buffer_.addFrame(*frame, sample_rate, num_channels);
+        Result res = buffer_.addFrame(*frame, sample_rate, num_channels);
+        if (res != Result::kSuccess) {
+          *num_samples_read_out = num_samples_max - dst_len;
+          return res;
+        }
       } else {
-        // no more input! fill with sin wave
+        // No more input.
+        // Pad output buffer if requested by caller.
         constexpr float freq = 2 * 222 * float(M_PI);
         switch (pad_behavior) {
           case mrsAudioTrackReadBufferPadBehavior::kDoNotPad:
@@ -205,13 +234,13 @@ void AudioTrackReadBuffer::Read(int sample_rate,
             RTC_NOTREACHED();
             break;
         }
-
         *num_samples_read_out = num_samples_max - dst_len;
-        return;  // and return
+        return Result::kSuccess;  // and return
       }
     }
   }
   *num_samples_read_out = num_samples_max;
+  return Result::kSuccess;
 }
 
 }  // namespace WebRTC

--- a/libs/mrwebrtc/src/media/audio_track_read_buffer.h
+++ b/libs/mrwebrtc/src/media/audio_track_read_buffer.h
@@ -8,6 +8,7 @@
 
 #include "export.h"
 #include "refptr.h"
+#include "result.h"
 #include "tracked_object.h"
 
 enum class mrsAudioTrackReadBufferPadBehavior;
@@ -20,7 +21,8 @@ struct AudioFrame;
 class PeerConnection;
 
 /// Implementation of |mrsAudioTrackReadBufferHandle|.
-class AudioTrackReadBuffer : public TrackedObject, webrtc::AudioTrackSinkInterface {
+class AudioTrackReadBuffer : public TrackedObject,
+                             webrtc::AudioTrackSinkInterface {
  public:
   /// Create a new stream which buffers |bufferMs| milliseconds of audio.
   /// WebRTC delivers audio at 10ms intervals so pass a multiple of 10.
@@ -32,13 +34,13 @@ class AudioTrackReadBuffer : public TrackedObject, webrtc::AudioTrackSinkInterfa
   ~AudioTrackReadBuffer();
 
   /// See |mrsAudioTrackReadBufferRead|.
-  void Read(int sample_rate,
-            int num_channels,
-            mrsAudioTrackReadBufferPadBehavior pad_behavior,
-            float* samples_out,
-            int num_samples_max,
-            int* num_samples_read_out,
-            bool* has_overrun_out) noexcept;
+  Result Read(int sample_rate,
+              int num_channels,
+              mrsAudioTrackReadBufferPadBehavior pad_behavior,
+              float* samples_out,
+              int num_samples_max,
+              int* num_samples_read_out,
+              bool* has_overrun_out) noexcept;
 
   /// AudioTrackSinkInterface implementation.
   virtual void OnData(const void* audio_data,
@@ -46,7 +48,6 @@ class AudioTrackReadBuffer : public TrackedObject, webrtc::AudioTrackSinkInterfa
                       int sample_rate,
                       size_t number_of_channels,
                       size_t number_of_frames);
-
 
  private:
   const rtc::scoped_refptr<webrtc::AudioTrackInterface> track_;
@@ -86,7 +87,7 @@ class AudioTrackReadBuffer : public TrackedObject, webrtc::AudioTrackSinkInterfa
       return take;
     }
     // Extract/resample data from frame and add it to our buffer.
-    void addFrame(const Frame& frame, int dstSampleRate, int dstChannels);
+    Result addFrame(const Frame& frame, int dstSampleRate, int dstChannels);
   };
   // Only accessed from callers of Read - no locking needed.
   Buffer buffer_;

--- a/libs/mrwebrtc/test/audio_track_read_buffer_tests.cpp
+++ b/libs/mrwebrtc/test/audio_track_read_buffer_tests.cpp
@@ -1,0 +1,244 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "audio_frame.h"
+#include "device_audio_track_source_interop.h"
+#include "interop_api.h"
+#include "local_audio_track_interop.h"
+#include "remote_audio_track_interop.h"
+#include "transceiver_interop.h"
+
+#include "test_utils.h"
+
+namespace {
+
+class AudioTrackReadBufferTests
+    : public TestUtils::TestBase,
+      public testing::WithParamInterface<mrsSdpSemantic> {};
+
+}  // namespace
+
+#if !defined(MRSW_EXCLUDE_DEVICE_TESTS)
+
+namespace {
+
+// PeerConnectionAudioTrackAddedCallback
+using AudioTrackAddedCallback =
+    InteropCallback<const mrsRemoteAudioTrackAddedInfo*>;
+
+// PeerConnectionAudioFrameCallback
+using AudioFrameCallback = InteropCallback<const AudioFrame&>;
+
+bool IsSilent_uint8(const uint8_t* data,
+                    uint32_t size,
+                    uint8_t& min,
+                    uint8_t& max) noexcept {
+  // 8bpp in [0:255] range, UINT8
+  const uint8_t* const s = data;
+  const uint8_t* const e = s + size;
+  // Currently "mute" on audio does not mute completely, so the frame is
+  // not *exactly* zero. So check if it's close enough.
+  min = 255;
+  max = 0;
+  for (const uint8_t* p = s; p < e; ++p) {
+    min = std::min(min, *p);
+    max = std::max(max, *p);
+  }
+  const bool is_silent = (min >= 126) && (max <= 129);  // ~1%
+  return is_silent;
+}
+
+bool IsSilent_int16(const int16_t* data,
+                    uint32_t size,
+                    int16_t& min,
+                    int16_t& max) noexcept {
+  // 16bpp in [-32768:32767] range, SINT16
+  const int16_t* const s = data;
+  const int16_t* const e = s + size;
+  // Currently "mute" on audio does not mute completely, so the frame is
+  // not *exactly* zero. So check if it's close enough.
+  min = 32767;
+  max = -32768;
+  for (const int16_t* p = s; p < e; ++p) {
+    min = std::min(min, *p);
+    max = std::max(max, *p);
+  }
+  const bool is_silent = (min >= -5) && (max <= 5);  // ~1.5e-4 = 0.015%
+  return is_silent;
+}
+
+}  // namespace
+
+INSTANTIATE_TEST_CASE_P(,
+                        AudioTrackReadBufferTests,
+                        testing::ValuesIn(TestUtils::TestSemantics),
+                        TestUtils::SdpSemanticToString);
+
+TEST_P(AudioTrackReadBufferTests, Resample) {
+  mrsPeerConnectionConfiguration pc_config{};
+  pc_config.sdp_semantic = GetParam();
+  LocalPeerPairRaii pair(pc_config);
+
+  // Grab the handle of the remote track from the remote peer (#2) via the
+  // AudioTrackAdded callback.
+  mrsTransceiverHandle audio_transceiver2{};
+  mrsRemoteAudioTrackHandle audio_track2{};
+  Event track_added2_ev;
+  AudioTrackAddedCallback track_added2_cb =
+      [&audio_track2, &audio_transceiver2,
+       &track_added2_ev](const mrsRemoteAudioTrackAddedInfo* info) {
+        audio_track2 = info->track_handle;
+        audio_transceiver2 = info->audio_transceiver_handle;
+        track_added2_ev.Set();
+      };
+  mrsPeerConnectionRegisterAudioTrackAddedCallback(pair.pc2(),
+                                                   CB(track_added2_cb));
+
+  // Create an audio transceiver on #1
+  mrsTransceiverHandle audio_transceiver1{};
+  mrsTransceiverInitConfig transceiver_config{};
+  transceiver_config.name = "transceiver1";
+  transceiver_config.media_kind = mrsMediaKind::kAudio;
+  ASSERT_EQ(Result::kSuccess,
+            mrsPeerConnectionAddTransceiver(pair.pc1(), &transceiver_config,
+                                            &audio_transceiver1));
+  ASSERT_NE(nullptr, audio_transceiver1);
+
+  // Create the audio source #1
+  mrsLocalAudioDeviceInitConfig device_config{};
+  mrsDeviceAudioTrackSourceHandle audio_source1{};
+  ASSERT_EQ(Result::kSuccess,
+            mrsDeviceAudioTrackSourceCreate(&device_config, &audio_source1));
+  ASSERT_NE(nullptr, audio_source1);
+
+  // Create the local audio track #1
+  mrsLocalAudioTrackInitSettings init_settings{};
+  init_settings.track_name = "test_audio_track";
+  mrsLocalAudioTrackHandle audio_track1{};
+  ASSERT_EQ(Result::kSuccess,
+            mrsLocalAudioTrackCreateFromSource(&init_settings, audio_source1,
+                                               &audio_track1));
+  ASSERT_NE(nullptr, audio_track1);
+
+  // Audio tracks start enabled
+  ASSERT_NE(mrsBool::kFalse, mrsLocalAudioTrackIsEnabled(audio_track1));
+
+  // Check transceiver #1 consistency
+  {
+    // Local track is NULL
+    mrsLocalVideoTrackHandle track_handle_local{};
+    ASSERT_EQ(Result::kSuccess, mrsTransceiverGetLocalAudioTrack(
+                                    audio_transceiver1, &track_handle_local));
+    ASSERT_EQ(nullptr, track_handle_local);
+
+    // Remote track is NULL
+    mrsRemoteVideoTrackHandle track_handle_remote{};
+    ASSERT_EQ(Result::kSuccess, mrsTransceiverGetRemoteAudioTrack(
+                                    audio_transceiver1, &track_handle_remote));
+    ASSERT_EQ(nullptr, track_handle_remote);
+  }
+
+  // Add the local audio track on the transceiver #1
+  ASSERT_EQ(Result::kSuccess,
+            mrsTransceiverSetLocalAudioTrack(audio_transceiver1, audio_track1));
+
+  // Check transceiver #1 consistency
+  {
+    // Local track is audio_track1
+    mrsLocalVideoTrackHandle track_handle_local{};
+    ASSERT_EQ(Result::kSuccess, mrsTransceiverGetLocalAudioTrack(
+                                    audio_transceiver1, &track_handle_local));
+    ASSERT_EQ(audio_track1, track_handle_local);
+
+    // Remote track is NULL
+    mrsRemoteVideoTrackHandle track_handle_remote{};
+    ASSERT_EQ(Result::kSuccess, mrsTransceiverGetRemoteAudioTrack(
+                                    audio_transceiver1, &track_handle_remote));
+    ASSERT_EQ(nullptr, track_handle_remote);
+  }
+
+  // Connect #1 and #2
+  pair.ConnectAndWait();
+
+  // Wait for remote track to be added on #2
+  ASSERT_TRUE(track_added2_ev.WaitFor(5s));
+  ASSERT_NE(nullptr, audio_track2);
+  ASSERT_NE(nullptr, audio_transceiver2);
+
+  // Check transceiver #2 consistency
+  {
+    // Local track is NULL
+    mrsLocalVideoTrackHandle track_handle_local{};
+    ASSERT_EQ(Result::kSuccess, mrsTransceiverGetLocalAudioTrack(
+                                    audio_transceiver2, &track_handle_local));
+    ASSERT_EQ(nullptr, track_handle_local);
+
+    // Remote track is audio_track2
+    mrsRemoteVideoTrackHandle track_handle_remote{};
+    ASSERT_EQ(Result::kSuccess, mrsTransceiverGetRemoteAudioTrack(
+                                    audio_transceiver2, &track_handle_remote));
+    ASSERT_EQ(audio_track2, track_handle_remote);
+  }
+
+  // Create read buffer
+  mrsAudioTrackReadBufferHandle read_buffer2{};
+  ASSERT_EQ(Result::kSuccess,
+            mrsRemoteAudioTrackCreateReadBuffer(audio_track2, &read_buffer2));
+
+  // Check several times this, because the audio "mute" is flaky, does not
+  // really mute the audio, so check that the reported status is still
+  // correct.
+  ASSERT_NE(mrsBool::kFalse, mrsLocalAudioTrackIsEnabled(audio_track1));
+
+  // Try some dummy resampling with some improbable frequency that the internal
+  // resampler surely does not support, whatever the input frequency from the
+  // audio device may be (generally 48kHz).
+  constexpr int kImprobableSampleRate = 7919;  // prime number
+  int num_samples_read = 0;
+  mrsBool has_overrun = mrsBool::kFalse;
+  std::vector<float> buffer(30 * 24000 *
+                            2);  // 30fps * 24000samples * 2 channels = 1 second
+  ASSERT_EQ(mrsResult::kAudioResamplingNotSupported,
+            mrsAudioTrackReadBufferRead(
+                read_buffer2, kImprobableSampleRate, 1,
+                mrsAudioTrackReadBufferPadBehavior::kPadWithZero, buffer.data(),
+                (int)buffer.size(), &num_samples_read, &has_overrun));
+
+  // Give the track some time to stream audio data, and during this time use the
+  // read buffer to read incoming data (and exercise the resampler).
+  size_t total_samples_read = 0;
+  const auto start_time = std::chrono::system_clock::now();
+  const auto end_time = start_time + std::chrono::seconds(3);
+  auto cur_time = start_time;
+  while (cur_time < end_time) {
+    // Read some data
+    mrsAudioTrackReadBufferRead(
+        read_buffer2, 24000, 2,
+        mrsAudioTrackReadBufferPadBehavior::kPadWithZero, buffer.data(),
+        (int)buffer.size(), &num_samples_read, &has_overrun);
+    ASSERT_EQ(mrsBool::kFalse, has_overrun);
+    total_samples_read += num_samples_read;
+
+    // Check data
+    // TODO - See comment in audio_track_tests.cpp, this is flaky because it
+    //        relies on the microphone and some noise gate. This would be best
+    //        tested if we had external audio tracks...
+
+    cur_time = std::chrono::system_clock::now();
+  }
+  ASSERT_GT(total_samples_read, 0);
+
+  // Same as above
+  ASSERT_NE(mrsBool::kFalse, mrsLocalAudioTrackIsEnabled(audio_track1));
+
+  ASSERT_TRUE(pair.WaitExchangeCompletedFor(5s));
+
+  // Clean-up
+  mrsAudioTrackReadBufferDestroy(read_buffer2);
+  mrsRefCountedObjectRemoveRef(audio_track1);
+  mrsRefCountedObjectRemoveRef(audio_source1);
+}
+
+#endif  // MRSW_EXCLUDE_DEVICE_TESTS

--- a/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj
+++ b/tools/build/mrwebrtc/win32/tests/mrwebrtc-win32-tests.vcxproj
@@ -67,6 +67,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\device_audio_track_source_tests.cpp" />
+    <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\audio_track_read_buffer_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\audio_track_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\data_channel_tests.cpp" />
     <ClCompile Include="$(MRWebRTCProjectRoot)libs\mrwebrtc\test\external_video_track_source_tests.cpp" />


### PR DESCRIPTION
Handle failures to resample audio to the given frequency with an
explicit error code instead of an assertion. Log a warning that the
audio frame is dropped, and return an error code from the audio track
read buffer's read call.