### PR TITLE
Add text message support for data channel send and receive callbacks.

### DIFF
--- a/libs/mrwebrtc/include/data_channel_interop.h
+++ b/libs/mrwebrtc/include/data_channel_interop.h
@@ -22,6 +22,16 @@ enum class mrsDataChannelState : int32_t {
   kClosed = 3
 };
 
+/// Data channel message types. Messages can be sent and receieved with these
+/// kinds.
+enum class mrsMessageKind : int32_t {
+    /// The message is a binary representation.
+    kBinary = 1,
+
+    /// The message is a text representation.
+    kText = 2, 
+};
+
 /// Assign some opaque user data to the data channel. The implementation will
 /// store the pointer in the data channel object and not touch it. It can be
 /// retrieved with |mrsDataChannelGetUserData()| at any point during the data
@@ -42,6 +52,14 @@ mrsDataChannelGetUserData(mrsDataChannelHandle handle) noexcept;
 /// using any other MR-WebRTC APIs; re-entrancy is not supported.
 using mrsDataChannelMessageCallback = void(
     MRS_CALL*)(void* user_data, const void* data, const uint64_t size);
+
+/// Callback fired when a message |data| of byte size |size| with kind |messageKind|
+/// is received on a data channel.
+///
+/// The code responding to this callback should unwind the stack before
+/// using any other MR-WebRTC APIs; re-entrancy is not supported.
+using mrsDataChannelMessageExCallback = void(
+    MRS_CALL*)(void* user_data, const mrsMessageKind messageKind, const void* data, const uint64_t size);
 
 /// Callback invoked when a data channel internal buffering changes.
 /// The |previous| and |current| values are the old and new sizes in bytes of
@@ -69,6 +87,8 @@ using mrsDataChannelStateCallback = void(MRS_CALL*)(void* user_data,
 struct mrsDataChannelCallbacks {
   mrsDataChannelMessageCallback message_callback{};
   void* message_user_data{};
+  mrsDataChannelMessageExCallback message_ex_callback{};
+  void* message_ex_user_data{};
   mrsDataChannelBufferingCallback buffering_callback{};
   void* buffering_user_data{};
   mrsDataChannelStateCallback state_callback{};
@@ -96,6 +116,19 @@ MRS_API void MRS_CALL mrsDataChannelRegisterCallbacks(
 /// monitor the state change event to know when it is safe to send a message.
 MRS_API mrsResult MRS_CALL
 mrsDataChannelSendMessage(mrsDataChannelHandle data_channel_handle,
+                          const void* data,
+                          uint64_t size) noexcept;
+
+/// Send through the given data channel a message |data| of byte length
+/// |size| with kind |messageKind|. The message may be buffered internally,
+/// and the caller should monitor the buffering event to avoid overflowing
+/// the internal buffer.
+///
+/// This returns an error if the data channel is not open. The caller should
+/// monitor the state change event to know when it is safe to send a message.
+MRS_API mrsResult MRS_CALL
+mrsDataChannelSendMessageEx(mrsDataChannelHandle data_channel_handle,
+                          mrsMessageKind messageKind,
                           const void* data,
                           uint64_t size) noexcept;
 

--- a/libs/mrwebrtc/src/data_channel.h
+++ b/libs/mrwebrtc/src/data_channel.h
@@ -35,6 +35,9 @@ class DataChannel : public webrtc::DataChannelObserver {
   /// Callback fired on newly available data channel data.
   using MessageCallback = Callback<const void*, const uint64_t>;
 
+  /// Callback fired on newly available data channel data.
+  using MessageExCallback = Callback<const mrsMessageKind, const void*, const uint64_t>;
+
   /// Callback fired when data buffering changed.
   /// The first parameter indicates the old buffering amount in bytes, the
   /// second one the new value, and the last one indicates the limit in bytes
@@ -81,6 +84,7 @@ class DataChannel : public webrtc::DataChannelObserver {
   MRS_NODISCARD std::string label() const;
 
   void SetMessageCallback(MessageCallback callback) noexcept;
+  void SetMessageExCallback(MessageExCallback callback) noexcept;
   void SetBufferingCallback(BufferingCallback callback) noexcept;
   void SetStateCallback(StateCallback callback) noexcept;
 
@@ -90,6 +94,9 @@ class DataChannel : public webrtc::DataChannelObserver {
 
   /// Send a blob of data through the data channel.
   bool Send(const void* data, size_t size) noexcept;
+
+  /// Send a message through the data channel with the specified message kind.
+  bool SendEx(mrsMessageKind messageKind, const void* data, size_t size) noexcept;
 
   //
   // Advanced use
@@ -127,6 +134,7 @@ class DataChannel : public webrtc::DataChannelObserver {
   rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel_;
 
   MessageCallback message_callback_ RTC_GUARDED_BY(mutex_);
+  MessageExCallback message_ex_callback_ RTC_GUARDED_BY(mutex_);
   BufferingCallback buffering_callback_ RTC_GUARDED_BY(mutex_);
   StateCallback state_callback_ RTC_GUARDED_BY(mutex_);
   mutable std::mutex mutex_;

--- a/libs/mrwebrtc/src/interop/data_channel_interop.cpp
+++ b/libs/mrwebrtc/src/interop/data_channel_interop.cpp
@@ -33,6 +33,8 @@ void MRS_CALL mrsDataChannelRegisterCallbacks(
   if (auto data_channel = static_cast<DataChannel*>(handle)) {
     data_channel->SetMessageCallback(
         {callbacks->message_callback, callbacks->message_user_data});
+    data_channel->SetMessageExCallback(
+        {callbacks->message_ex_callback, callbacks->message_ex_user_data});
     data_channel->SetBufferingCallback(
         {callbacks->buffering_callback, callbacks->buffering_user_data});
     data_channel->SetStateCallback(
@@ -50,4 +52,17 @@ mrsDataChannelSendMessage(mrsDataChannelHandle dataChannelHandle,
   }
   return (data_channel->Send(data, (size_t)size) ? Result::kSuccess
                                                  : Result::kUnknownError);
+}
+
+mrsResult MRS_CALL
+mrsDataChannelSendMessageEx(mrsDataChannelHandle dataChannelHandle,
+                          mrsMessageKind messageKind,
+                          const void* data,
+                          uint64_t size) noexcept {
+  auto data_channel = static_cast<DataChannel*>(dataChannelHandle);
+  if (!data_channel) {
+    return Result::kInvalidNativeHandle;
+  }
+  return (data_channel->SendEx(messageKind, data, (size_t)size) ? Result::kSuccess
+                                                                : Result::kUnknownError);
 }


### PR DESCRIPTION
Finally got around to this update. I've updated the solution to not be a breaking change. Added new method for sending text messages over the data channel.
Added a new event which is fired when non-binary data is received.

This will still be a change in the inner workings of the mr-webrtc dll. I've opened up an issue to discuss what can be done about it below!
