### PR TITLE
Compress webrtc.lib out folder in release CI

### DIFF
--- a/tools/ci/templates/jobs-mrwebrtc-release-build.yaml
+++ b/tools/ci/templates/jobs-mrwebrtc-release-build.yaml
@@ -153,11 +153,17 @@ jobs:
     timeoutInMinutes: 120
 
   - ${{ if eq(parameters.buildPlatform, 'UWP') }}:
+    # Compress some to avoid out-of-disk-space error
+    - pwsh: |
+        & compact /C "/S:$(Build.SourcesDirectory)/external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/out"
+        & compact /C "/S:$(Build.SourcesDirectory)/external/webrtc-uwp-sdk/webrtc/xplatform/webrtc/OUTPUT"
+      displayName: 'Compress webrtc.lib output folders'
+
     # Build the UWP wrapper
     - task: MSBuild@1
       displayName: 'Build Org.WebRTC WinRT wrappers'
       inputs:
-        solution: '$(projectRoot)Org.WebRtc.Universal/Org.WebRtc.vcxproj'
+        solution: '$(projectRoot)Org.WebRtc.WrapperGlue.Universal/Org.WebRtc.WrapperGlue.vcxproj'
         msbuildVersion: '15.0'
         msbuildArchitecture: x64
         platform: ${{parameters.buildArch}}


### PR DESCRIPTION
Prevent out-of-disk-space error by compressing the libwebrtc output folders
after building `webrtc.lib`. Those folders contain mainly `.obj` and `.pdb`
files, which are highly compressible (1:2 to 1:4 ratios) and are very large in
the first place, making some agents run out of disk space during build.

Also fix release CI to build only the UWP wrappers (`.lib`) and not the full
WinRT projection (`.dll`), which is not used and consumes CPU time, RAM, and
disk space, for nothing.
