### PR TITLE
fix: do not attempt to release data channel memory twice

### DIFF
--- a/examples/TestNetCoreConsole/Program.cs
+++ b/examples/TestNetCoreConsole/Program.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.MixedReality.WebRTC;
 
@@ -35,17 +37,23 @@ namespace TestNetCoreConsole
 
                 // Create a new peer connection automatically disposed at the end of the program
                 using var pc = new PeerConnection();
+                using var signaler = new NamedPipeSignaler.NamedPipeSignaler(pc, "testpipe");
 
                 // Initialize the connection with a STUN server to allow remote access
                 var config = new PeerConnectionConfiguration
                 {
-                    IceServers = new List<IceServer> {
+                    IceServers = new List<IceServer> { 
                             new IceServer{ Urls = { "stun:stun.l.google.com:19302" } }
                         }
                 };
+
                 await pc.InitializeAsync(config);
                 Console.WriteLine("Peer connection initialized.");
-
+                 
+                var dataChannelLabel = $"data_channel_{Guid.NewGuid()}";
+                Console.WriteLine($"Adding data channel with label '{dataChannelLabel}'");
+                await pc.AddDataChannelAsync(dataChannelLabel, true, true, CancellationToken.None);
+                
                 // Record video from local webcam, and send to remote peer
                 if (needVideo)
                 {
@@ -80,7 +88,6 @@ namespace TestNetCoreConsole
 
                 // Setup signaling
                 Console.WriteLine("Starting signaling...");
-                var signaler = new NamedPipeSignaler.NamedPipeSignaler(pc, "testpipe");
                 signaler.SdpMessageReceived += async (SdpMessage message) =>
                 {
                     await pc.SetRemoteDescriptionAsync(message);
@@ -94,7 +101,6 @@ namespace TestNetCoreConsole
                     pc.AddIceCandidate(candidate);
                 };
                 await signaler.StartAsync();
-
                 // Start peer connection
                 pc.Connected += () => { Console.WriteLine("PeerConnection: connected."); };
                 pc.IceStateChanged += (IceConnectionState newState) => { Console.WriteLine($"ICE state: {newState}"); };
@@ -123,7 +129,14 @@ namespace TestNetCoreConsole
                 Console.WriteLine("Press a key to stop recording...");
                 Console.ReadKey(true);
 
-                signaler.Stop();
+                Console.WriteLine("Removing data channels...");
+                foreach (var dataChannel in pc.DataChannels.ToImmutableArray())
+                {
+                    Console.WriteLine($"Removing DataChannel {dataChannel.Label}: State '{dataChannel.State}'");
+                    pc.RemoveDataChannel(dataChannel);
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(10));
             }
             catch (Exception e)
             {
@@ -135,10 +148,10 @@ namespace TestNetCoreConsole
 
             Console.WriteLine("Program termined.");
 
-            localAudioTrack.Dispose();
-            localVideoTrack.Dispose();
-            audioTrackSource.Dispose();
-            videoTrackSource.Dispose();
+            localAudioTrack?.Dispose();
+            localVideoTrack?.Dispose();
+            audioTrackSource?.Dispose();
+            videoTrackSource?.Dispose();
         }
     }
 }

--- a/examples/TestNetCoreConsole/Program.cs
+++ b/examples/TestNetCoreConsole/Program.cs
@@ -135,8 +135,6 @@ namespace TestNetCoreConsole
                     Console.WriteLine($"Removing DataChannel {dataChannel.Label}: State '{dataChannel.State}'");
                     pc.RemoveDataChannel(dataChannel);
                 }
-
-                await Task.Delay(TimeSpan.FromSeconds(10));
             }
             catch (Exception e)
             {

--- a/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
+++ b/libs/Microsoft.MixedReality.WebRTC/PeerConnection.cs
@@ -500,8 +500,8 @@ namespace Microsoft.MixedReality.WebRTC
         {
             switch (type)
             {
-            case SdpMessageType.Offer: return "offer";
-            case SdpMessageType.Answer: return "answer";
+                case SdpMessageType.Offer: return "offer";
+                case SdpMessageType.Answer: return "answer";
             }
             throw new ArgumentException($"Cannot convert invalid SdpMessageType value '{type}'.");
         }
@@ -1468,12 +1468,6 @@ namespace Microsoft.MixedReality.WebRTC
 
                 var res = PeerConnectionInterop.PeerConnection_RemoveDataChannel(_nativePeerhandle, dataChannel._nativeHandle);
                 Utils.ThrowOnErrorCode(res);
-
-                DataChannelRemoved?.Invoke(dataChannel);
-
-                // PeerConnection is owning the data channel, and all internal states have been
-                // updated and events triggered, so notify the data channel to clean its internal state.
-                dataChannel.DestroyNative();
             }
             else
             {


### PR DESCRIPTION
PR for issue described in https://github.com/microsoft/MixedReality-WebRTC/issues/722

The data channel memory was freed twice, once by the caller and then once again by an event registration, from what I can tell the event registration is there to handle when a remote peer removes a data channel.

Also added some code so the NamedPipeSignaler demo doesn't crash as much.