### PR TITLE
NodeDssSignaler: Ensure that the local peer ID is a valid SDP token

### DIFF
--- a/libs/mrwebrtc/include/local_audio_track_interop.h
+++ b/libs/mrwebrtc/include/local_audio_track_interop.h
@@ -11,7 +11,7 @@ extern "C" {
 
 /// Configuration for creating a local audio track.
 struct mrsLocalAudioTrackInitSettings {
-  /// Track name. This must be a valid SDP token (see |mrsSdpTokenIsValid()|), or
+  /// Track name. This must be a valid SDP token (see |mrsSdpIsValidToken()|), or
   /// |nullptr| to let the implementation generate a valid unique track name.
   const char* track_name{};
 };

--- a/libs/mrwebrtc/include/local_video_track_interop.h
+++ b/libs/mrwebrtc/include/local_video_track_interop.h
@@ -9,7 +9,7 @@ extern "C" {
 
 /// Configuration for creating a local video track.
 struct mrsLocalVideoTrackInitSettings {
-  /// Track name. This must be a valid SDP token (see |mrsSdpTokenIsValid()|),
+  /// Track name. This must be a valid SDP token (see |mrsSdpIsValidToken()|),
   /// or |nullptr| to let the implementation generate a valid unique track name.
   const char* track_name{};
 };

--- a/libs/unity/library/Runtime/Scripts/Attributes/SdpTokenAttribute.cs
+++ b/libs/unity/library/Runtime/Scripts/Attributes/SdpTokenAttribute.cs
@@ -16,6 +16,11 @@ namespace Microsoft.MixedReality.WebRTC.Unity
     public class SdpTokenAttribute : PropertyAttribute
     {
         /// <summary>
+        /// Regular expression that matches all characters which can't be used in an SDP token.
+        /// </summary>
+        public const string InvalidCharacters = "[^A-Za-z0-9!#$%&'*+-.^_`{|}~]";
+
+        /// <summary>
         /// Allow empty tokens, that is a string property which is <c>null</c> or an empty string.
         /// This is not valid in the RFC, but can be allowed as a property value to represent a default
         /// value generated at runtime by the implementation instead of being provided by the user.
@@ -62,13 +67,10 @@ namespace Microsoft.MixedReality.WebRTC.Unity
                 throw new ArgumentNullException("Invalid null SDP token.");
             }
 
-            var regex = new Regex("^[A-Za-z0-9!#$%&'*+-.^_`{|}~]+$");
-            if (regex.IsMatch(name))
+            if (Regex.IsMatch(name, InvalidCharacters))
             {
-                return;
+                throw new ArgumentException($"SDP token '{name}' contains invalid characters.");
             }
-
-            throw new ArgumentException($"SDP token '{name}' contains invalid characters.");
         }
     }
 }

--- a/libs/unity/library/Runtime/Scripts/Signaling/NodeDssSignaler.cs
+++ b/libs/unity/library/Runtime/Scripts/Signaling/NodeDssSignaler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -224,6 +225,8 @@ namespace Microsoft.MixedReality.WebRTC.Unity
             {
                 LocalPeerId = SystemInfo.deviceName;
             }
+            // In any case, make sure that the peer ID is a valid SDP token
+            LocalPeerId = Regex.Replace(LocalPeerId, SdpTokenAttribute.InvalidCharacters, "_");
         }
 
         /// <summary>


### PR DESCRIPTION
If no local peer ID is set, NodeDssSignaler derives it from the device ID. Apparently, it's quite common for them on Android to contain spaces, which aren't allowed in SDP tokens. If we fix this, we might as well go all the way.